### PR TITLE
Support door sensor with intrusionDetect only

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -832,7 +832,6 @@ class HaDoor(LockEntity, HAEntity):
         else:
             raise AttributeError("The required attributes 'openState' or 'intrusionDetect' are not available in the device.")
 
-
 class HaGate(CoverEntity, HAEntity):
     """Representation of a Gate."""
 

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -824,8 +824,14 @@ class HaDoor(LockEntity, HAEntity):
 
     @property
     def is_locked(self) -> bool:
-        """Return if the door is closed."""
-        return self._device.openState == "LOCKED"
+        """Return if the door is locked."""
+        if hasattr(self._device, 'openState'):
+            return self._device.openState == "LOCKED"
+        elif hasattr(self._device, 'intrusionDetect'):
+            return not self._device.intrusionDetect
+        else:
+            raise AttributeError("The required attributes 'openState' or 'intrusionDetect' are not available in the device.")
+
 
 class HaGate(CoverEntity, HAEntity):
     """Representation of a Gate."""


### PR DESCRIPTION
Hi,

There is at least one sensor type with Tydom which doesn't have an openState property. 

Logs example:
```
2024-09-08 15:58:54.829 INFO (MainThread) [custom_components.deltadore_tydom] Incomming message - type : 2 - message : b'\x02PUT /devices/data HTTP/1.1\r\nServer: Tydom-001A25082FB6\r\ncontent-type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n87\r\n[{"id":1725603527,"endpoints":[{"id":1725603527,"error":0,"data":[{"name":"intrusionDetect","validity":"upToDate","value":false}]}]}]\r\n\r\n0\r\n\r\n'
2024-09-08 15:58:54.831 DEBUG (MainThread) [custom_components.deltadore_tydom] parse_devices_data : [{'id': 1725603527, 'endpoints': [{'id': 1725603527, 'error': 0, 'data': [{'name': 'intrusionDetect', 'validity': 'upToDate', 'value': False}]}]}]
```

Therefore, I added a possibility to rely on intrusionDetect variable if the openState property is missing.

Thank you in advance.