### PR TITLE
Refactor MessageHandler

### DIFF
--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -1,4 +1,5 @@
 """A demonstration 'hub' that connects several devices."""
+
 from __future__ import annotations
 
 import asyncio
@@ -36,6 +37,7 @@ from .ha_entities import (
 
 from .const import LOGGER
 
+
 class Hub:
     """Hub for Delta Dore Tydom."""
 
@@ -61,7 +63,7 @@ class Hub:
         self._host = host
         self._mac = mac
         self._pass = password
-        self._refresh_interval = int(refresh_interval)*60
+        self._refresh_interval = int(refresh_interval) * 60
         self._zone_home = zone_home
         self._zone_away = zone_away
         self._pin = alarmpin
@@ -85,8 +87,8 @@ class Hub:
             mac=self._mac,
             host=self._host,
             password=self._pass,
-            zone_home = self._zone_home,
-            zone_away = self._zone_away,
+            zone_home=self._zone_home,
+            zone_away=self._zone_away,
             alarm_pin=self._pin,
             event_callback=self.handle_event,
         )
@@ -96,7 +98,7 @@ class Hub:
     def update_config(self, refresh_interval, zone_home, zone_away):
         """Update zone configuration."""
         self._tydom_client.update_config(zone_home, zone_away)
-        self._refresh_interval = int(refresh_interval)*60
+        self._refresh_interval = int(refresh_interval) * 60
         self._zone_home = zone_home
         self._zone_away = zone_away
 
@@ -129,12 +131,19 @@ class Hub:
     def ready(self) -> bool:
         """Check if we're ready to work."""
         # and self.add_alarm_callback is not None
-        return self.add_cover_callback is not None and self.add_sensor_callback is not None and self.add_climate_callback is not None and self.add_light_callback is not None and self.add_lock_callback is not None and self.add_update_callback is not None and self.add_alarm_callback is not None
-
+        return (
+            self.add_cover_callback is not None
+            and self.add_sensor_callback is not None
+            and self.add_climate_callback is not None
+            and self.add_light_callback is not None
+            and self.add_lock_callback is not None
+            and self.add_update_callback is not None
+            and self.add_alarm_callback is not None
+        )
 
     async def setup(self, connection: ClientWebSocketResponse) -> None:
         """Listen to tydom events."""
-        # wait for callbacks to become available
+        # wait for callbacks to become available
         while not self.ready():
             await asyncio.sleep(1)
         LOGGER.debug("Listen to tydom events")
@@ -155,7 +164,7 @@ class Hub:
                             self.devices[device.device_id], device
                         )
 
-    async def create_ha_device(self, device):
+    async def create_ha_device(self, device):  # noqa: C901
         """Create a new HA device."""
         match device:
             case Tydom():
@@ -313,9 +322,8 @@ class Hub:
     async def refresh_data(self) -> None:
         """Periodically refresh data for devices which don't do push."""
         while True:
-            if(self._refresh_interval > 0):
+            if self._refresh_interval > 0:
                 await self._tydom_client.poll_devices_data_5m()
                 await asyncio.sleep(self._refresh_interval)
             else:
                 await asyncio.sleep(60)
-

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1,6 +1,7 @@
 """Tydom message parsing."""
 
 import asyncio
+import contextlib
 import json
 import time
 from dataclasses import dataclass
@@ -27,6 +28,8 @@ from .tydom_devices import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from .tydom_client import TydomClient
 
 # Device dict for parsing
@@ -74,7 +77,7 @@ class MessageHandler:
                     parsed_message.body,
                     uri_origin,
                     parsed_message.headers.get("content-type"),
-                    transaction_id=int(transaction_id) if transaction_id else None,
+                    transaction_id=transaction_id if transaction_id else None,
                 )
             except BaseException:
                 LOGGER.error("Error when parsing tydom message (%s)", bytes_str)
@@ -180,7 +183,8 @@ class MessageHandler:
 
         if data:
             if content_type == "application/json":
-                parsed = json.loads(data)
+                with contextlib.suppress(json.decoder.JSONDecodeError):
+                    parsed = json.loads(data)
             elif content_type == "text/html":
                 msg_type = partial(no_op, "msg_html")
 

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1,28 +1,32 @@
 """Tydom message parsing."""
-import json
-from http.client import HTTPResponse
-from http.server import BaseHTTPRequestHandler
-from io import BytesIO
-import traceback
-import urllib3
-import re
 
-from .tydom_devices import (
-    Tydom,
-    TydomDevice,
-    TydomEnergy,
-    TydomShutter,
-    TydomSmoke,
-    TydomBoiler,
-    TydomWindow,
-    TydomDoor,
-    TydomGate,
-    TydomGarage,
-    TydomLight,
-    TydomAlarm,
-)
+import asyncio
+import json
+import time
+from dataclasses import dataclass
+from http.client import HTTPMessage, LineTooLong
+from http.client import HTTPResponse as CoreHTTPResponse
+from io import BytesIO
+from typing import TYPE_CHECKING, cast
 
 from ..const import LOGGER
+from .tydom_devices import (
+    Tydom,
+    TydomAlarm,
+    TydomBoiler,
+    TydomDevice,
+    TydomDoor,
+    TydomEnergy,
+    TydomGarage,
+    TydomGate,
+    TydomLight,
+    TydomShutter,
+    TydomSmoke,
+    TydomWindow,
+)
+
+if TYPE_CHECKING:
+    from .tydom_client import TydomClient
 
 # Device dict for parsing
 device_name = {}
@@ -30,137 +34,135 @@ device_endpoint = {}
 device_type = {}
 device_metadata = {}
 
-class MessageHandler:
-    """Handle incomming Tydom messages."""
 
-    def __init__(self, tydom_client, cmd_prefix):
+class MessageHandler:
+    """Handle incoming Tydom messages."""
+
+    def __init__(self, tydom_client: "TydomClient", cmd_prefix: bytes) -> None:
         """Initialize MessageHandler."""
         self.tydom_client = tydom_client
         self.cmd_prefix = cmd_prefix
+        self._end_reply_events: dict[int, asyncio.Event] = {}
 
-    @staticmethod
-    def get_uri_origin(data) -> str:
-        """Extract Uri-Origin from Tydom messages if present."""
-        uri_origin = ""
-        re_matcher = re.match(
-            ".*Uri-Origin: ([a-zA-Z0-9\\-._~:/?#\\[\\]@!$&'\\(\\)\\*\\+,;%=]+).*",
-            data,
-        )
+    async def route_response(self, bytes_str: bytes) -> list["TydomDevice"] | None:
+        """Identify message type and dispatch the result.
 
-        if re_matcher:
-            # LOGGER.info("///// Uri-Origin : %s", re_matcher.group(1))
-            uri_origin = re_matcher.group(1)
-        # else:
-        # LOGGER.info("///// no match")
-        return uri_origin
+        Args:
+            bytes_str: Incoming message
 
-    @staticmethod
-    def get_http_request_line(data) -> str:
-        """Extract Http request line."""
-        clean_data = data.replace('\\x02', '')
-        request_line = ""
-        re_matcher = re.match(
-            "b'(.*)HTTP/1.1",
-            clean_data,
-        )
-        if re_matcher:
-            # LOGGER.info("///// PUT : %s", re_matcher.group(1))
-            request_line = re_matcher.group(1)
-        # else:
-        #    LOGGER.info("///// no match")
-        return request_line.strip()
-
-    async def incoming_triage(self, bytes_str):
-        """Identify message type and dispatch the result."""
-
+        """
         if bytes_str is None:
             return None
 
         incoming = None
-
-        # Find Uri-Origin in header if available
-        uri_origin = MessageHandler.get_uri_origin(str(bytes_str))
-
-        # Find http request line before http response
-        http_request_line = MessageHandler.get_http_request_line(str(bytes_str))
+        stripped_msg = bytes_str.strip(self.cmd_prefix)
 
         try:
-            if http_request_line is not None and len(http_request_line) > 0:
-                LOGGER.debug("%s detected !", http_request_line)
-                try:
-                    try:
-                        incoming = self.parse_put_response(bytes_str)
-                    except BaseException:
-                        # Tywatt response starts at 7
-                        incoming = self.parse_put_response(bytes_str, 7)
-                    return await self.parse_response(
-                        incoming, uri_origin, http_request_line
-                    )
-                except BaseException:
-                    LOGGER.error("Error when parsing tydom message (%s)", bytes_str)
-                    LOGGER.exception("Error when parsing tydom message")
-                    return None
-            elif len(uri_origin) > 0:
-                response = self.response_from_bytes(bytes_str[len(self.cmd_prefix) :])
-                incoming = response.data.decode("utf-8")
-                try:
-                    return await self.parse_response(
-                        incoming, uri_origin, http_request_line
-                    )
-                except BaseException:
-                    LOGGER.error("Error when parsing tydom message (%s)", bytes_str)
-                    return None
-            else:
-                LOGGER.warning("Unknown tydom message type received (%s)", bytes_str)
-                return None
+            if stripped_msg.startswith(b"HTTP/"):
+                parsed_message = parse_response(stripped_msg)
+                # Find Uri-Origin in header if available
+                uri_origin = parsed_message.headers.get("Uri-Origin", "")
 
-        except Exception as ex:
-            LOGGER.exception("exception")
-            LOGGER.error(
-                "Technical error when parsing tydom message (%s) : %s", bytes_str, ex
-            )
-            LOGGER.debug("Incoming payload (%s)", incoming)
-            LOGGER.debug("exception : %s", ex)
-            raise Exception(
-                "Something really wrong happened!"
-            ) from ex
+            else:
+                parsed_message = parse_request(stripped_msg)
+                uri_origin = parsed_message.path
+            transaction_id = parsed_message.headers.get("Transac-Id")
+
+            try:
+                return await self.parse_response(
+                    parsed_message.body,
+                    uri_origin,
+                    parsed_message.headers.get("content-type"),
+                    transaction_id=int(transaction_id) if transaction_id else None,
+                )
+            except BaseException:
+                LOGGER.error("Error when parsing tydom message (%s)", bytes_str)
             return None
 
-    async def parse_response(self, incoming, uri_origin, http_request_line):
+        except Exception as ex:
+            LOGGER.error(
+                "Technical error when parsing tydom message (%s) : %s",
+                bytes_str,
+                ex,
+                exc_info=ex,
+            )
+            LOGGER.debug("Incoming payload (%s)", incoming)
+            raise Exception("Something really wrong happened!") from ex
+
+    def prepare_request(
+        self,
+        method: str,
+        url: str,
+        body: dict | bytes | None = None,
+        headers: dict | None = None,
+        reply_event: asyncio.Event | None = None,
+    ) -> tuple[int, bytes]:
+        headers = headers or {}
+        # Transaction ID is actually the current time in ms
+        transaction_id = headers.get("Transac-Id", str(time.time_ns())[:13])
+        headers["Transac-Id"] = transaction_id
+        if body:
+            if isinstance(body, dict):
+                body = json.dumps(body).encode("ascii")
+                headers["Content-Type"] = "application/json; charset=UTF-8"
+            content_length = headers.get("Content-Length", str(len(body)))
+            headers["Content-Length"] = content_length
+
+        request = bytes(f"{method} {url} HTTP/1.1\r\n", "ascii")
+        if len(headers):
+            for k, v in headers.items():
+                request += bytes(f"{k}: {v}\r\n", "ascii")
+
+        if body:
+            request += b"\r\n"
+            request += cast(bytes, body) + b"\r\n"
+
+        request += b"\r\n"
+
+        if reply_event:
+            self._end_reply_events[transaction_id] = reply_event
+
+        return (transaction_id, request)
+
+    async def parse_response(
+        self,
+        data: bytes | None,
+        uri_origin: str,
+        content_type: str | None,
+        transaction_id: int | None,
+    ) -> list | None:
         """Parse basic response.
 
-        Typically GET responses + instanciate covers and alarm class for updating data.
+        Typically GET responses + instantiate covers and alarm class for updating data.
         """
-        data = incoming
+        parsed = None
         msg_type = None
-        first = str(data[:40])
 
-        if "/configs/file" in uri_origin:
-            msg_type = "msg_config"
-        elif "/devices/cmeta" in uri_origin:
-            msg_type = "msg_cmetadata"
-        elif "/configs/gateway/api_mode" in uri_origin:
-            msg_type = "msg_api_mode"
-        elif "/groups/file" in uri_origin:
-            msg_type = "msg_groups"
-        elif "/devices/meta" in uri_origin:
-            msg_type = "msg_metadata"
-        elif "/scenarios/file" in uri_origin:
-            msg_type = "msg_scenarios"
-        elif "/devices/install" in http_request_line:
-            msg_type = "msg_pairing"
-        elif "/events" in http_request_line:
-            msg_type = "msg_event"
-        elif "/ping" in uri_origin:
-            msg_type = "msg_ping"
-        elif data != "" and "cdata" in data:
-            msg_type = "msg_cdata"
-        elif "doctype" in first:
-            msg_type = "msg_html"
-        elif "/info" in uri_origin:
-            msg_type = "msg_info"
-        elif "id" in first:
-            msg_type = "msg_data"
+        if data:
+            if content_type == "application/json":
+                parsed = json.loads(data)
+            elif content_type == "text/html":
+                msg_type = "msg_html"
+
+        MSG_MAPPING = {
+            "/configs/file": "msg_config",
+            "/configs/gateway/api_mode": "msg_api_mode",
+            "/devices/cdata": "msg_cdata",
+            "/devices/cmeta": "msg_cmetadata",
+            "/devices/install": "msg_pairing",
+            "/devices/meta": "msg_metadata",
+            "/events": "msg_event",
+            "/groups/file": "msg_groups",
+            "/info": "msg_info",
+            "/ping": "msg_ping",
+            "/scenarios/file": "msg_scenarios",
+        }
+
+        if msg_type is None:
+            msg_type = MSG_MAPPING.get(uri_origin)
+
+            if msg_type is None and data and b"id" in data[:40]:
+                msg_type = "msg_data"
 
         if msg_type is None:
             LOGGER.warning("Unknown message type received %s", data)
@@ -168,23 +170,20 @@ class MessageHandler:
             LOGGER.debug("Message received detected as (%s)", msg_type)
             try:
                 if msg_type == "msg_config":
-                    parsed = json.loads(data)
                     return await MessageHandler.parse_config_data(parsed=parsed)
 
                 elif msg_type == "msg_cmetadata":
-                    parsed = json.loads(data)
                     return await self.parse_cmeta_data(parsed=parsed)
 
                 elif msg_type == "msg_data":
-                    parsed = json.loads(data)
                     return await self.parse_devices_data(parsed=parsed)
 
                 elif msg_type == "msg_cdata":
-                    parsed = json.loads(data)
-                    return await self.parse_devices_cdata(parsed=parsed)
+                    return await self.parse_devices_cdata(
+                        parsed=parsed, transaction_id=transaction_id
+                    )
 
                 elif msg_type == "msg_metadata":
-                    parsed = json.loads(data)
                     return await self.parse_devices_metadata(parsed=parsed)
 
                 elif msg_type == "msg_event":
@@ -195,16 +194,14 @@ class MessageHandler:
                     LOGGER.debug("HTML Response ?")
 
                 elif msg_type == "msg_info":
-                    parsed = json.loads(data)
                     return await self.parse_msg_info(parsed)
 
                 elif msg_type == "msg_ping":
                     self.tydom_client.receive_pong()
 
             except Exception as e:
-                LOGGER.error("Error on parsing tydom response (%s)", data)
+                LOGGER.error("Error on parsing tydom response (%s)", data, exc_info=e)
                 LOGGER.exception("Error on parsing tydom response")
-                traceback.print_exception(e)
         LOGGER.debug("Incoming data parsed with success")
 
     async def parse_devices_metadata(self, parsed):
@@ -222,7 +219,9 @@ class MessageHandler:
                     for meta in metadata:
                         if meta == "name":
                             continue
-                        device_metadata[device_unique_id][metadata_name][meta] = metadata[meta]
+                        device_metadata[device_unique_id][metadata_name][meta] = (
+                            metadata[meta]
+                        )
         return []
 
     async def parse_msg_info(self, parsed):
@@ -230,7 +229,16 @@ class MessageHandler:
         LOGGER.debug("parse_msg_info : %s", parsed)
 
         return [
-            Tydom(self.tydom_client, self.tydom_client.id, self.tydom_client.id, self.tydom_client.id, "Tydom Gateway", None, None, parsed)
+            Tydom(
+                self.tydom_client,
+                self.tydom_client.id,
+                self.tydom_client.id,
+                self.tydom_client.id,
+                "Tydom Gateway",
+                None,
+                None,
+                parsed,
+            )
         ]
 
     @staticmethod
@@ -256,17 +264,44 @@ class MessageHandler:
                 return TydomShutter(
                     tydom_client, uid, device_id, name, last_usage, endpoint, None, data
                 )
-            case "window" | "windowFrench" | "windowSliding" | "klineWindowFrench" | "klineWindowSliding":
+            case (
+                "window"
+                | "windowFrench"
+                | "windowSliding"
+                | "klineWindowFrench"
+                | "klineWindowSliding"
+            ):
                 return TydomWindow(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case "belmDoor" | "klineDoor":
                 return TydomDoor(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case "garage_door":
                 return TydomGarage(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case "gate":
                 return TydomGate(
@@ -292,76 +327,78 @@ class MessageHandler:
                 )
             case "conso":
                 return TydomEnergy(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case "sensorDFR":
                 return TydomSmoke(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case "boiler" | "sh_hvac" | "electric" | "aeraulic":
                 return TydomBoiler(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case "alarm":
                 return TydomAlarm(
-                    tydom_client, uid, device_id, name, last_usage, endpoint, device_metadata[uid], data
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata[uid],
+                    data,
                 )
             case _:
                 # TODO generic sensor ?
-                LOGGER.warn("Unknown usage : %s for device_id %s, uid %s", last_usage, device_id, uid)
+                LOGGER.warn(
+                    "Unknown usage : %s for device_id %s, uid %s",
+                    last_usage,
+                    device_id,
+                    uid,
+                )
                 return
 
     @staticmethod
     async def parse_config_data(parsed):
         """Parse config data."""
         LOGGER.debug("parse_config_data : %s", parsed)
-        devices = []
         for i in parsed["endpoints"]:
             device_unique_id = str(i["id_endpoint"]) + "_" + str(i["id_device"])
 
-            # device = await MessageHandler.get_device(i["last_usage"], device_unique_id, i["name"], i["id_endpoint"], None)
-            # if device is not None:
-            #    devices.append(device)
-
-            LOGGER.debug("config_data device parsed : %s - %s", device_unique_id, i["name"])
+            LOGGER.debug(
+                "config_data device parsed : %s - %s", device_unique_id, i["name"]
+            )
 
             device_name[device_unique_id] = i["name"]
-            device_type[device_unique_id] = i["last_usage"]
+            device_type[device_unique_id] = i["last_usage"] or "unknown"
             device_endpoint[device_unique_id] = i["id_endpoint"]
 
-            if (
-                i["last_usage"] == "shutter"
-                or i["last_usage"] == "klineShutter"
-                or i["last_usage"] == "light"
-                or i["last_usage"] == "window"
-                or i["last_usage"] == "windowFrench"
-                or i["last_usage"] == "windowSliding"
-                or i["last_usage"] == "belmDoor"
-                or i["last_usage"] == "klineDoor"
-                or i["last_usage"] == "klineWindowFrench"
-                or i["last_usage"] == "klineWindowSliding"
-                or i["last_usage"] == "garage_door"
-                or i["last_usage"] == "gate"
-            ):
-                pass
-
-            if i["last_usage"] == "boiler" or i["last_usage"] == "conso":
-                pass
             if i["last_usage"] == "alarm":
                 device_name[device_unique_id] = "Tyxal Alarm"
 
-            if i["last_usage"] == "electric":
-                pass
-
-            if i["last_usage"] == "sensorDFR":
-                pass
-
-            if i["last_usage"] == "":
-                device_type[device_unique_id] = "unknown"
-
         LOGGER.debug("Configuration updated")
-        LOGGER.debug("devices : %s", devices)
-        return devices
+        return []
 
     async def parse_cmeta_data(self, parsed):
         """Parse cmeta data."""
@@ -441,7 +478,6 @@ class MessageHandler:
         for i in parsed:
             for endpoint in i["endpoints"]:
                 if endpoint["error"] == 0 and len(endpoint["data"]) > 0:
-
                     try:
                         device_id = i["id"]
                         endpoint_id = endpoint["id"]
@@ -482,7 +518,7 @@ class MessageHandler:
                         LOGGER.exception("msg_data error in parsing !")
         return devices
 
-    async def parse_devices_cdata(self, parsed):
+    async def parse_devices_cdata(self, parsed, transaction_id: int | None = None):
         """Parse devices cdata."""
         LOGGER.debug("parse_devices_cdata : %s", parsed)
         devices = []
@@ -499,11 +535,12 @@ class MessageHandler:
 
                         data = {}
                         for elem in endpoint["cdata"]:
-                            if type_of_id == 'conso':
-
+                            if type_of_id == "conso":
                                 element_name = None
                                 if elem["parameters"].get("dest"):
-                                    element_name = elem["name"] + "_" + elem["parameters"]["dest"]
+                                    element_name = (
+                                        elem["name"] + "_" + elem["parameters"]["dest"]
+                                    )
                                 else:
                                     continue
 
@@ -531,44 +568,10 @@ class MessageHandler:
                                     )
 
                     except Exception:
-                        LOGGER.exception('Error when parsing msg_cdata')
+                        LOGGER.exception("Error when parsing msg_cdata")
         return devices
 
-    # PUT response DIRTY parsing
-    def parse_put_response(self, bytes_str, start=6):
-        """Parse PUT response."""
-        # TODO : Find a cooler way to parse nicely the PUT HTTP response
-        resp = bytes_str[len(self.cmd_prefix) :].decode("utf-8")
-        fields = resp.split("\r\n")
-        fields = fields[start:]  # ignore the PUT / HTTP/1.1
-        end_parsing = False
-        i = 0
-        output = ""
-        while not end_parsing:
-            field = fields[i]
-            if len(field) == 0 or field == "0":
-                end_parsing = True
-            else:
-                output += field
-                i = i + 2
-        parsed = json.loads(output)
-        return json.dumps(parsed)
-
     # FUNCTIONS
-
-    @staticmethod
-    def response_from_bytes(data):
-        """Get HTTPResponse from bytes."""
-        sock = BytesIOSocket(data)
-        response = HTTPResponse(sock)
-        response.begin()
-        return urllib3.HTTPResponse.from_httplib(response)
-
-    @staticmethod
-    def put_response_from_bytes(data):
-        """Get HTTPResponse from bytes."""
-        request = HTTPRequest(data)
-        return request
 
     def get_type_from_id(self, id):
         """Get device type from id."""
@@ -602,16 +605,83 @@ class BytesIOSocket:
         return self.handle
 
 
-class HTTPRequest(BaseHTTPRequestHandler):
+@dataclass(frozen=True)
+class HTTPResponse:
+    """HTTPResponse."""
+
+    status: int
+    headers: HTTPMessage
+    body: bytes | None
+
+
+def parse_response(raw_message: bytes) -> HTTPResponse:
+    sock = BytesIOSocket(raw_message)
+    response = CoreHTTPResponse(sock)
+    response.begin()
+
+    return HTTPResponse(
+        status=response.status, headers=response.headers, body=response.read()
+    )
+
+
+_MAXLINE = 65536
+
+
+class FakeHTTPRequest(CoreHTTPResponse):
+    def _read_status(self):
+        # This is the only line that is different for a request vs a response
+        # so we fake it.
+        line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
+        if len(line) > _MAXLINE:
+            raise LineTooLong("status line")
+        if self.debuglevel > 0:
+            print("reply:", repr(line))
+        if not line:
+            raise ValueError("No request line")
+
+        words = line.rstrip("\r\n").split()
+
+        version = words[-1]
+
+        if not version.startswith("HTTP/"):
+            self._close_conn()
+            raise ValueError(line)
+
+        command, path = words[:2]
+        self.method = command
+        self.path = path
+
+        # Return fake status and reason to keep parsing the message
+        return version, 200, ""
+
+
+@dataclass(frozen=True)
+class HTTPRequest:
     """HTTPRequest."""
 
-    def __init__(self, request_text):
-        """Initialize a HTTPRequest."""
-        self.raw_requestline = request_text
-        self.error_code = self.error_message = None
-        self.parse_request()
+    method: str
+    path: str
+    headers: HTTPMessage
+    body: bytes | None
 
-    def send_error(self, code, message):
-        """Set error code and message."""
-        self.error_code = code
-        self.error_message = message
+
+def parse_request(raw_request: bytes) -> HTTPRequest:
+    """Parse a HTTP request sent through the websocket.
+
+    Args:
+        raw_request: Websocket message
+
+    Returns:
+        The parsed request.
+
+    """
+    sock = BytesIOSocket(raw_request)
+    request = FakeHTTPRequest(sock)
+    request.begin()
+
+    return HTTPRequest(
+        method=request.method,
+        path=request.path,
+        headers=request.headers,
+        body=request.read(),
+    )

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
+from functools import partial
 from http.client import HTTPMessage, LineTooLong
 from http.client import HTTPResponse as CoreHTTPResponse
 from io import BytesIO
@@ -129,82 +130,81 @@ class MessageHandler:
         data: bytes | None,
         uri_origin: str,
         content_type: str | None,
-        transaction_id: int | None,
-    ) -> list | None:
-        """Parse basic response.
+        transaction_id: str | None,
+    ) -> list[TydomDevice] | None:
+        """Parse response.
 
-        Typically GET responses + instantiate covers and alarm class for updating data.
+        Args:
+            data: Response body
+            uri_origin: Response URL
+            content_type: Response content type (can't be trusted)
+            transaction_id: Response transaction ID
+
+        Returns:
+            List of Tydom devices if applicable.
+
         """
-        parsed = None
-        msg_type = None
+
+        async def no_op(message_type: str, *args):
+            LOGGER.debug("%s response", message_type)
+
+        async def event_message(*args):
+            LOGGER.debug("Event message, refreshing...")
+            await self.tydom_client.get_devices_data()
+
+        async def ping_message(*args):
+            self.tydom_client.receive_pong()
+
+        MSG_MAPPING = {
+            "/configs/file": MessageHandler.parse_config_data,
+            "/configs/gateway/api_mode": partial(no_op, "msg_api_mode"),
+            "/devices/cdata": self.parse_devices_cdata,
+            "/devices/cmeta": self.parse_cmeta_data,
+            "/devices/install": partial(no_op, "msg_pairing"),
+            "/devices/meta": self.parse_devices_metadata,
+            "/events": event_message,
+            "/groups/file": partial(no_op, "msg_groups"),
+            "/info": self.parse_msg_info,
+            "/ping": ping_message,
+            "/refresh/all": partial(no_op, "msg_refresh_all"),
+            "/scenarios/file": partial(no_op, "msg_scenarios"),
+        }
+
+        parsed = data
+        msg_type: (
+            Callable[
+                [bytes | dict | None, str | None], Awaitable[list[TydomDevice] | None]
+            ]
+            | None
+        ) = None
 
         if data:
             if content_type == "application/json":
                 parsed = json.loads(data)
             elif content_type == "text/html":
-                msg_type = "msg_html"
-
-        MSG_MAPPING = {
-            "/configs/file": "msg_config",
-            "/configs/gateway/api_mode": "msg_api_mode",
-            "/devices/cdata": "msg_cdata",
-            "/devices/cmeta": "msg_cmetadata",
-            "/devices/install": "msg_pairing",
-            "/devices/meta": "msg_metadata",
-            "/events": "msg_event",
-            "/groups/file": "msg_groups",
-            "/info": "msg_info",
-            "/ping": "msg_ping",
-            "/scenarios/file": "msg_scenarios",
-        }
+                msg_type = partial(no_op, "msg_html")
 
         if msg_type is None:
             msg_type = MSG_MAPPING.get(uri_origin)
 
-            if msg_type is None and data and b"id" in data[:40]:
-                msg_type = "msg_data"
+            if msg_type is None and data:
+                first = data[:40]
+                if b"doctype" in first:  # Content-Type header is not respected
+                    msg_type = partial(no_op, "msg_html")
+                elif b"id" in first:
+                    msg_type = self.parse_devices_data
 
         if msg_type is None:
-            LOGGER.warning("Unknown message type received %s", data)
+            LOGGER.warning("Unknown message type received %s: %s", uri_origin, data)
         else:
-            LOGGER.debug("Message received detected as (%s)", msg_type)
+            LOGGER.debug("Message received from %s", uri_origin)
             try:
-                if msg_type == "msg_config":
-                    return await MessageHandler.parse_config_data(parsed=parsed)
-
-                elif msg_type == "msg_cmetadata":
-                    return await self.parse_cmeta_data(parsed=parsed)
-
-                elif msg_type == "msg_data":
-                    return await self.parse_devices_data(parsed=parsed)
-
-                elif msg_type == "msg_cdata":
-                    return await self.parse_devices_cdata(
-                        parsed=parsed, transaction_id=transaction_id
-                    )
-
-                elif msg_type == "msg_metadata":
-                    return await self.parse_devices_metadata(parsed=parsed)
-
-                elif msg_type == "msg_event":
-                    LOGGER.debug("Event message, refreshing...")
-                    await self.tydom_client.get_devices_data()
-
-                elif msg_type == "msg_html":
-                    LOGGER.debug("HTML Response ?")
-
-                elif msg_type == "msg_info":
-                    return await self.parse_msg_info(parsed)
-
-                elif msg_type == "msg_ping":
-                    self.tydom_client.receive_pong()
-
+                return await msg_type(parsed, transaction_id)
             except Exception as e:
                 LOGGER.error("Error on parsing tydom response (%s)", data, exc_info=e)
-                LOGGER.exception("Error on parsing tydom response")
         LOGGER.debug("Incoming data parsed with success")
 
-    async def parse_devices_metadata(self, parsed):
+    async def parse_devices_metadata(self, parsed, transaction_id):
         """Parse metadata."""
         LOGGER.debug("metadata : %s", parsed)
         for device in parsed:
@@ -224,7 +224,7 @@ class MessageHandler:
                         )
         return []
 
-    async def parse_msg_info(self, parsed):
+    async def parse_msg_info(self, parsed, transaction_id):
         """Parse message info."""
         LOGGER.debug("parse_msg_info : %s", parsed)
 
@@ -380,7 +380,7 @@ class MessageHandler:
                 return
 
     @staticmethod
-    async def parse_config_data(parsed):
+    async def parse_config_data(parsed, transaction_id):
         """Parse config data."""
         LOGGER.debug("parse_config_data : %s", parsed)
         for i in parsed["endpoints"]:
@@ -400,7 +400,7 @@ class MessageHandler:
         LOGGER.debug("Configuration updated")
         return []
 
-    async def parse_cmeta_data(self, parsed):
+    async def parse_cmeta_data(self, parsed, transaction_id):
         """Parse cmeta data."""
         LOGGER.debug("parse_cmeta_data : %s", parsed)
         for i in parsed:
@@ -470,7 +470,7 @@ class MessageHandler:
 
         LOGGER.debug("Metadata configuration updated")
 
-    async def parse_devices_data(self, parsed):
+    async def parse_devices_data(self, parsed, transaction_id):
         """Parse device data."""
         LOGGER.debug("parse_devices_data : %s", parsed)
         devices = []
@@ -518,7 +518,7 @@ class MessageHandler:
                         LOGGER.exception("msg_data error in parsing !")
         return devices
 
-    async def parse_devices_cdata(self, parsed, transaction_id: int | None = None):
+    async def parse_devices_cdata(self, parsed, transaction_id: str | None = None):
         """Parse devices cdata."""
         LOGGER.debug("parse_devices_cdata : %s", parsed)
         devices = []

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -573,7 +573,7 @@ class TydomClient:
         body: str
         if value is None:
             body = '{"' + name + '":"null}'
-        elif isinstance(value, (bool, int)):
+        elif isinstance(value, bool | int):
             body = '{"' + name + '":"' + str(value).lower() + "}"
         else:
             body = '{"' + name + '":"' + value + '"}'

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1,15 +1,17 @@
 """Tydom API Client."""
+
 import os
 import asyncio
 import socket
 import base64
 import re
-import async_timeout
-import aiohttp
 import ssl
 import traceback
+from typing import TYPE_CHECKING, cast
 
-from typing import cast
+import aiohttp
+import async_timeout
+
 from urllib3 import encode_multipart_formdata
 from aiohttp import ClientWebSocketResponse, ClientSession, WSMsgType
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -20,12 +22,17 @@ from .const import (
     DELTADORE_AUTH_GRANT_TYPE,
     DELTADORE_AUTH_CLIENTID,
     DELTADORE_AUTH_SCOPE,
-    DELTADORE_API_SITES)
+    DELTADORE_API_SITES,
+)
 from .MessageHandler import MessageHandler
 
 from requests.auth import HTTPDigestAuth
 
 from ..const import LOGGER
+
+if TYPE_CHECKING:
+    from .tydom_devices import TydomDevice
+
 
 class TydomClientApiClientError(Exception):
     """Exception to indicate a general API error."""
@@ -46,6 +53,7 @@ file_mode = False
 file_lines = None
 file_index = 0
 file_name = "/config/traces.txt"
+
 
 class TydomClient:
     """Tydom API Client."""
@@ -84,11 +92,11 @@ class TydomClient:
 
         if self._remote_mode:
             LOGGER.info("Configure remote mode (%s)", self._host)
-            self._cmd_prefix = "\x02"
+            self._cmd_prefix = b"\x02"
             self._ping_timeout = 40
         else:
             LOGGER.info("Configure local mode (%s)", self._host)
-            self._cmd_prefix = ""
+            self._cmd_prefix = b""
             self._ping_timeout = None
 
         self._message_handler = MessageHandler(
@@ -212,7 +220,7 @@ class TydomClient:
         }
 
         # configuration needed for local mode
-        #- Wrap slow blocking call flagged by HA
+        # - Wrap slow blocking call flagged by HA
         sslcontext = await asyncio.to_thread(ssl.create_default_context)
         sslcontext.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
         sslcontext.check_hostname = False
@@ -309,12 +317,14 @@ class TydomClient:
 
         await self.get_scenarii()
 
-    async def consume_messages(self):
-        """Read and parse incomming messages."""
+    async def consume_messages(self) -> list["TydomDevice"] | None:
+        """Read and parse incoming messages."""
         global file_lines, file_mode, file_index
         if file_mode:
-            if (len(file_lines) > file_index):
-                incoming = file_lines[file_index].replace("\\r", '\x0d').replace("\\n", "\x0a")
+            if len(file_lines) > file_index:
+                incoming = (
+                    file_lines[file_index].replace("\\r", "\x0d").replace("\\n", "\x0a")
+                )
                 incoming_bytes_str = incoming.encode("utf-8")
                 file_index += 1
                 LOGGER.info("Incomming message - message : %s", incoming_bytes_str)
@@ -322,7 +332,7 @@ class TydomClient:
                 await asyncio.sleep(10)
                 return None
             await asyncio.sleep(1)
-            return await self._message_handler.incoming_triage(incoming_bytes_str)
+            return await self._message_handler.route_response(incoming_bytes_str)
         try:
             if self._connection.closed or self.pending_pings > 5:
                 await self._connection.close()
@@ -334,7 +344,11 @@ class TydomClient:
                 "Incomming message - type : %s - message : %s", msg.type, msg.data
             )
 
-            if msg.type == WSMsgType.CLOSE or msg.type == WSMsgType.CLOSED or msg.type == WSMsgType.CLOSING:
+            if (
+                msg.type == WSMsgType.CLOSE
+                or msg.type == WSMsgType.CLOSED
+                or msg.type == WSMsgType.CLOSING
+            ):
                 LOGGER.debug("Close message type received")
                 return None
             elif msg.type == WSMsgType.ERROR:
@@ -346,7 +360,7 @@ class TydomClient:
 
             incoming_bytes_str = cast(bytes, msg.data)
 
-            return await self._message_handler.incoming_triage(incoming_bytes_str)
+            return await self._message_handler.route_response(incoming_bytes_str)
 
         except Exception:
             LOGGER.exception("Unable to handle message")
@@ -374,7 +388,7 @@ class TydomClient:
         )
         return digest
 
-    async def send_bytes(self, a_bytes : bytes):
+    async def send_bytes(self, a_bytes: bytes):
         """Send bytes to connection, retry if it fails."""
         if self._connection is not None:
             try:
@@ -385,9 +399,7 @@ class TydomClient:
                     self._connection = await self.async_connect()
                     await self._connection.send_bytes(a_bytes)
                 except ConnectionResetError:
-                    LOGGER.warning(
-                        "Cannot send message to Tydom. Connection was lost."
-            )
+                    LOGGER.warning("Cannot send message to Tydom. Connection was lost.")
         else:
             LOGGER.warning(
                 "Cannot send message to Tydom because no connection has been established yet."
@@ -396,13 +408,12 @@ class TydomClient:
     async def send_message(self, method, msg):
         """Send Generic message to Tydom."""
         message = (
-            self._cmd_prefix
-            + method
+            method
             + " "
             + msg
             + " HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
         )
-        a_bytes = bytes(message, "ascii")
+        a_bytes = self._cmd_prefix + bytes(message, "ascii")
         LOGGER.debug(
             "Sending message to tydom (%s %s)",
             method,
@@ -411,14 +422,13 @@ class TydomClient:
         if not file_mode:
             await self.send_bytes(a_bytes)
 
-
     # ########################
     # Utils methods
     # ########################
 
     @staticmethod
     def generate_random_key():
-        """Generate 16 bytes random key for Sec-WebSocket-Keyand convert it to base64."""
+        """Generate 16 bytes random key for Sec-WebSocket-Key and convert it to base64."""
         return str(base64.b64encode(os.urandom(16)))
 
     # ########################
@@ -518,11 +528,8 @@ class TydomClient:
         """Give order to endpoint."""
         # 10 here is the endpoint = the device (shutter in this case) to open.
         device_id = str(id)
-        str_request = (
-            self._cmd_prefix
-            + f"GET /devices/{device_id}/endpoints/{device_id}/data HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
-        )
-        a_bytes = bytes(str_request, "ascii")
+        str_request = f"GET /devices/{device_id}/endpoints/{device_id}/data HTTP/1.1\r\nContent-Length: 0\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
+        a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
         LOGGER.debug("Sending message to tydom (%s %s)", "GET device data", str_request)
         if not file_mode:
             await self.send_bytes(a_bytes)
@@ -566,20 +573,19 @@ class TydomClient:
         body: str
         if value is None:
             body = '{"' + name + '":"null}'
-        elif isinstance(value, bool) or isinstance(value, int):
-            body = '{"' + name + '":"' + str(value).lower() + '}'
+        elif isinstance(value, (bool, int)):
+            body = '{"' + name + '":"' + str(value).lower() + "}"
         else:
             body = '{"' + name + '":"' + value + '"}'
 
         str_request = (
-            self._cmd_prefix
-            + f"PUT {path} HTTP/1.1\r\nContent-Length: "
+            f"PUT {path} HTTP/1.1\r\nContent-Length: "
             + str(len(body))
             + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
             + body
             + "\r\n\r\n"
         )
-        a_bytes = bytes(str_request, "ascii")
+        a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
         LOGGER.debug("Sending message to tydom (%s %s)", "PUT data", body)
         if not file_mode:
             await self.send_bytes(a_bytes)
@@ -592,39 +598,57 @@ class TydomClient:
         if value is None:
             body = '[{"name":"' + name + '","value":null}]'
         elif isinstance(value, bool):
-            body = '[{"name":"' + name + '","value":' + str(value).lower() + '}]'
+            body = '[{"name":"' + name + '","value":' + str(value).lower() + "}]"
         else:
             body = '[{"name":"' + name + '","value":"' + value + '"}]'
 
         # endpoint_id is the endpoint = the device (shutter in this case) to
         # open.
         str_request = (
-            self._cmd_prefix
-            + f"PUT /devices/{device_id}/endpoints/{endpoint_id}/data HTTP/1.1\r\nContent-Length: "
+            f"PUT /devices/{device_id}/endpoints/{endpoint_id}/data HTTP/1.1\r\nContent-Length: "
             + str(len(body))
             + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
             + body
             + "\r\n\r\n"
         )
-        a_bytes = bytes(str_request, "ascii")
+        a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
         LOGGER.debug("Sending message to tydom (%s %s)", "PUT device data", body)
         if not file_mode:
             await self.send_bytes(a_bytes)
 
         return 0
 
-    async def put_alarm_cdata(self, device_id, endpoint_id=None, alarm_pin=None, value=None, zone_id=None, legacy_zones=False):
+    async def put_alarm_cdata(
+        self,
+        device_id,
+        endpoint_id=None,
+        alarm_pin=None,
+        value=None,
+        zone_id=None,
+        legacy_zones=False,
+    ):
         """Configure alarm mode."""
         if legacy_zones:
             if zone_id is not None:
                 zones_array = zone_id.split(",")
                 for zone in zones_array:
-                    await self._put_alarm_cdata(device_id, endpoint_id, alarm_pin, value, zone, legacy_zones)
+                    await self._put_alarm_cdata(
+                        device_id, endpoint_id, alarm_pin, value, zone, legacy_zones
+                    )
         else:
-            await self._put_alarm_cdata(device_id, endpoint_id, alarm_pin, value, zone_id, legacy_zones)
+            await self._put_alarm_cdata(
+                device_id, endpoint_id, alarm_pin, value, zone_id, legacy_zones
+            )
 
-
-    async def _put_alarm_cdata(self, device_id, endpoint_id=None, alarm_pin=None, value=None, zone_id=None, legacy_zones=False):
+    async def _put_alarm_cdata(
+        self,
+        device_id,
+        endpoint_id=None,
+        alarm_pin=None,
+        value=None,
+        zone_id=None,
+        legacy_zones=False,
+    ):
         """Configure alarm mode."""
         # Credits to @mgcrea on github !
         # AWAY # "PUT /devices/{}/endpoints/{}/cdata?name=alarmCmd HTTP/1.1\r\ncontent-length: 29\r\ncontent-type: application/json; charset=utf-8\r\ntransac-id: request_124\r\n\r\n\r\n{"value":"ON","pwd":{}}\r\n\r\n"
@@ -655,22 +679,12 @@ class TydomClient:
         try:
             if zone_id is None or zone_id == "":
                 cmd = "alarmCmd"
-                body = (
-                    '{"value":"'
-                    + str(value)
-                    + '","pwd":"'
-                    + str(pin)
-                    + '"}'
-                )
+                body = '{"value":"' + str(value) + '","pwd":"' + str(pin) + '"}'
             else:
                 if legacy_zones:
                     cmd = "partCmd"
                     body = (
-                        '{"value":"'
-                        + str(value)
-                        + ', "part":"'
-                        + str(zone_id)
-                        + '"}'
+                        '{"value":"' + str(value) + ', "part":"' + str(zone_id) + '"}'
                     )
                 else:
                     cmd = "zoneCmd"
@@ -685,15 +699,14 @@ class TydomClient:
                     )
 
             str_request = (
-                self._cmd_prefix
-                + f"PUT /devices/{device_id}/endpoints/{endpoint_id}/cdata?name={cmd} HTTP/1.1\r\nContent-Length: "
+                f"PUT /devices/{device_id}/endpoints/{endpoint_id}/cdata?name={cmd} HTTP/1.1\r\nContent-Length: "
                 + str(len(body))
                 + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
                 + body
                 + "\r\n\r\n"
             )
 
-            a_bytes = bytes(str_request, "ascii")
+            a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
             LOGGER.debug("Sending message to tydom (%s %s)", "PUT cdata", body)
 
             try:


### PR DESCRIPTION
This refactor `MessageHandler` to:
- use a more robust parsing of messages
- simplify the routing and some code without effect
- add a method `prepare_request` - this could be dropped if deemed unneeded here

This is extracted from #166