### PR TITLE
Add support for area-based thermostats Tywell Control (RE2020 / Tywell Pro / Tydom Home)

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -841,7 +841,7 @@ class HaClimate(ClimateEntity, HAEntity):
             elif hvac_mode == HVACMode.COOL:
                 tydom_mode = "COOLING"
             await self._device.set_area_data("authorization", tydom_mode)
-        
+
         # Logique existante pour les anciens matériels
         else:
             await self._device.set_hvac_mode(self.dict_modes_ha_to_dd.get(hvac_mode))
@@ -857,7 +857,7 @@ class HaClimate(ClimateEntity, HAEntity):
             # Logique pour le matériel récent (RE2020)
             if self._device.device_type == "re2020ControlBoiler":
                 await self._device.set_area_data("setpoint", str(temperature))
-            
+
             # Logique existante pour les anciens matériels
             else:
                 await self._device.set_temperature(str(temperature))

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -664,6 +664,8 @@ class HaClimate(ClimateEntity, HAEntity):
         self._attr_name = self._device.device_name
         self._enable_turn_on_off_backwards_compatibility = False
 
+        self._attr_hvac_mode = HVACMode.OFF
+        
         self.dict_modes_ha_to_dd = {
             HVACMode.COOL: "COOLING",
             HVACMode.HEAT: "NORMAL",

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -665,7 +665,7 @@ class HaClimate(ClimateEntity, HAEntity):
         self._enable_turn_on_off_backwards_compatibility = False
 
         self._attr_hvac_mode = HVACMode.OFF
-        
+
         self.dict_modes_ha_to_dd = {
             HVACMode.COOL: "COOLING",
             HVACMode.HEAT: "NORMAL",

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -99,6 +99,7 @@ class Hub:
             zone_night=self._zone_night,
             alarm_pin=self._pin,
             event_callback=self.handle_event,
+            hub=self, # LIGNE AJOUTÉE
         )
 
         self.online = True

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -778,18 +778,18 @@ class MessageHandler:
                     if hasattr(device, 'link_id') and device.link_id == area_id:
                         linked_device_uid = uid
                         break
-            
+
             if linked_device_uid:
                 device_id = self.hub.devices[linked_device_uid]._id
                 endpoint_id = self.hub.devices[linked_device_uid]._endpoint
                 name_of_id = self.get_name_from_id(linked_device_uid)
                 type_of_id = self.get_type_from_id(linked_device_uid)
-                
+
                 data = {}
                 for elem in area.get("data", []):
                     if elem.get("validity") == "upToDate":
                         data[elem["name"]] = elem["value"]
-                
+
                 device = await MessageHandler.get_device(
                     self.tydom_client,
                     type_of_id,

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -770,7 +770,7 @@ class MessageHandler:
 
         for area in parsed:
             area_id = area.get("id")
-            
+
             # Find which device is linked to this area
             linked_device_uid = None
             if self.hub and self.hub.devices: # Vérifie que le hub et sa liste d'appareils existent

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -269,6 +269,13 @@ class TydomBoiler(TydomDevice):
             self._id, self._endpoint, "setpoint", temperature
         )
 
+    async def set_area_data(self, name, value):
+        """Set data for the linked area."""
+        if hasattr(self, 'link_id'):
+            LOGGER.debug("setting area data for %s to %s on area %s", name, value, self.link_id)
+            await self._tydom_client.put_areas_data(self.link_id, name, value)
+
+
 
 class TydomWindow(TydomDevice):
     """represents a window."""


### PR DESCRIPTION
## Description

This pull request adds support for the latest generation of Delta Dore thermostats, such as the **Tywell Control**, which appear to follow the RE2020 standard. These devices use a different communication logic compared to older hardware.

### The Problem

The current integration fails to properly support these thermostats for several reasons:
1.  The device usage type `re2020ControlBoiler` is not recognized and is ignored.
2.  Crucial state updates (like `setpoint` and HVAC `mode`) are sent via the `/areas/data` endpoint, not `/devices/data`, 
3.  The HVAC mode is controlled by the `authorization` attribute (`HEATING`, `COOLING`, `STOP`), not `thermicLevel` or `hvacMode` as with older devices.


### The Solution

This PR introduces a series of changes to handle this new area-based logic while **maintaining backward compatibility** with existing hardware.

**Key Changes:**

-   **`MessageHandler.py`**:
    -   Added `re2020ControlBoiler` to the list of known climate device types.
    -   Implemented a new `parse_areas_data` function to correctly process state updates coming from the `/areas/data` endpoint.
    -   Enhanced the URL routing logic in `parse_response` to correctly match dynamic URLs (e.g., `/areas/12345/data`).
    -   Updated `parse_devices_data` to store the `link_id` that associates a device with its corresponding area.

-   **`tydom_client.py` & `tydom_devices.py`**:
    -   Added new methods (`put_areas_data`, `set_area_data`) to correctly format and send commands to the `/areas/data` endpoint.
    -   Passed the `Hub` object reference down to the `MessageHandler` to give it access to the global device list.

-   **`ha_entities.py` (`HaClimate` class)**:
    -   The `hvac_mode` property now correctly reads the `authorization` attribute.
    -   `async_set_hvac_mode` and `async_set_temperature` now use conditional logic: they call the new `area`-based command methods for `re2020ControlBoiler` devices, while falling back to the old methods for other hardware.
    -   Added `HEAT` and `COOL` to the list of supported HVAC modes for these devices.

### Testing

These changes have been tested on a Tywell Pro with Tywell Control thermostats. After applying the patch:
-   The `climate` entities are correctly created.
-   State updates from the physical thermostat (temperature, setpoint, mode) are correctly and instantly reflected in Home Assistant.
-   Commands sent from Home Assistant (changing setpoint, changing mode to Heat/Cool/Off) are successfully executed by the physical thermostat.

This should resolve the issues for users with this new generation of Delta Dore hardware.

<img width="644" height="1184" alt="image" src="https://github.com/user-attachments/assets/1b9176ac-2218-46de-9e6d-cc9154269446" />
<img width="639" height="1217" alt="image" src="https://github.com/user-attachments/assets/38670ebe-543c-4ae3-96be-90523539d5c6" />
