### PR TITLE
Fix on/off Zigbee lights 

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -341,7 +341,10 @@ class TydomLight(TydomDevice):
         """Tell light to turn on."""
         if brightness is None:
             command = "TOGGLE"
-            if "levelCmd" in self._metadata and "enum_values" in self._metadata["levelCmd"]:
+            if (
+                "levelCmd" in self._metadata
+                and "enum_values" in self._metadata["levelCmd"]
+            ):
                 if "ON" in self._metadata["levelCmd"]["enum_values"]:
                     command = "ON"
 
@@ -350,7 +353,7 @@ class TydomLight(TydomDevice):
                 )
             else:
                 await self._tydom_client.put_devices_data(
-                self._id, self._endpoint, "level", "100"
+                    self._id, self._endpoint, "level", "100"
                 )
 
         else:
@@ -374,7 +377,7 @@ class TydomLight(TydomDevice):
             )
         else:
             await self._tydom_client.put_devices_data(
-            self._id, self._endpoint, "level", "0"
+                self._id, self._endpoint, "level", "0"
             )
 
         self._tydom_client.add_poll_device_url_1s(


### PR DESCRIPTION
Hi, This PR introduces a fix for On/off on Deltadore Zigbee Color Lights.

Zigbee Lights (https://www.deltadore.fr/domotique/pilotage-eclairage/eclairages-connectes/easy-bulb-e27cw-ref-6353002) aren't compatible with actually code , because this lights has no **levelCmd** with **enum_values: ON/OFF**.

Use **metadata: level** with **value** instead of levelCmd for Zigbee Color Lights.

**Light On**
home-assistant  | 2025-10-28 10:02:02.883 INFO (MainThread) [custom_components.deltadore_tydom] Incoming message - type : 2 - message : b'PUT /devices/data HTTP/1.1\r\nServer: Tydom-001A25FFFFFF\r\ncontent-type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n7B\r\n[{"id":1744305237,"endpoints":[{"id":1744305237,"error":0,"data":[{"name":"level","validity":"upToDate","value":100}]}]}]\r\n\r\n0\r\n\r\n'
home-assistant  | 2025-10-28 10:02:02.884 INFO (MainThread) [custom_components.deltadore_tydom] Device update (id=1744305237, endpoint=1744305237, name=Ampoule Cheminée , type=light)

**Light Off**
home-assistant  | 2025-10-28 10:03:30.861 INFO (MainThread) [custom_components.deltadore_tydom] Incoming message - type : 2 - message : b'PUT /devices/data HTTP/1.1\r\nServer: Tydom-001A2FFFFFF\r\ncontent-type: application/json\r\nTransfer-Encoding: chunked\r\n\r\n79\r\n[{"id":1744305237,"endpoints":[{"id":1744305237,"error":0,"data":[{"name":"level","validity":"upToDate","value":0}]}]}]\r\n\r\n0\r\n\r\n'
home-assistant  | 2025-10-28 10:03:30.862 INFO (MainThread) [custom_components.deltadore_tydom] Device update (id=1744305237, endpoint=1744305237, name=Ampoule Cheminée , type=light)

Updated Tydom_devices.py to:
- Use level with value for On/Off Lights
- keep compatibility with levelCmd