### PR TITLE
Refactor Tydom window and door entities: add correct BinarySensorEntity, fix entity routing, improve device_class behavior

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -906,11 +906,11 @@ class HaWindowBinary(BinarySensorEntity, HAEntity):
     _attr_device_class = BinarySensorDeviceClass.WINDOW
 
     def __init__(self, device: TydomWindow, hass) -> None:
-       """Initialize the binary sensor for a Tydom window."""
+        """Initialize the binary sensor for a Tydom window."""
         self.hass = hass
         self._device = device
         self._device._ha_device = self
-        self._attr_unique_id = f"{self._device.device_id}_window_binary"
+        self._attr_unique_id = f"{self._device.device_id}"
         self._attr_name = self._device.device_name
         self._registered_sensors = []
 
@@ -925,12 +925,12 @@ class HaWindowBinary(BinarySensorEntity, HAEntity):
     @property
     def is_on(self) -> bool:
         """Return True if the window is open, False if closed or locked."""
-        if hasattr(self._device, "openState"):
-            # ex. "LOCKED", "OPEN_FRENCH", "OPEN_HOPPER", ...
-            return self._device.openState != "LOCKED"
-        if hasattr(self._device, "intrusionDetect"):
-            return bool(self._device.intrusionDetect)
+        raw = getattr(self._device, "openState", None)
+        if isinstance(raw, str):
+            raw_l = raw.lower()
+            return raw_l not in ("closed", "locked")
         return False
+
 
 class HaDoor(CoverEntity, HAEntity):
     """Representation of a Door."""
@@ -987,11 +987,8 @@ class HaDoorBinary(BinarySensorEntity, HAEntity):
         self.hass = hass
         self._device = device
         self._device._ha_device = self
-
         self._attr_unique_id = f"{self._device.device_id}"
-
         self._attr_name = self._device.device_name
-
         self._registered_sensors = []
 
     @property
@@ -1008,13 +1005,9 @@ class HaDoorBinary(BinarySensorEntity, HAEntity):
         raw = getattr(self._device, "openState", None)
         if isinstance(raw, str):
             raw_l = raw.lower()
-            # ouvert
-            if raw_l not in ("closed", "locked"):
-                return True
-            # fermé
-            return False
-
+            return raw_l not in ("closed", "locked")
         return False
+
 
 class HaGate(CoverEntity, HAEntity):
     """Representation of a Gate."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -896,12 +896,17 @@ class HaWindow(CoverEntity, HAEntity):
             return True
 
 class HaWindowBinary(BinarySensorEntity, HAEntity):
-    """Binary sensor (window): ON = open, OFF = closed."""
+    """Binary sensor for a Tydom window.
+
+    Exposes ON when the window is open (any open mode),
+    and OFF when closed/locked.
+    """
 
     should_poll = False
     _attr_device_class = BinarySensorDeviceClass.WINDOW
 
     def __init__(self, device: TydomWindow, hass) -> None:
+       """Initialize the binary sensor for a Tydom window."""
         self.hass = hass
         self._device = device
         self._device._ha_device = self
@@ -911,6 +916,7 @@ class HaWindowBinary(BinarySensorEntity, HAEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Return device metadata for Home Assistant."""
         return {
             "identifiers": {(DOMAIN, self._device.device_id)},
             "name": self._device.device_name,
@@ -918,10 +924,7 @@ class HaWindowBinary(BinarySensorEntity, HAEntity):
 
     @property
     def is_on(self) -> bool:
-        """
-        True (ON) = la fenêtre est ouverte (peu importe le type d’ouverture).
-        False (OFF) = fermée/LOCKED.
-        """
+        """Return True if the window is open, False if closed or locked."""
         if hasattr(self._device, "openState"):
             # ex. "LOCKED", "OPEN_FRENCH", "OPEN_HOPPER", ...
             return self._device.openState != "LOCKED"
@@ -971,12 +974,16 @@ class HaDoor(CoverEntity, HAEntity):
             )
 
 class HaDoorBinary(BinarySensorEntity, HAEntity):
-    """Binary sensor (door): ON = open, OFF = closed."""
+    """Binary sensor for a Tydom door.
+
+    Exposes ON when the door is open, OFF when closed/locked.
+    """
 
     should_poll = False
     _attr_device_class = BinarySensorDeviceClass.DOOR
 
     def __init__(self, device: TydomDoor, hass) -> None:
+        """Initialize the binary sensor for a Tydom door."""
         self.hass = hass
         self._device = device
         self._device._ha_device = self
@@ -989,6 +996,7 @@ class HaDoorBinary(BinarySensorEntity, HAEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
+        """Return device metadata for Home Assistant."""
         return {
             "identifiers": {(DOMAIN, self._device.device_id)},
             "name": self._device.device_name,
@@ -996,6 +1004,7 @@ class HaDoorBinary(BinarySensorEntity, HAEntity):
 
     @property
     def is_on(self) -> bool:
+        """Return True if the door is open, False if closed or locked."""
         raw = getattr(self._device, "openState", None)
         if isinstance(raw, str):
             raw_l = raw.lower()

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -30,8 +30,6 @@ from .ha_entities import (
     HAEnergy,
     HASmoke,
     HaClimate,
-    HaWindow,
-    HaDoor,
     HaGate,
     HaGarage,
     HaLight,


### PR DESCRIPTION
This PR fixes the long-standing issue where Tydom windows and doors
were exposed as BinarySensorEntity through HaWindow/HaDoor, while
these classes actually inherit from CoverEntity. This resulted in
incorrect behavior (yellow icons, non-binary states, incorrect device_class behavior).

Changes included:

Add HaWindowBinary and HaDoorBinary (BinarySensorEntity)
Always register these as the official binary_sensor for windows/doors
Register HaWindow/HaDoor only as cover when supported (position/level)
Keep existing multi-state openState sensors for UI detail
Improve Home Assistant alarm compatibility (true ON/OFF logic)
Clean separation between cover (multi-state) and binary sensor (open/close)

This brings the Tydom integration in line with HA design guidelines 
and fixes several long-standing UX inconsistencies.
