### PR TITLE
Support position control for garage doors

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2559,6 +2559,11 @@ class HaGarage(CoverEntity, HAEntity):
                 self._attr_supported_features | CoverEntityFeature.STOP
             )
 
+        if hasattr(device, "level"):
+            self._attr_supported_features = (
+                self._attr_supported_features | CoverEntityFeature.SET_POSITION
+            )
+
     @property
     def device_info(self) -> DeviceInfo:
         """Information about this entity/device."""
@@ -2582,6 +2587,13 @@ class HaGarage(CoverEntity, HAEntity):
         else:
             return None
 
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the current position of the garage door."""
+        if hasattr(self._device, "level"):
+            return getattr(self._device, "level", None)
+        return None
+
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         if (
@@ -2600,6 +2612,10 @@ class HaGarage(CoverEntity, HAEntity):
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
         await self._device.stop()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Set the garage door position."""
+        await self._device.set_level(kwargs[ATTR_POSITION])
 
 
 class HaLight(LightEntity, HAEntity):

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -388,6 +388,12 @@ class TydomGarage(TydomDevice):
             self._id, self._endpoint, "levelCmd", "TOGGLE"
         )
 
+    async def set_level(self, level: int) -> None:
+        """Set garage door to the given level."""
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "level", str(level)
+        )
+
 
 class TydomLight(TydomDevice):
     """represents a light."""


### PR DESCRIPTION
I use the SOMMER Delta Dore X3D module (S11561-00001) to control my garage door, which supports both retrieving the current garage door position and setting it to an exact position.
So Tydom exposes a `level` property for my garage door device.

I updated `HaGarage` entity  to conditionally supports this, for devices with a `level` attribute.
*Note: I'm not sure if this is the right way to check whether this feature is available, since I don't have garage door devices that don't support retrieving/setting the exact position.*