### PR TITLE
Add missing state_class to analog sensors (outTemperature, energy min/max, thermometer)

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -1570,6 +1570,20 @@ class HAEnergy(SensorEntity, HAEntity):
         "energyInstantTi1P": SensorStateClass.MEASUREMENT,
         "energyInstantTi1I": SensorStateClass.MEASUREMENT,
         "outTemperature": SensorStateClass.MEASUREMENT,
+        "energyInstantTotElec_Min": SensorStateClass.MEASUREMENT,
+        "energyInstantTotElec_Max": SensorStateClass.MEASUREMENT,
+        "energyScaleTotElec_Min": SensorStateClass.MEASUREMENT,
+        "energyScaleTotElec_Max": SensorStateClass.MEASUREMENT,
+        "energyInstantTotElec_P_Min": SensorStateClass.MEASUREMENT,
+        "energyInstantTotElec_P_Max": SensorStateClass.MEASUREMENT,
+        "energyScaleTotElec_P_Min": SensorStateClass.MEASUREMENT,
+        "energyScaleTotElec_P_Max": SensorStateClass.MEASUREMENT,
+        "energyInstantTi1P_Min": SensorStateClass.MEASUREMENT,
+        "energyInstantTi1P_Max": SensorStateClass.MEASUREMENT,
+        "energyScaleTi1P_Min": SensorStateClass.MEASUREMENT,
+        "energyScaleTi1P_Max": SensorStateClass.MEASUREMENT,
+        "energyInstantTi1I_Min": SensorStateClass.MEASUREMENT,
+        "energyInstantTi1I_Max": SensorStateClass.MEASUREMENT,
     }
 
     units = {
@@ -2799,6 +2813,10 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         "outTemperature": UnitOfTemperature.CELSIUS,
     }
 
+    state_classes = {
+        "outTemperature": SensorStateClass.MEASUREMENT,
+    }
+
     def __init__(self, device: TydomAlarm, hass) -> None:
         """Initialize the sensor."""
         self.hass = hass
@@ -3048,6 +3066,7 @@ class HaThermo(SensorEntity, HAEntity):
         self._state = False
         self._registered_sensors = ["outTemperature"]
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
     @property


### PR DESCRIPTION
## Summary

Several analog sensors created by the integration declare a numeric `device_class` (and unit) but no `state_class`. As a result Home Assistant records no long-term statistics for them, and they can't be used in `statistics-graph` cards or compared over time. This adds `state_class: measurement` to the sensors that were missing it.

## Sensors fixed

- **`HaAlarm`** — `outTemperature` (had `device_class: temperature` + °C, but no `state_class`).
- **`HAEnergy`** — the `_Min` / `_Max` variants of the instantaneous current/power sensors. The base values (`energyInstantTotElec`, `energyInstantTotElecP`, `energyInstantTi1P`, `energyInstantTi1I`) already declare `measurement`; their min/max counterparts did not.
- **`HaThermo`** — the thermometer's temperature value (sets `device_class: temperature` + °C but no `state_class`).

All use `SensorStateClass.MEASUREMENT` (already imported). Energy index sensors already correctly use `TOTAL_INCREASING` and are left unchanged.

## Effect

These sensors now get long-term statistics and can be used directly in statistics graphs, without needing a wrapper template sensor just to add `state_class`.
