### PR TITLE
Expose passive windows/doors as real binary_sensors (boolean on/off, window/door device_class)

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2480,17 +2480,26 @@ class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
     def is_on(self) -> bool:
         """Return True when the window/door is open.
 
-        Mirrors the cover's is_closed logic so the reported state stays
-        identical, just expressed as a boolean: closed only when openState is
-        "LOCKED" (the "LOCKED" semantics come from HaWindow/HaDoor, not from
-        here), otherwise driven by intrusionDetect.
+        Mirrors the cover's is_closed logic, expressed as a boolean: closed
+        only when openState is "LOCKED" (the "LOCKED" semantics come from
+        HaWindow/HaDoor, not from here), otherwise driven by intrusionDetect.
+        Only evaluated while `available` is True (a usable state is present).
         """
-        if hasattr(self._device, "openState"):
-            return getattr(self._device, "openState", None) != "LOCKED"
-        if hasattr(self._device, "intrusionDetect"):
-            return bool(getattr(self._device, "intrusionDetect", False))
-        LOGGER.error("Unknown state for device %s", self._device.device_id)
-        return False
+        if getattr(self._device, "openState", None) is not None:
+            return self._device.openState != "LOCKED"
+        return bool(getattr(self._device, "intrusionDetect", False))
+
+    @property
+    def available(self) -> bool:
+        """Available only while the device reports a usable contact state.
+
+        Returns unavailable (rather than a misleading "off"/closed) when the
+        Tydom endpoint stops sending data, mirroring the diagnostic sensors
+        created for the same device.
+        """
+        if getattr(self._device, "openState", None) is not None:
+            return True
+        return getattr(self._device, "intrusionDetect", None) is not None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2430,6 +2430,107 @@ class HaClimate(ClimateEntity, HAEntity):
         await self._device.set_temperature(str(kwargs.get(ATTR_TEMPERATURE)))
 
 
+class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
+    """Binary sensor for a passive (non-motorized) Tydom window or door.
+
+    Motorized windows/doors are exposed as covers (HaWindow / HaDoor). Passive
+    ones only report an open/closed contact, so a CoverEntity is the wrong
+    abstraction: its state is "open"/"closed" rather than "on"/"off", which
+    breaks the standard window/door device_class behavior and `state_color` in
+    the UI. This entity reports a proper boolean contact state instead.
+    """
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    # Overridden by the window/door subclasses.
+    _opening_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.WINDOW
+
+    def __init__(self, device: TydomDevice, hass) -> None:
+        """Initialize the opening binary sensor."""
+        self.hass = hass
+        self._device = device
+        self._device._ha_device = self
+        # Reuse the "_cover" unique_id: a passive window/door was previously a
+        # CoverEntity routed to the binary_sensor platform with this very id.
+        # Keeping it preserves the existing entity_id across the upgrade instead
+        # of orphaning the old entity and creating a new one. The domain
+        # (binary_sensor) and platform (deltadore_tydom) are unchanged, so the
+        # registry matches the existing entry; only the reported state changes
+        # from open/closed to on/off.
+        self._attr_unique_id = f"{self._device.device_id}_cover"
+        self._attr_name = self._device.device_name
+        self._registered_sensors = []
+        self._attr_device_class = self._opening_device_class
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh on every device push (see HACover for the MRO rationale)."""
+        await super().async_added_to_hass()
+        self._device.register_callback(self.async_write_ha_state)
+        self._device._ha_device = self
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the push callback registered in async_added_to_hass."""
+        self._device.remove_callback(self.async_write_ha_state)
+        if hasattr(self._device, "_ha_device") and self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the window/door is open.
+
+        Mirrors the cover's is_closed logic so the reported state stays
+        identical, just expressed as a boolean: closed only when openState is
+        "LOCKED" (the "LOCKED" semantics come from HaWindow/HaDoor, not from
+        here), otherwise driven by intrusionDetect.
+        """
+        if hasattr(self._device, "openState"):
+            return getattr(self._device, "openState", None) != "LOCKED"
+        if hasattr(self._device, "intrusionDetect"):
+            return bool(getattr(self._device, "intrusionDetect", False))
+        LOGGER.error("Unknown state for device %s", self._device.device_id)
+        return False
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information to link this entity with the correct device."""
+        device_info = self._get_device_info()
+        info: DeviceInfo = {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": device_info["manufacturer"],
+        }
+        if "model" in device_info:
+            info["model"] = device_info["model"]
+        return self._enrich_device_info(info)
+
+
+class HaWindowOpening(HaOpeningBinarySensor):
+    """Binary sensor for a passive (non-motorized) Tydom window."""
+
+    _attr_icon = "mdi:window-open"
+    _opening_device_class = BinarySensorDeviceClass.WINDOW
+
+    sensor_classes = {
+        "battDefect": BinarySensorDeviceClass.PROBLEM,
+        "intrusionDetect": BinarySensorDeviceClass.PROBLEM,
+    }
+
+
+class HaDoorOpening(HaOpeningBinarySensor):
+    """Binary sensor for a passive (non-motorized) Tydom door."""
+
+    _attr_icon = "mdi:door"
+    _opening_device_class = BinarySensorDeviceClass.DOOR
+
+    sensor_classes = {
+        "battDefect": BinarySensorDeviceClass.PROBLEM,
+        "calibrationDefect": BinarySensorDeviceClass.PROBLEM,
+        "intrusionDetect": BinarySensorDeviceClass.PROBLEM,
+    }
+
+
 class HaWindow(CoverEntity, HAEntity):
     """Representation of a Window."""
 

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -38,6 +38,8 @@ from .ha_entities import (
     HaClimate,
     HaWindow,
     HaDoor,
+    HaWindowOpening,
+    HaDoorOpening,
     HaGate,
     HaGarage,
     HaLight,
@@ -371,10 +373,8 @@ class Hub:
             self.add_sensor_callback(ha_device.get_sensors())
 
     async def _create_window_device(self, device: TydomWindow) -> None:
-        """Create window device (cover or binary_sensor)."""
+        """Create window device (cover if motorized, else binary_sensor)."""
         LOGGER.debug("Create window %s", device.device_id)
-        ha_device = HaWindow(device, self._hass)
-        self.ha_devices[device.device_id] = ha_device
 
         # Décision automatique selon les attributs du device
         if any(
@@ -384,6 +384,7 @@ class Hub:
                 "Window %s has motor control → adding as cover",
                 device.device_id,
             )
+            ha_device = HaWindow(device, self._hass)
             if self.add_cover_callback:
                 self.add_cover_callback([ha_device])
         else:
@@ -391,17 +392,17 @@ class Hub:
                 "Window %s is passive → adding as binary_sensor",
                 device.device_id,
             )
+            ha_device = HaWindowOpening(device, self._hass)
             if self.add_binary_sensor_callback:
                 self.add_binary_sensor_callback([ha_device])
 
+        self.ha_devices[device.device_id] = ha_device
         if self.add_sensor_callback:
             self.add_sensor_callback(ha_device.get_sensors())
 
     async def _create_door_device(self, device: TydomDoor) -> None:
-        """Create door device (cover or binary_sensor)."""
+        """Create door device (cover if motorized, else binary_sensor)."""
         LOGGER.debug("Create door %s", device.device_id)
-        ha_device = HaDoor(device, self._hass)
-        self.ha_devices[device.device_id] = ha_device
 
         # Décision automatique selon les attributs du device
         if any(
@@ -410,15 +411,18 @@ class Hub:
             LOGGER.debug(
                 "Door %s has motor control → adding as cover", device.device_id
             )
+            ha_device = HaDoor(device, self._hass)
             if self.add_cover_callback:
                 self.add_cover_callback([ha_device])
         else:
             LOGGER.debug(
                 "Door %s is passive → adding as binary_sensor", device.device_id
             )
+            ha_device = HaDoorOpening(device, self._hass)
             if self.add_binary_sensor_callback:
                 self.add_binary_sensor_callback([ha_device])
 
+        self.ha_devices[device.device_id] = ha_device
         if self.add_sensor_callback:
             self.add_sensor_callback(ha_device.get_sensors())
 


### PR DESCRIPTION
## Problem

Passive (non-motorized) windows and doors are registered on the `binary_sensor` platform, but using the `HaWindow` / `HaDoor` **CoverEntity** classes (`hub.py`, `_create_window_device` / `_create_door_device`). A `CoverEntity` reports `open` / `closed` states, not `on` / `off`. As a result these "binary sensors":

- don't get the standard `window` / `door` binary-sensor `device_class` behavior,
- break `state_color` in Lovelace (the open state isn't colored),
- force users to wrap them in template sensors just to obtain proper on/off coloring.

## Change

Add `HaOpeningBinarySensor` with two thin subclasses `HaWindowOpening` / `HaDoorOpening`, a real `BinarySensorEntity` whose `is_on` returns a boolean. The hub now routes passive windows/doors to these instead of the cover classes. Motorized windows/doors are untouched and still exposed as covers.

Key points:

- **State is unchanged, only its representation.** `is_on` mirrors the cover's existing `is_closed` logic exactly (`openState != "LOCKED"`, else `bool(intrusionDetect)`), so behavior is identical, just expressed as on/off with `device_class: window` / `door`.
- **Migration-safe.** The new entity keeps the existing `"{device_id}_cover"` unique_id. Same domain (`binary_sensor`) and platform, so the registry matches the existing entry: the `entity_id` is preserved, no orphaned entity, no dashboard/automation breakage. (`CoverDeviceClass.WINDOW` and `BinarySensorDeviceClass.WINDOW` are both the string `"window"`, so even the stored device_class doesn't churn.)
- **Single entity per device.** Updates keep routing through the existing `register_callback` / `_ha_device` mechanism used by `HASmoke` and `HACover`.

## Relation to #254

#254 set out to fix the same issue, but I think this PR is a cleaner way to get there:

- #254 registered **both** a binary_sensor **and** a cover for the same device, and both set `self._device._ha_device = self` in `__init__`. The one created last wins, so the other entity never refreshes. This PR creates exactly **one** entity per device (cover if motorized, else binary_sensor), so there's no shared-pointer collision, and it uses the callback-based refresh that `main` already standardized on.
- #254's `is_on` shipped a large block of `LOGGER.warning(...)` debug logging (firing on every state read). None of that here.
- #254 is currently red on Ruff and conflicts with `main` (it predates the substantial refactor of the `_ha_device` lifecycle). This PR is rebased on current `main` and passes `ruff check` + `ruff format --check` (0.15.18, the pinned CI version).

## CI note

The **Hassfest Validation** check is expected to fail here for a reason unrelated to this PR: `translations/en.json` still embeds URLs in 5 `description` fields, which the latest hassfest image rejects. This is the same pre-existing failure seen on #321 (which merged through it). No translation changes are included here to keep the PR focused.

## Testing

- `python3 -m ruff check custom_components/` and `python3 -m ruff format custom_components/ --check` pass (ruff 0.15.18).
- `py_compile` clean.
