### PR TITLE
Add support for third-party Zigbee plugs (e.g. Hue) + fix HASwitch crash

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -4749,7 +4749,7 @@ class HASwitch(SwitchEntity, HAEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes."""
         attrs: dict[str, Any] = {}
-        return self._enrich_extra_state_attributes(attrs)  # type: ignore[attr-defined]
+        return attrs
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -461,6 +461,8 @@ async def _create_switch_device(self, device: TydomPlug) -> None:
         self.ha_devices[device.device_id] = ha_device
         if self.add_switch_callback is not None:
             self.add_switch_callback([ha_device])
+        if self.add_sensor_callback is not None:
+            self.add_sensor_callback(ha_device.get_sensors())
 
     async def _create_alarm_device(self, device: TydomAlarm) -> None:
         """Create alarm device."""

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -21,6 +21,7 @@ from .tydom.tydom_devices import (
     TydomGate,
     TydomGarage,
     TydomLight,
+    TydomPlug,
     TydomAlarm,
     TydomWeather,
     TydomWater,
@@ -144,6 +145,7 @@ class Hub:
             TydomGate: self._create_gate_device,
             TydomGarage: self._create_garage_device,
             TydomLight: self._create_light_device,
+            TydomPlug: self._create_switch_device,
             TydomAlarm: self._create_alarm_device,
             TydomWeather: self._create_weather_device,
             TydomWater: self._create_water_device,
@@ -451,6 +453,14 @@ class Hub:
             self.add_light_callback([ha_device])
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(ha_device.get_sensors())
+
+async def _create_switch_device(self, device: TydomPlug) -> None:
+        """Create switch device for generic third-party plugs (e.g. Hue via Zigbee)."""
+        LOGGER.debug("Create switch %s", device.device_id)
+        ha_device = HASwitch(device, self._hass)
+        self.ha_devices[device.device_id] = ha_device
+        if self.add_switch_callback is not None:
+            self.add_switch_callback([ha_device])
 
     async def _create_alarm_device(self, device: TydomAlarm) -> None:
         """Create alarm device."""

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -454,7 +454,7 @@ class Hub:
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(ha_device.get_sensors())
 
-async def _create_switch_device(self, device: TydomPlug) -> None:
+    async def _create_switch_device(self, device: TydomPlug) -> None:
         """Create switch device for generic third-party plugs (e.g. Hue via Zigbee)."""
         LOGGER.debug("Create switch %s", device.device_id)
         ha_device = HASwitch(device, self._hass)

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -22,6 +22,7 @@ from .tydom_devices import (
     TydomGarage,
     TydomGate,
     TydomLight,
+    TydomPlug,
     TydomShutter,
     TydomSmoke,
     TydomWindow,
@@ -481,6 +482,17 @@ class MessageHandler:
                 )
             case "sensorThermo":
                 return TydomThermo(
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata.get(uid),
+                    data,
+                )
+            case "plug":
+                return TydomPlug(
                     tydom_client,
                     uid,
                     device_id,

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -565,6 +565,32 @@ class TydomThermo(TydomDevice):
     """Represents a thermometer."""
 
 
+class TydomPlug(TydomDevice):
+    """Represents a generic third-party smart plug (e.g. Zigbee Philips Hue plug).
+
+    These devices report their state via a ``plugCmd`` attribute (ON/OFF)
+    instead of the more common ``on``/``level``/``state`` attributes used by
+    native Delta Dore devices, so they need dedicated handling.
+    """
+
+    @property
+    def on(self) -> bool:
+        """Return True if the plug is currently on."""
+        return getattr(self, "plugCmd", None) == "ON"
+
+    async def turn_on(self) -> None:
+        """Turn the plug on."""
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "plugCmd", "ON"
+        )
+
+    async def turn_off(self) -> None:
+        """Turn the plug off."""
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "plugCmd", "OFF"
+        )
+
+
 class TydomScene(TydomDevice):
     """Represents a scene/scenario."""
 


### PR DESCRIPTION
**Bug 1 — Third-party Zigbee plugs are read-only**

Devices with `last_usage: "plug"` (third-party Zigbee plugs paired directly
to a Tydom Home box — e.g. a Philips Hue smart plug, manufacturer
`Signify Netherlands B.V.`) are not handled in `MessageHandler.py`'s device
type matcher, so they fall into the generic fallback and are only ever
exposed as a read-only `sensor` entity, even though they report a `plugCmd`
attribute (ON/OFF) that could be used for control.

The generic switch-detection heuristic in `hub.py`'s `_create_generic_device`
only checks for `on`/`level`/`state` attributes on the device instance — it
never matches `plugCmd`-style attributes, even though the parallel metadata
check does look for any key ending in `"Cmd"`.

**Bug 2 — `HASwitch.extra_state_attributes` crashes**

Once a device does get routed through `HASwitch`, adding the entity raises:
AttributeError: 'HASwitch' object has no attribute '_enrich_extra_state_attributes'

`_enrich_extra_state_attributes` (and `_get_controlled_by_scenes`) are only
defined on `HACover`, not on the shared `HAEntity` base or on `HASwitch`
itself. This means `HASwitch` was likely never successfully instantiated in
practice before.

**Fix**

This PR:
- Adds a `TydomPlug` class (`tydom_devices.py`) handling `plugCmd`-based
  on/off control.
- Adds a `case "plug":` branch in `MessageHandler.py`.
- Routes `TydomPlug` to a new `_create_switch_device` factory method in
  `hub.py`, creating a proper `switch` entity.
- Fixes `HASwitch.extra_state_attributes` to not call the missing
  `HACover`-only method.

Tested locally on DSM Container Manager with a Philips Hue smart plug
paired to a Tydom Home box — the device now correctly appears as
`switch.xxx` and is controllable.