### PR TITLE
Fix pilot-wire (fil pilote) climate zones: expose off/heat + comfort/eco/away presets

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -15,7 +15,11 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
+    PRESET_AWAY,
+    PRESET_COMFORT,
+    PRESET_ECO,
     PRESET_NONE,
 )
 from homeassistant.const import (
@@ -2263,6 +2267,49 @@ class HaClimate(ClimateEntity, HAEntity):
         ):
             self._attr_max_temp = self._device._metadata["setpoint"]["max"]
 
+        # Fil-pilote (pilot-wire) electric heater, e.g. Delta Dore RF 6600 FP
+        # (X3D). These zones expose an hvacMode attribute but have NO usable
+        # setpoint metadata and no HEATING/COOLING mode enum. Real thermostats
+        # expose a setpoint and AC units advertise a COOLING/HEATING mode enum,
+        # so they never match here and keep their previous behaviour intact.
+        # The pilot-wire order is carried by thermicLevel (STOP=Off,
+        # ANTI_FROST=Frost protection, ECO=Eco, COMFORT=Comfort); the Tydom box
+        # schedule and the native Delta Dore app both drive that register while
+        # hvacMode stays NORMAL. So we model OFF + HEAT with comfort/eco/away
+        # presets, all mapped onto thermicLevel; there is no setpoint to drive.
+        metadata = self._device._metadata
+        has_setpoint_meta = (
+            metadata is not None
+            and "setpoint" in metadata
+            and ("min" in metadata["setpoint"] or "max" in metadata["setpoint"])
+        )
+        has_heatcool_enum_meta = metadata is not None and any(
+            isinstance(metadata.get(attr), dict)
+            and (
+                "HEATING" in metadata[attr].get("enum_values", [])
+                or "COOLING" in metadata[attr].get("enum_values", [])
+            )
+            for attr in ("comfortMode", "hvacMode", "thermicLevel")
+        )
+        self._is_filpilote = (
+            hasattr(self._device, "hvacMode")
+            and not has_setpoint_meta
+            and not has_heatcool_enum_meta
+        )
+
+        if self._is_filpilote:
+            self._attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+            self._attr_preset_modes = [
+                PRESET_COMFORT,
+                PRESET_ECO,
+                PRESET_AWAY,
+                PRESET_NONE,
+            ]
+            self._attr_supported_features |= ClimateEntityFeature.PRESET_MODE
+            # No setpoint on these zones: drop TARGET_TEMPERATURE so HA does not
+            # show a temperature control that would write a phantom setpoint.
+            self._attr_supported_features &= ~ClimateEntityFeature.TARGET_TEMPERATURE
+
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
         await super().async_added_to_hass()
@@ -2297,6 +2344,11 @@ class HaClimate(ClimateEntity, HAEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return the current operation (e.g. heat, cool, idle)."""
+        if getattr(self, "_is_filpilote", False):
+            # Derive from thermicLevel (the live pilot-wire order), not hvacMode:
+            # the app/schedule set thermicLevel while hvacMode stays NORMAL.
+            level = getattr(self._device, "thermicLevel", None)
+            return HVACMode.OFF if level == "STOP" else HVACMode.HEAT
         if hasattr(self._device, "hvacMode"):
             hvac_mode = getattr(self._device, "hvacMode", None)
             if hvac_mode is not None and hvac_mode in self.dict_modes_dd_to_ha:
@@ -2323,6 +2375,16 @@ class HaClimate(ClimateEntity, HAEntity):
                 )
                 return self.dict_modes_dd_to_ha[thermic_level]
         return HVACMode.OFF
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running action (best-effort for fil-pilote)."""
+        if getattr(self, "_is_filpilote", False):
+            # No temperature feedback exists, so we cannot distinguish heating
+            # from idle: report OFF when the order is STOP, HEATING otherwise.
+            level = getattr(self._device, "thermicLevel", None)
+            return HVACAction.OFF if level == "STOP" else HVACAction.HEATING
+        return None
 
     @property
     def current_temperature(self) -> float | None:
@@ -2385,11 +2447,29 @@ class HaClimate(ClimateEntity, HAEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
+        if getattr(self, "_is_filpilote", False):
+            # OFF -> pilot-wire STOP. HEAT -> keep the current heating order, or
+            # default to Comfort when coming from STOP; the level is chosen via
+            # preset_mode (comfort/eco/away).
+            if hvac_mode == HVACMode.OFF:
+                await self._device.set_thermic_level("STOP")
+            elif getattr(self._device, "thermicLevel", None) in (None, "STOP"):
+                await self._device.set_thermic_level("COMFORT")
+            return
         await self._device.set_hvac_mode(self.dict_modes_ha_to_dd[hvac_mode])
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
+        if getattr(self, "_is_filpilote", False):
+            level = getattr(self._device, "thermicLevel", None)
+            if level == "COMFORT":
+                return PRESET_COMFORT
+            if level == "ECO":
+                return PRESET_ECO
+            if level == "ANTI_FROST":
+                return PRESET_AWAY
+            return PRESET_NONE
         if hasattr(self._device, "comfortMode"):
             comfort_mode = getattr(self._device, "comfortMode", None)
             if comfort_mode is not None and comfort_mode in self._attr_preset_modes:
@@ -2403,6 +2483,15 @@ class HaClimate(ClimateEntity, HAEntity):
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new target preset mode."""
         if preset_mode == PRESET_NONE:
+            return
+        if getattr(self, "_is_filpilote", False):
+            # Drive the pilot-wire order register directly (as the app does).
+            if preset_mode == PRESET_COMFORT:
+                await self._device.set_thermic_level("COMFORT")
+            elif preset_mode == PRESET_ECO:
+                await self._device.set_thermic_level("ECO")
+            elif preset_mode == PRESET_AWAY:
+                await self._device.set_thermic_level("ANTI_FROST")
             return
         # Try to set comfortMode first
         if (

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -235,7 +235,12 @@ class TydomBoiler(TydomDevice):
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "hvacMode", "NORMAL"
                 )
-                await self.set_temperature("19.0")
+                # Only push a setpoint for devices that actually have one
+                # (real thermostats expose setpoint metadata). Fil-pilote zones
+                # have none; writing one is a phantom value ignored by the
+                # device (upstream #246).
+                if self._metadata is not None and "setpoint" in self._metadata:
+                    await self.set_temperature("19.0")
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "antifrostOn", False
                 )
@@ -304,6 +309,12 @@ class TydomBoiler(TydomDevice):
 
         await self._tydom_client.put_devices_data(
             self._id, self._endpoint, "setpoint", temperature
+        )
+
+    async def set_thermic_level(self, level):
+        """Set the pilot-wire order directly (fil-pilote zones)."""
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "thermicLevel", level
         )
 
 


### PR DESCRIPTION
## Problem

Pilot-wire (fil pilote) electric heaters, e.g. the Delta Dore RF 6600 FP (X3D), expose an `hvacMode` attribute but have **no setpoint** and **no `comfortMode`/`hvacMode`/`thermicLevel` enum metadata**. For these zones today:

- `HaClimate` advertises `hvac_modes = [off, auto]`.
- `async_set_hvac_mode(auto)` maps to `dict_modes_ha_to_dd[AUTO] = "AUTO"`, and `TydomBoiler.set_hvac_mode` has no `AUTO` branch, so it logs `ERROR Unknown hvac mode: AUTO` and does nothing.
- HA core validates `set_hvac_mode` against the entity's `hvac_modes`, so `heat` is refused with `not_valid_hvac_mode`.

Result: the zone can be turned **off** from HA (off maps to `STOP`), but there is no working way to turn it **back on**. `preset_mode` also falls back to a hardcoded default list whose setter is gated on absent enum metadata, so presets are a no-op too. This is the root cause behind #291 (X3D heater, changes from HA have no effect) and #231 (`KeyError 'ECO'`, only auto/heat/off selectable).

## How these zones actually work

Verified on live RF 6600 FP hardware: the pilot-wire order is carried by **`thermicLevel`** with values `STOP` / `ANTI_FROST` / `ECO` / `COMFORT` (= Off / Frost protection / Eco / Comfort). The Tydom weekly schedule and the native Delta Dore app both drive `thermicLevel` directly while `hvacMode` stays `NORMAL`. `hvacMode = NORMAL` means "follow the program", not a fixed level.

## Fix

Detect a pilot-wire zone (has `hvacMode`, no usable `setpoint` metadata, and no `HEATING`/`COOLING` value in any mode enum) and, for that zone only:

- advertise `hvac_modes = [off, heat]` and `preset_modes = [comfort, eco, away]`
- derive `hvac_mode`, `preset_mode` and `hvac_action` from `thermicLevel`
- write `thermicLevel` for off/heat and for each preset (new `TydomBoiler.set_thermic_level`): off -> `STOP`, comfort -> `COMFORT`, eco -> `ECO`, away -> `ANTI_FROST`
- drop `TARGET_TEMPERATURE`, since there is no setpoint

This matches the HA-standard pilot-wire modelling used by the Heatzy and Qubino wire-pilot integrations (`[HEAT, OFF]` + comfort/eco/away presets; `AUTO` only when the device has a real program of its own).

Also guards the hardcoded `set_temperature("19.0")` in the `NORMAL` branch so it only fires when the device exposes a `setpoint`, avoiding a phantom setpoint write on pilot-wire zones (#246).

## Keep same behavior for other device types

This PR keeps the same behavior for other heater types. Thermostats (which expose `setpoint` metadata), AC units (which advertise a `COOLING`/`HEATING` mode enum) and boilers all carry metadata that makes the discriminator false, so their `hvac_modes`, presets, mode mappings, setpoint writes and `supported_features` are byte-for-byte unchanged. `hvac_action` returns `None` for non pilot-wire devices (the inherited default).

## Testing

Applied on a live install (v0.23, HAOS) with two RF 6600 FP zones and a full restart:

- entity advertises `hvac_modes [off, heat]`, `preset_modes [comfort, eco, away, none]`, `supported_features 400` (no target temperature), `hvac_action` present
- comfort -> `thermicLevel COMFORT`, eco -> `ECO`, away -> `ANTI_FROST`, off -> `STOP`
- off then heat turns the zone back on (`heat` -> `thermicLevel COMFORT`, state `heat`) - the behaviour that was previously broken
- `hvacMode` stays `NORMAL` throughout; state and preset track `thermicLevel`

Lint: `ruff check` and `ruff format --check` (pinned 0.15.18) both pass on the changed files.

Refs #291, #231, #246.
