### PR TITLE
Improve Tydom connection reliability on reload and slow gateways

### DIFF
--- a/custom_components/deltadore_tydom/__init__.py
+++ b/custom_components/deltadore_tydom/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN, Platform
 from homeassistant.config_entries import ConfigEntry
@@ -300,6 +302,15 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+async def _teardown_hub(
+    hass: HomeAssistant, entry: ConfigEntry, tydom_hub: hub.Hub
+) -> None:
+    """Stop the hub and remove it from hass.data when it is still registered."""
+    await tydom_hub.async_shutdown()
+    if hass.data.get(DOMAIN, {}).get(entry.entry_id) is tydom_hub:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Delta Dore Tydom from a config entry."""
 
@@ -316,6 +327,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     refresh_interval = "30"
     if CONF_REFRESH_INTERVAL in entry.data:
         refresh_interval = entry.data[CONF_REFRESH_INTERVAL]
+
+    existing_hub = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if existing_hub is not None:
+        await existing_hub.async_shutdown()
 
     tydom_hub = hub.Hub(
         hass,
@@ -351,7 +366,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             target=tydom_hub.refresh_data(), hass=hass, name="Tydom refresh data"
         )
 
+    except asyncio.CancelledError:
+        await _teardown_hub(hass, entry, tydom_hub)
+        raise
     except Exception as err:
+        await _teardown_hub(hass, entry, tydom_hub)
         raise ConfigEntryNotReady from err
 
     # This creates each HA object for each platform your device requires.
@@ -365,6 +384,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # This is called when an entry/configured device is to be removed. The class
     # needs to unload itself, and remove callbacks. See the classes for further
     # details
+    tydom_hub = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if tydom_hub is not None:
+        await tydom_hub.async_shutdown()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/deltadore_tydom/const.py
+++ b/custom_components/deltadore_tydom/const.py
@@ -174,11 +174,11 @@ def get_polling_interval_for_validity(validity: str | None) -> int | None:
 
 
 # Timeout constants (in seconds) for different operation types
-TIMEOUT_QUICK_REQUEST = 5.0  # Fast operations like simple GET requests
-TIMEOUT_NORMAL_REQUEST = 10.0  # Standard operations like PUT, POST
-TIMEOUT_LONG_REQUEST = 30.0  # Long operations like historical data, firmware updates
-TIMEOUT_WEBSOCKET_CONNECT = 10.0  # WebSocket connection timeout
-TIMEOUT_WEBSOCKET_RECEIVE = 5.0  # WebSocket receive timeout
+TIMEOUT_QUICK_REQUEST = 15.0  # Fast operations like simple GET requests
+TIMEOUT_NORMAL_REQUEST = 30.0  # Standard request/reply over the websocket
+TIMEOUT_LONG_REQUEST = 60.0  # Cloud credential fetch, digest handshake, historical data
+TIMEOUT_WEBSOCKET_CONNECT = 30.0  # WebSocket upgrade (after digest handshake)
+TIMEOUT_WEBSOCKET_RECEIVE = 20.0  # Per-message websocket receive timeout
 TIMEOUT_PING = 40.0  # Ping timeout for remote mode
 
 

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2391,9 +2391,7 @@ class HaClimate(ClimateEntity, HAEntity):
             if comfort_mode == "STOP":
                 return HVACMode.OFF
         if thermic_level is not None and thermic_level in self.dict_modes_dd_to_ha:
-            LOGGER.debug(
-                "thermicLevel = %s", self.dict_modes_dd_to_ha[thermic_level]
-            )
+            LOGGER.debug("thermicLevel = %s", self.dict_modes_dd_to_ha[thermic_level])
             return self.dict_modes_dd_to_ha[thermic_level]
         return HVACMode.HEAT
 
@@ -2420,19 +2418,11 @@ class HaClimate(ClimateEntity, HAEntity):
         target = self.target_temperature
         if authorization == "COOLING":
             if current is not None and target is not None:
-                return (
-                    HVACAction.IDLE
-                    if current < target
-                    else HVACAction.COOLING
-                )
+                return HVACAction.IDLE if current < target else HVACAction.COOLING
             return HVACAction.COOLING
         if authorization == "HEATING":
             if current is not None and target is not None:
-                return (
-                    HVACAction.IDLE
-                    if current > target
-                    else HVACAction.HEATING
-                )
+                return HVACAction.IDLE if current > target else HVACAction.HEATING
             return HVACAction.HEATING
         return None
 

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -127,6 +127,7 @@ class Hub:
 
         self.online = True
         self._reload_button_created = False
+        self._shutting_down = False
 
         # Polling cache for optimization
         self._polling_cache: dict[
@@ -173,9 +174,28 @@ class Hub:
 
     async def connect(self) -> ClientWebSocketResponse:
         """Connect to Tydom."""
+        if self._shutting_down:
+            raise asyncio.CancelledError()
         connection = await self._tydom_client.async_connect()
+        if self._shutting_down:
+            await self._tydom_client.async_disconnect()
+            raise asyncio.CancelledError()
         await self._tydom_client.listen_tydom(connection)
         return connection
+
+    async def async_shutdown(self) -> None:
+        """Stop background work and release the Tydom websocket."""
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        await self._tydom_client.async_disconnect()
+
+    async def _interruptible_sleep(self, seconds: float) -> None:
+        """Sleep in short slices so shutdown is picked up quickly."""
+        remaining = seconds
+        while remaining > 0 and not self._shutting_down:
+            await asyncio.sleep(min(1.0, remaining))
+            remaining -= 1.0
 
     @staticmethod
     async def get_tydom_credentials(
@@ -190,7 +210,13 @@ class Hub:
         """Validate credentials."""
         connection = await self._tydom_client.async_connect()
         if hasattr(connection, "close"):
-            await connection.close()
+            try:
+                await asyncio.wait_for(connection.close(), timeout=3.0)
+            except TimeoutError:
+                LOGGER.warning(
+                    "Timed out closing Tydom websocket after credential test"
+                )
+        self._tydom_client._connection = None
 
     def ready(self) -> bool:
         """Check if we're ready to work."""
@@ -227,13 +253,17 @@ class Hub:
         """Listen to tydom events."""
         # wait for callbacks to become available
         while not self.ready():
+            if self._shutting_down:
+                return
             await asyncio.sleep(1)
         LOGGER.debug("Listen to tydom events")
 
         # Validate data consistency after initial setup
         await self._validate_data_consistency()
-        while True:
+        while not self._shutting_down:
             devices = await self._tydom_client.consume_messages()
+            if self._shutting_down:
+                return
             if devices is not None:
                 for device in devices:
                     if device.device_id not in self.devices:
@@ -609,16 +639,16 @@ class Hub:
 
     async def ping(self) -> None:
         """Periodically send pings."""
-        while True:
+        while not self._shutting_down:
             await self._tydom_client.ping()
-            await asyncio.sleep(30)
+            await self._interruptible_sleep(30)
 
     async def refresh_all(self) -> None:
         """Periodically refresh all metadata and data.
 
         It allows new devices to be discovered.
         """
-        while True:
+        while not self._shutting_down:
             await self._tydom_client.get_info()
             await self._tydom_client.put_api_mode()
             await self._tydom_client.get_groups()
@@ -629,13 +659,13 @@ class Hub:
             await self._tydom_client.get_devices_data()
             await self._tydom_client.get_scenarii()
             await self._tydom_client.get_moments()
-            await asyncio.sleep(600)
+            await self._interruptible_sleep(600)
 
     async def refresh_data_1s(self) -> None:
         """Refresh data for devices in list."""
-        while True:
+        while not self._shutting_down:
             await self._tydom_client.poll_devices_data_1s()
-            await asyncio.sleep(1)
+            await self._interruptible_sleep(1)
 
     def _rebuild_polling_cache(self) -> None:
         """Rebuild polling cache efficiently.
@@ -678,7 +708,7 @@ class Hub:
         The polling groups are rebuilt every 5 minutes to account for
         metadata changes.
         """
-        while True:
+        while not self._shutting_down:
             current_time = time.time()
 
             # Rebuild cache only if expired
@@ -712,14 +742,14 @@ class Hub:
                                 )
 
                 # Sleep for the shortest interval
-                await asyncio.sleep(shortest_interval)
+                await self._interruptible_sleep(shortest_interval)
             else:
                 # No devices need polling, use default refresh interval
                 if self._refresh_interval > 0:
                     await self._tydom_client.poll_devices_data_5m()
-                    await asyncio.sleep(self._refresh_interval)
+                    await self._interruptible_sleep(self._refresh_interval)
                 else:
-                    await asyncio.sleep(60)
+                    await self._interruptible_sleep(60)
 
     async def reload_devices(self) -> None:
         """Recharger tous les appareils et entités comme au démarrage initial.

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -22,7 +22,6 @@ from urllib3 import encode_multipart_formdata
 from ..const import (
     LOGGER,
     validate_value_with_metadata,
-    TIMEOUT_QUICK_REQUEST,
     TIMEOUT_NORMAL_REQUEST,
     TIMEOUT_LONG_REQUEST,
     TIMEOUT_WEBSOCKET_CONNECT,
@@ -165,6 +164,7 @@ class TydomClient:
         self._max_reconnect_delay = 60.0
         self._reconnect_backoff_factor = 2.0
         self.online = True
+        self._shutting_down = False
 
         # Metadata cache with TTL (Time To Live)
         self._metadata_cache: dict[
@@ -186,7 +186,7 @@ class TydomClient:
         if file_mode:
             return "dummyPassword"
         try:
-            async with async_timeout.timeout(TIMEOUT_QUICK_REQUEST):
+            async with async_timeout.timeout(TIMEOUT_LONG_REQUEST):
                 response = await session.request(
                     method="GET", url=DELTADORE_AUTH_URL, proxy=proxy
                 )
@@ -280,6 +280,8 @@ class TydomClient:
     async def async_connect(self) -> ClientWebSocketResponse:
         """Connect to the Tydom API."""
         global file_lines, file_mode, file_name
+        if self._shutting_down:
+            raise asyncio.CancelledError()
         self.pending_pings = 0
         if file_mode:
             with open(file_name) as file:
@@ -313,12 +315,9 @@ class TydomClient:
         session = async_create_clientsession(self._hass, False)
 
         try:
-            # Use TIMEOUT_WEBSOCKET_CONNECT instead of TIMEOUT_QUICK_REQUEST because
-            # the initial GET request is part of the WebSocket connection process:
-            # it obtains the digest challenge, calculates authentication, and establishes
-            # the WebSocket connection. This can take longer, especially on first connection
-            # or with network latency.
-            async with async_timeout.timeout(TIMEOUT_WEBSOCKET_CONNECT):
+            # Digest handshake can be very slow on busy local gateways (tydom2mqtt
+            # applies no timeout to the equivalent HTTP step).
+            async with async_timeout.timeout(TIMEOUT_LONG_REQUEST):
                 response = await session.request(
                     method="GET",
                     url=f"https://{self._host}:443/mediation/client?mac={self._mac}&appli=1",
@@ -352,25 +351,24 @@ class TydomClient:
                 else:
                     raise TydomClientApiClientError("Could't find auth nonce")
 
-                http_headers = {}
-                http_headers["Authorization"] = self.build_digest_headers(
-                    re_matcher.group(1)
-                )
+                ws_headers = {
+                    "Authorization": self.build_digest_headers(re_matcher.group(1))
+                }
 
-                connection = await session.ws_connect(
-                    method="GET",
-                    url=f"wss://{self._host}:443/mediation/client?mac={self._mac}&appli=1",
-                    headers=http_headers,
-                    autoping=True,
-                    heartbeat=2.0,
-                    timeout=TIMEOUT_WEBSOCKET_CONNECT,  # type: ignore[arg-type]
-                    receive_timeout=TIMEOUT_WEBSOCKET_RECEIVE,
-                    autoclose=True,
-                    proxy=proxy,
-                    ssl=sslcontext,
-                )
+            connection = await session.ws_connect(
+                method="GET",
+                url=f"wss://{self._host}:443/mediation/client?mac={self._mac}&appli=1",
+                headers=ws_headers,
+                autoping=True,
+                heartbeat=2.0,
+                timeout=TIMEOUT_WEBSOCKET_CONNECT,  # type: ignore[arg-type]
+                receive_timeout=TIMEOUT_WEBSOCKET_RECEIVE,
+                autoclose=True,
+                proxy=proxy,
+                ssl=sslcontext,
+            )
 
-                return connection
+            return connection
 
         except TimeoutError as exception:
             raise TydomClientApiClientCommunicationError(
@@ -386,8 +384,27 @@ class TydomClient:
                 "Something really wrong happened!"
             ) from exception
 
+    def begin_shutdown(self) -> None:
+        """Signal that the client must stop reconnecting and using the socket."""
+        self._shutting_down = True
+
+    async def async_disconnect(self) -> None:
+        """Close the active websocket connection, if any."""
+        self.begin_shutdown()
+        connection = self._connection
+        self._connection = None
+        if connection is not None and not connection.closed:
+            try:
+                await asyncio.wait_for(connection.close(), timeout=3.0)
+            except TimeoutError:
+                LOGGER.warning("Timed out closing Tydom websocket")
+            except Exception:
+                LOGGER.exception("Error closing Tydom websocket")
+
     async def listen_tydom(self, connection: ClientWebSocketResponse):
         """Listen for Tydom messages."""
+        if self._shutting_down:
+            return
         STRUCTURED_LOGGER.connection_event(
             "info",
             "listen_started",
@@ -396,7 +413,11 @@ class TydomClient:
         )
         self._connection = connection
         await self.ping()
+        if self._shutting_down:
+            return
         await self.get_info()
+        if self._shutting_down:
+            return
         # await self.put_api_mode()
         # await self.get_geoloc()
         # await self.get_local_claim()
@@ -410,11 +431,15 @@ class TydomClient:
 
         # await self.get_info()
         await self.get_groups()
+        if self._shutting_down:
+            return
         await self.post_refresh()
         await self.get_configs_file()
         await self.get_devices_meta()
         await self.get_devices_cmeta()
         await self.get_devices_data()
+        if self._shutting_down:
+            return
 
         await self.get_scenarii()
 
@@ -438,7 +463,11 @@ class TydomClient:
                   will stop after max_reconnect_attempts and mark client as offline.
 
         """
+        if self._shutting_down:
+            return
         while self._reconnect_attempts < self._max_reconnect_attempts:
+            if self._shutting_down:
+                return
             delay = min(
                 self._reconnect_delay
                 * (self._reconnect_backoff_factor**self._reconnect_attempts),
@@ -502,9 +531,13 @@ class TydomClient:
             await asyncio.sleep(1)
             return await self._message_handler.route_response(incoming_bytes_str)
         try:
+            if self._shutting_down:
+                return None
             if self._connection is None:
                 return None
             if self._connection.closed or self.pending_pings > 5:
+                if self._shutting_down:
+                    return None
                 await self._connection.close()
                 await self._reconnect_with_backoff()
                 return None
@@ -541,6 +574,8 @@ class TydomClient:
 
             return await self._message_handler.route_response(incoming_bytes_str)
 
+        except asyncio.CancelledError:
+            raise
         except Exception:
             # Ne pas logger le message complet pour éviter d'exposer des informations sensibles
             LOGGER.exception("Unable to handle message")
@@ -582,6 +617,9 @@ class TydomClient:
         if file_mode:
             return
 
+        if self._shutting_down:
+            return
+
         if self._connection is None:
             LOGGER.warning(
                 "Cannot send message to Tydom because no connection has been established yet."
@@ -610,6 +648,8 @@ class TydomClient:
                         delay,
                     )
                     try:
+                        if self._shutting_down:
+                            return
                         # Try to reconnect
                         self._connection = await self.async_connect()
                         await asyncio.sleep(delay)
@@ -703,7 +743,7 @@ class TydomClient:
             url: Request URL
             body: Request body
             headers: Request headers
-            timeout: Timeout in seconds (default: 10.0)
+            timeout: Timeout in seconds (default: 30.0)
 
         Returns:
             List of reply events or None

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -102,16 +102,14 @@ class TydomDevice:
                 ]:
                     setattr(self, attribute, value)
         await self.publish_updates()
-        if hasattr(self, "_ha_device") and self._ha_device is not None:
-            try:
-                self._ha_device.async_write_ha_state()
-            except Exception:
-                LOGGER.exception("update failed")
 
     async def publish_updates(self) -> None:
         """Schedule call all registered callbacks."""
         for callback in self._callbacks:
-            callback()
+            try:
+                callback()
+            except Exception:
+                LOGGER.exception("Device callback failed for %s", self.device_id)
 
 
 class Tydom(TydomDevice):


### PR DESCRIPTION
Reloading the integration used to loop through setup_retry: closing the websocket without stopping background tasks let reconnect logic fight the new setup attempt.

- Coordinate shutdown with a client-level flag so reconnect and send paths stop once teardown begins
- Shut down any existing hub before setup, on setup failure/cancellation, and before unloading platforms
- Make background loops exit promptly via interruptible sleeps
- Guard device update callbacks without writing entity state too early

Local Tydom gateways can also be slow to answer (10s+). This caused my integration to fail to initialize sometimes up to 30 times. With this fix it succeeds on 1st try. Align timeouts with tydom2mqtt behaviour: raise limits and split the digest HTTP handshake (60s) from the websocket upgrade (30s) instead of sharing one deadline. Use a longer window for the multi-step cloud credential fetch.