### PR TITLE
Add support for KLINE motorized doors (belmDoor/podPosition)

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2705,7 +2705,9 @@ class HaDoor(CoverEntity, HAEntity):
     """Representation of a Door."""
 
     _attr_should_poll = False
-    _attr_supported_features: CoverEntityFeature | None = None
+    _attr_supported_features: CoverEntityFeature = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    )
     _attr_device_class = CoverDeviceClass.DOOR
     _attr_icon = "mdi:door"
     _attr_has_entity_name = True
@@ -2752,9 +2754,11 @@ class HaDoor(CoverEntity, HAEntity):
         return self._enrich_device_info(info)
 
     @property
-    def is_closed(self) -> bool:
-        """Return if the door is locked."""
-        if hasattr(self._device, "openState"):
+    def is_closed(self) -> bool | None:
+        """Return if the door is closed."""
+        if hasattr(self._device, "podPosition"):
+            return getattr(self._device, "podPosition", None) in ("CLOSE", "LOCK")
+        elif hasattr(self._device, "openState"):
             open_state = getattr(self._device, "openState", None)
             return open_state == "LOCKED"
         elif hasattr(self._device, "intrusionDetect"):
@@ -2762,8 +2766,17 @@ class HaDoor(CoverEntity, HAEntity):
             return not bool(intrusion_detect)
         else:
             raise AttributeError(
-                "The required attributes 'openState' or 'intrusionDetect' are not available in the device."
+                "The required attributes 'podPosition', 'openState' or "
+                "'intrusionDetect' are not available in the device."
             )
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the door."""
+        await self._device.open()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the door."""
+        await self._device.close()
 
     @property
     def icon(self) -> str:

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -407,8 +407,18 @@ class Hub:
         LOGGER.debug("Create door %s", device.device_id)
 
         # Décision automatique selon les attributs du device
+        # podPosition : attribut utilisé par les portes motorisées KLINE
+        # (device_type "belmDoor" / "klineDoor"), en lecture/écriture avec
+        # les valeurs OPEN / CLOSE / LOCK.
         if any(
-            hasattr(device, a) for a in ["position", "positionCmd", "level", "levelCmd"]
+            hasattr(device, a)
+            for a in [
+                "position",
+                "positionCmd",
+                "level",
+                "levelCmd",
+                "podPosition",
+            ]
         ):
             LOGGER.debug(
                 "Door %s has motor control → adding as cover", device.device_id

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -325,6 +325,24 @@ class TydomWindow(TydomDevice):
 class TydomDoor(TydomDevice):
     """represents a door."""
 
+    async def open(self) -> None:
+        """Tell door to open."""
+        await self._tydom_client.put_devices_data_validated(
+            self._id, self._endpoint, "podPosition", "OPEN", device=self
+        )
+
+    async def close(self) -> None:
+        """Tell door to close (unlocked)."""
+        await self._tydom_client.put_devices_data_validated(
+            self._id, self._endpoint, "podPosition", "CLOSE", device=self
+        )
+
+    async def lock(self) -> None:
+        """Tell door to close and lock (KLINE doors only, no unlock)."""
+        await self._tydom_client.put_devices_data_validated(
+            self._id, self._endpoint, "podPosition", "LOCK", device=self
+        )
+
 
 class TydomGate(TydomDevice):
     """represents a gate."""


### PR DESCRIPTION
## Add support for KLINE motorized doors (belmDoor / podPosition)

### Context

Devices of type `belmDoor` (`last_usage`/`first_usage`, `picto_belmdoor`,
`widget_behavior.tutorial_id: "6_pod_kline"`) — i.e. Delta Dore KLINE
motorized door pods — report their state through the `podPosition`
attribute rather than the generic `position` / `positionCmd` / `level`
/ `levelCmd` attributes already handled for windows/gates/garages.

`/devices/meta` for such a device returns:

```json
{
  "name": "podPosition",
  "type": "string",
  "permission": "rw",
  "validity": "DATA_POLLING",
  "shared": false,
  "enum_values": ["OPEN", "CLOSE", "LOCK"]
}
```

`podPosition` is read/write directly (no separate `*Cmd` attribute),
with three possible values: `OPEN`, `CLOSE`, `LOCK`.

Because `hub.py::_create_door_device` only checked for
`position`/`positionCmd`/`level`/`levelCmd`, these doors were always
created as a passive `binary_sensor` (`HaDoorOpening`), with no way to
open them remotely, even though the hardware supports it.

### Changes

- **`hub.py`**: add `podPosition` to the attribute list used in
  `_create_door_device` to decide between `cover` and `binary_sensor`.
  Only the door branch is affected — `_create_window_device` (which
  has an identical-looking check) is left untouched.
- **`tydom/tydom_devices.py`**: add `open()`, `close()`, and `lock()`
  coroutines to `TydomDoor`, writing `OPEN`/`CLOSE`/`LOCK` to
  `podPosition` via `TydomClient.put_devices_data_validated` (so the
  value is validated against the device's own metadata before being
  sent).
- **`ha_entities.py`** (`HaDoor`):
  - `_attr_supported_features` now advertises
    `CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE`.
  - `is_closed` first checks `podPosition` (`CLOSE` or `LOCK` → closed),
    falling back to the existing `openState`/`intrusionDetect` logic
    for doors that don't expose `podPosition`, so no other device type
    is affected.
  - `async_open_cover` / `async_close_cover` call the new
    `TydomDoor.open()` / `close()`.

### Not included on purpose

`LOCK` is intentionally **not** exposed as a remote command. On the
KLINE hardware this PR was tested against, locking/unlocking the door
is a manual, mechanical action (key or button on the door itself) —
only the open/closed position is motorized and remotely controllable.
Exposing a "lock" action from `podPosition` would be misleading, so
only `OPEN`/`CLOSE` are wired up. `podPosition == "LOCK"` is still
correctly reflected as "closed" in `is_closed`/`icon` if the door
happens to be manually locked.

### Testing

- Verified against a real `belmDoor` device (`PorteEnt`, KLINE pod)
  logged in production: device now shows up as
  `cover.<name>` with working Open/Close buttons instead of an
  "unavailable" binary_sensor.
- `ruff format --check` and `ruff check` pass on all three modified
  files.
- `python -m py_compile` passes on all three modified files.

### Notes for reviewer

The pre-existing `binary_sensor` entity for devices that were already
set up before this change will become "unavailable" after upgrading,
since the device now creates a `cover` entity instead. Users should
remove the stale `binary_sensor` entity manually from
**Settings → Devices & services → Entities**. Happy to add a note
about this to the changelog/README if useful.
