### PR TITLE
Skip scheduled Validate runs on forks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
     name: "Hassfest Validation"
+    # Skip scheduled runs on forks (HACS repository checks only pass on the upstream repo)
+    if: github.event_name != 'schedule' || github.repository == 'CyrilP/hass-deltadore-tydom-component'
     runs-on: "ubuntu-latest"
     steps:
         - name: "Checkout the repository"
@@ -24,6 +26,8 @@ jobs:
 
   hacs: # https://github.com/hacs/action
     name: "HACS Validation"
+    # Skip scheduled runs on forks (HACS repository checks only pass on the upstream repo)
+    if: github.event_name != 'schedule' || github.repository == 'CyrilP/hass-deltadore-tydom-component'
     runs-on: "ubuntu-latest"
     steps:
         - name: "Checkout the repository"


### PR DESCRIPTION
## Problem

The `Validate` workflow runs daily via `schedule`, including on forks. On forks, the HACS validation always fails on repository-level checks that only the upstream repository can satisfy:

- `Validation issues` failed: The repository does not have issues enabled
- `Validation topics` failed: The repository has no valid topics

(see https://hacs.xyz/docs/publish/include#check-repository)

Example failing scheduled run on a fork: https://github.com/kcgthb/hass-deltadore-tydom-component/actions/runs/28766793197

This produces a daily red run and a failure-notification email for every fork owner, with no actual problem in the code.

## Fix

Gate both jobs with:

```yaml
if: github.event_name != 'schedule' || github.repository == 'CyrilP/hass-deltadore-tydom-component'
```

Scheduled runs now only execute on the upstream repository. `push`, `pull_request` and `workflow_dispatch` runs are unaffected everywhere (including forks). This is the standard pattern recommended for scheduled workflows in repositories with forks.
