### PR TITLE
Fix pilot-wire detection broken by the write-only comfortMode [STOP, HEATING] enum

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2268,33 +2268,48 @@ class HaClimate(ClimateEntity, HAEntity):
             self._attr_max_temp = self._device._metadata["setpoint"]["max"]
 
         # Fil-pilote (pilot-wire) electric heater, e.g. Delta Dore RF 6600 FP
-        # (X3D). These zones expose an hvacMode attribute but have NO usable
-        # setpoint metadata and no HEATING/COOLING mode enum. Real thermostats
-        # expose a setpoint and AC units advertise a COOLING/HEATING mode enum,
-        # so they never match here and keep their previous behaviour intact.
-        # The pilot-wire order is carried by thermicLevel (STOP=Off,
-        # ANTI_FROST=Frost protection, ECO=Eco, COMFORT=Comfort); the Tydom box
-        # schedule and the native Delta Dore app both drive that register while
-        # hvacMode stays NORMAL. So we model OFF + HEAT with comfort/eco/away
-        # presets, all mapped onto thermicLevel; there is no setpoint to drive.
+        # (X3D). These zones expose hvacMode and thermicLevel but no usable
+        # setpoint metadata. The pilot-wire order is carried by thermicLevel
+        # (STOP=Off, ANTI_FROST=Frost protection, ECO=Eco, COMFORT=Comfort);
+        # the Tydom box schedule and the native Delta Dore app both drive that
+        # register while hvacMode stays NORMAL. So we model OFF + HEAT with
+        # comfort/eco/away presets, all mapped onto thermicLevel; there is no
+        # setpoint to drive.
+        #
+        # Verified metadata on live RF 6600 FP zones (Tydom 1.0):
+        #   hvacMode:     enum [NORMAL, STOP, ANTI_FROST], rw
+        #   thermicLevel: enum [ECO, MODERATO, MEDIO, COMFORT, STOP,
+        #                 ANTI_FROST], rw
+        #   comfortMode:  enum [STOP, HEATING], WRITE-ONLY command register
+        #   setpoint:     absent
+        # Only COOLING identifies an AC unit; HEATING must NOT disqualify,
+        # because the write-only comfortMode [STOP, HEATING] register above is
+        # a pilot-wire trait, not an AC mode enum. Real thermostats expose a
+        # setpoint and never carry the thermicLevel order register, so they
+        # keep their previous behaviour intact.
         metadata = self._device._metadata
         has_setpoint_meta = (
             metadata is not None
             and "setpoint" in metadata
             and ("min" in metadata["setpoint"] or "max" in metadata["setpoint"])
         )
-        has_heatcool_enum_meta = metadata is not None and any(
+        has_cool_enum_meta = metadata is not None and any(
             isinstance(metadata.get(attr), dict)
-            and (
-                "HEATING" in metadata[attr].get("enum_values", [])
-                or "COOLING" in metadata[attr].get("enum_values", [])
-            )
+            and "COOLING" in metadata[attr].get("enum_values", [])
             for attr in ("comfortMode", "hvacMode", "thermicLevel")
+        )
+        # Check the device attribute as well as the metadata: /devices/meta
+        # can be parsed after the device object got created (the metadata
+        # reference is never backfilled on later updates), so the detection
+        # must not depend on that ordering.
+        has_thermic_level = hasattr(self._device, "thermicLevel") or (
+            metadata is not None and "thermicLevel" in metadata
         )
         self._is_filpilote = (
             hasattr(self._device, "hvacMode")
+            and has_thermic_level
             and not has_setpoint_meta
-            and not has_heatcool_enum_meta
+            and not has_cool_enum_meta
         )
 
         if self._is_filpilote:


### PR DESCRIPTION
## Problem

On real RF 6600 FP (X3D) zones, the pilot-wire detection from #328 never triggers in v0.24. The zones fall back to the generic climate branch (`hvac_modes [off, auto, heat]`, raw `NORMAL/ECO/COMFORT` presets, phantom setpoint control), which is the broken behaviour #328 was meant to fix.

Here is what these zones actually advertise in `/devices/meta`, captured on live hardware:

```
hvacMode:     enum [NORMAL, STOP, ANTI_FROST], rw
thermicLevel: enum [ECO, MODERATO, MEDIO, COMFORT, STOP, ANTI_FROST], rw
comfortMode:  enum [STOP, HEATING], write-only
setpoint:     absent
```

The detection assumed pilot-wire zones expose no `HEATING`/`COOLING` mode enum at all. In reality they carry `comfortMode [STOP, HEATING]` (a write-only on/off command register), so the `HEATING` guard disqualifies exactly the zones the feature targets.

#328 still tested fine because of an ordering quirk: device objects can be created before `/devices/meta` is parsed, and `_metadata` is never backfilled afterwards. With `_metadata = None` every metadata check is false, so the old discriminator matched. Whether the detection works thus depends on message ordering at startup; on my v0.24 installs it is deterministically broken. (The never-backfilled metadata is a separate latent issue.)

## Fix

- Only `COOLING` disqualifies (AC units); `HEATING` no longer does.
- Require the `thermicLevel` order register, checked on the device attribute as well as the metadata, which also makes the detection independent of startup message ordering.

Real thermostats are unaffected: they don't carry `thermicLevel`, and they expose `setpoint` metadata, which remains a disqualifier.

## Testing

Live install (v0.24 + this patch, HAOS, two RF 6600 FP zones, full restart):

- both zones: `hvac_modes [off, heat]`, `preset_modes [comfort, eco, away, none]`, `supported_features 400`, `hvac_action` present
- presets track the real level both ways (`thermicLevel ECO` -> `eco`, `ANTI_FROST` -> `away`)
- write round-trip confirmed by the box: `eco` -> `thermicLevel ECO`, `away` -> `ANTI_FROST`

`ruff check` and `ruff format --check` (pinned 0.15.18) pass.

Side note: the metadata also reveals `MODERATO`/`MEDIO` levels (6-order fil pilote); exposing them as extra presets could be a follow-up.

Refs #328.
