### PR TITLE
Fix adaptive polling: add missing TydomClient.poll_device_data and dedupe _rebuild_polling_cache

### DIFF
--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -656,34 +656,6 @@ class Hub:
         self._polling_cache = new_cache
         LOGGER.debug("Polling cache rebuilt with %d entries", len(self._polling_cache))
 
-    def _rebuild_polling_cache(self) -> None:
-        """Rebuild polling cache efficiently.
-
-        This method scans all devices and their metadata to build a cache
-        mapping (device_id, attribute_name) to polling intervals based on
-        the validity metadata. The cache is rebuilt periodically to account
-        for metadata changes.
-
-        The cache structure: {(device_id, attr_name): interval_seconds}
-        - Devices with validity=INFINITE or upToDate are not cached (no polling)
-        - Devices with validity=ES_SUPERVISION are cached with 300s interval
-        - Devices with validity=SENSOR_SUPERVISION are cached with 60s interval
-        - Devices with validity=SYNCHRO_SUPERVISION are cached with 30s interval
-        """
-        new_cache: dict[tuple[str, str], int] = {}
-        for device_id, device in self.devices.items():
-            if not hasattr(device, "_metadata") or device._metadata is None:
-                continue
-            for attr_name, attr_metadata in device._metadata.items():
-                if isinstance(attr_metadata, dict):
-                    validity = attr_metadata.get("validity")
-                    interval = get_polling_interval_for_validity(validity)
-                    if interval is not None:
-                        new_cache[(device_id, attr_name)] = interval
-
-        # Update cache atomically
-        self._polling_cache = new_cache
-
     async def refresh_data(self) -> None:
         """Periodically refresh data for devices which don't do push.
 

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -3,6 +3,7 @@
 import asyncio
 import contextlib
 import json
+import re
 import time
 from dataclasses import dataclass
 from functools import partial
@@ -288,6 +289,30 @@ class MessageHandler:
 
         if msg_type is None:
             msg_type = MSG_MAPPING.get(uri_origin)
+
+            if msg_type is None and uri_origin:
+                # Response to GET /devices/{id}/endpoints/{id}/data (adaptive
+                # polling): a single flat {"id", "error", "data"} object, not
+                # the list-of-devices shape parse_devices_data expects. Rebuild
+                # the canonical shape using the ids from the URI (authoritative,
+                # and device/endpoint ids can differ).
+                endpoint_data = re.fullmatch(
+                    r"/devices/(\d+)/endpoints/(\d+)/data", uri_origin
+                )
+                if endpoint_data and isinstance(parsed, dict):
+                    parsed = [
+                        {
+                            "id": int(endpoint_data.group(1)),
+                            "endpoints": [
+                                {
+                                    "id": int(endpoint_data.group(2)),
+                                    "error": parsed.get("error", 0),
+                                    "data": parsed.get("data", []),
+                                }
+                            ],
+                        }
+                    ]
+                    msg_type = self.parse_devices_data
 
             if msg_type is None and data:
                 first = data[:40]
@@ -656,6 +681,11 @@ class MessageHandler:
         LOGGER.debug("parse_devices_data : %s", parsed)
         devices = []
         seen_unique_ids = {}  # Track unique_ids to detect collisions
+
+        if isinstance(parsed, dict):
+            # A bare device object would otherwise be iterated key by key,
+            # logging one "Unsupported message" warning per key.
+            parsed = [parsed]
 
         for i in parsed:
             if "endpoints" in i:

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -971,6 +971,20 @@ class TydomClient:
         req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
+    async def poll_device_data(self, device_id):
+        """Poll data for a single device.
+
+        Accepts either a plain device id or the composite
+        "<device_id>_<endpoint_id>" key used by the hub device registry.
+        """
+        dev_id, _, endpoint_id = str(device_id).partition("_")
+        endpoint_id = endpoint_id or dev_id
+        safe_dev = quote(str(dev_id), safe="")
+        safe_endpoint = quote(str(endpoint_id), safe="")
+        await self.get_poll_device_data(
+            f"/devices/{safe_dev}/endpoints/{safe_endpoint}/data"
+        )
+
     def add_poll_device_url_1s(self, url):
         """Add a device for polling."""
         if url not in self.poll_device_urls_1s:


### PR DESCRIPTION
## Problem

The adaptive polling introduced in #270 (`hub.py`, `refresh_data`) is broken on both sides of the request/response cycle:

**1. Request side.** The polling loop calls:

```python
await device._tydom_client.poll_device_data(device_id)
```

but `TydomClient` never defined a `poll_device_data` method (only `get_poll_device_data(url)` and `get_device_data(id)` exist). As a result, every poll cycle raises `AttributeError`, which is caught and logged as:

```
WARNING ... Error polling device 1627402733_1627402733: 'TydomClient' object has no attribute 'poll_device_data'
```

On my install this produces hundreds of warnings per day (one per device per cycle), and the supervised attributes (validity `ES_SUPERVISION` / `SENSOR_SUPERVISION` / `SYNCHRO_SUPERVISION`) are never refreshed.

**2. Response side** (discovered after deploying the first fix). The responses to `GET /devices/{id}/endpoints/{id}/data` are single flat objects:

```json
{"id": 1627402733, "error": 0, "data": [...]}
```

whereas `parse_devices_data` expects the `/devices/data` shape (a list of devices with an `endpoints` key). Iterating the flat dict yields its keys, so each poll response logged `Unsupported message received` three times (once per key) and the polled values were dropped. The polling requests were sent, but their results were never consumed.

`hub.py` also ended up with two identical definitions of `_rebuild_polling_cache` (the second silently shadows the first; they only differ by a debug log line).

## Fix

- Add `TydomClient.poll_device_data(device_id)`: accepts either a plain device id or the composite `"<device_id>_<endpoint_id>"` key used by the hub device registry, and issues `GET /devices/{id}/endpoints/{endpoint}/data` through the existing `get_poll_device_data(url)`.
- In `parse_response`, recognize the `/devices/{id}/endpoints/{id}/data` Uri-Origin and rebuild the canonical `/devices/data` shape from the URI ids (authoritative, and device/endpoint ids can differ) before routing to `parse_devices_data`.
- In `parse_devices_data`, wrap a bare dict into a list so an unknown flat message logs a single warning instead of one per key.
- Remove the duplicate `_rebuild_polling_cache` definition (kept the variant with the debug log).

## Testing

- `python3 -m py_compile` on the three files.
- `ruff check` and `ruff format --check` (ruff 0.15.18, as pinned in `requirements.txt`) pass.
- Deployed on my live install (Tydom 1.0, HA 2026.7): the recurring `Error polling device ...` and `Unsupported message received` warnings are gone, and debug logs confirm the full chain at each 5-minute cycle: poll request sent, flat response rebuilt and routed, `Device update (id=..., type=light)` applied to the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
