### PR TITLE
Fix alarm get_events and acknowledge_events (Tydom 1.0 + Tyxal+)

### DIFF
--- a/custom_components/deltadore_tydom/services.yaml
+++ b/custom_components/deltadore_tydom/services.yaml
@@ -1,18 +1,10 @@
 acknowledge_events:
   name: Acknowledge alarm events
-  description: Acknowledge all unacknowledged alarm events. Requires the alarm PIN code.
+  description: Acknowledge all unacknowledged alarm events.
   target:
     entity:
       integration: deltadore_tydom
       domain: alarm_control_panel
-  fields:
-    code:
-      name: Alarm PIN
-      description: The PIN code of the alarm system
-      required: true
-      selector:
-        text:
-          type: password
 get_events:
   name: Get alarm events
   description: Retrieve alarm events from the system. Returns a list of events based on the selected filter.

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -150,13 +150,7 @@
     "services": {
         "acknowledge_events": {
             "name": "Acknowledge defect events",
-            "description": "Acknowledge all defect alarm events.",
-            "fields": {
-                "code": {
-                    "name": "Alarm pin code",
-                    "description": "Alarm pin code"
-                }
-            }
+            "description": "Acknowledge all defect alarm events."
         },
         "get_events": {
             "name": "Get alarm events",

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -151,13 +151,7 @@
     "services": {
         "acknowledge_events": {
             "name": "Acquitter les événements de défaut",
-            "description": "Acquitter tous les événements d'alarme de défaut.",
-            "fields": {
-                "code": {
-                    "name": "Code PIN de l'alarme",
-                    "description": "Code PIN de l'alarme"
-                }
-            }
+            "description": "Acquitter tous les événements d'alarme de défaut."
         },
         "get_events": {
             "name": "Obtenir les événements d'alarme",

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -40,6 +40,13 @@ if TYPE_CHECKING:
 _MAX_REPLIES_SIZE = 5
 """Maximal number of replies to keep track of."""
 
+_HISTO_END_INDEX = 255
+"""Index value (0xFF) of the sentinel element closing an histo reply stream.
+
+Some firmwares never send an EOR flag; they mark the end of the enumeration
+with a last element carrying index 255 and invalid event data instead.
+"""
+
 # Device dict for parsing
 device_name = {}
 device_endpoint = {}
@@ -139,15 +146,46 @@ class MessageHandler:
         stripped_msg = bytes_str.strip(self.cmd_prefix)
 
         try:
+            status = None
             if stripped_msg.startswith(b"HTTP/"):
                 parsed_message = _parse_response(stripped_msg)
                 # Find Uri-Origin in header if available
                 uri_origin = parsed_message.headers.get("Uri-Origin", "")
+                status = parsed_message.status
 
             else:
                 parsed_message = parse_request(stripped_msg)
                 uri_origin = parsed_message.path
             transaction_id = parsed_message.headers.get("Transac-Id")
+
+            if (
+                status is not None
+                and transaction_id
+                and transaction_id in self._end_reply_events
+            ):
+                if status >= 400:
+                    # The box rejected the request; resolve the pending
+                    # reply right away instead of letting it time out.
+                    LOGGER.warning(
+                        "Request '%s' (%s) rejected with HTTP status %s",
+                        transaction_id,
+                        uri_origin,
+                        status,
+                    )
+                    event = self._end_reply_events.get(transaction_id)
+                    self.remove_reply(transaction_id)
+                    if event is not None:
+                        event.set()
+                    return None
+                if not parsed_message.body:
+                    # Empty acknowledgment of a pending request; the data
+                    # arrives in separate messages, so just wait for them.
+                    LOGGER.debug(
+                        "Empty acknowledgment received for request '%s' (%s).",
+                        transaction_id,
+                        uri_origin,
+                    )
+                    return None
 
             try:
                 return await self.parse_response(
@@ -872,7 +910,11 @@ class MessageHandler:
                                             reply["transaction_id"], None
                                         )
 
-                                if elem.get("EOR", False):
+                                values = elem.get("values") or {}
+                                if (
+                                    elem.get("EOR", False)
+                                    or values.get("index") == _HISTO_END_INDEX
+                                ):
                                     LOGGER.debug(
                                         "End of reply for request '%s'.", transaction_id
                                     )

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -158,25 +158,30 @@ class MessageHandler:
                 uri_origin = parsed_message.path
             transaction_id = parsed_message.headers.get("Transac-Id")
 
+            if status is not None and status >= 400:
+                # The box rejected the request; surface the error body (an
+                # HTML page naming the cause) instead of dropping it in the
+                # html no-op, and resolve any pending reply right away
+                # instead of letting it time out.
+                LOGGER.warning(
+                    "Request '%s' (%s) rejected with HTTP status %s: %s",
+                    transaction_id,
+                    uri_origin,
+                    status,
+                    (parsed_message.body or b"")[:500],
+                )
+                if transaction_id and transaction_id in self._end_reply_events:
+                    event = self._end_reply_events.get(transaction_id)
+                    self.remove_reply(transaction_id)
+                    if event is not None:
+                        event.set()
+                return None
+
             if (
                 status is not None
                 and transaction_id
                 and transaction_id in self._end_reply_events
             ):
-                if status >= 400:
-                    # The box rejected the request; resolve the pending
-                    # reply right away instead of letting it time out.
-                    LOGGER.warning(
-                        "Request '%s' (%s) rejected with HTTP status %s",
-                        transaction_id,
-                        uri_origin,
-                        status,
-                    )
-                    event = self._end_reply_events.get(transaction_id)
-                    self.remove_reply(transaction_id)
-                    if event is not None:
-                        event.set()
-                    return None
                 if not parsed_message.body:
                     # Empty acknowledgment of a pending request; the data
                     # arrives in separate messages, so just wait for them.

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1089,23 +1089,6 @@ class TydomClient:
         req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
-    async def put_data(self, path, name, value):
-        """Give order (name + value) to path."""
-        body = json.dumps({name: value})
-
-        str_request = (
-            f"PUT {path} HTTP/1.1\r\nContent-Length: "
-            + str(len(body))
-            + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
-            + body
-            + "\r\n\r\n"
-        )
-        a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
-        LOGGER.debug("Sending message to tydom (%s)", "PUT data")
-        if not file_mode:
-            await self.send_bytes(a_bytes)
-        return 0
-
     async def put_devices_data(
         self,
         device_id,
@@ -1340,16 +1323,17 @@ class TydomClient:
             LOGGER.error("put_alarm_cdata ERROR !", exc_info=True)
 
     async def put_ackevents_cdata(self, device_id, endpoint_id=None, alarm_pin=None):
-        """Acknowledge the alarm events."""
-        # PUT /devices/xxxx/endpoints/xxxx/cdata?name=ackEventCmd HTTP/1.1 {"pwd":"xxxxxx"}
-        pwd = alarm_pin or self._alarm_pin
-        if pwd is None:
-            LOGGER.warning("Tydom alarm pin is not set!")
-        await self.put_data(
-            f"/devices/{device_id}/endpoints/{endpoint_id}/cdata?name=ackEventCmd",
-            "pwd",
-            str(pwd),
-        )
+        """Acknowledge the alarm events.
+
+        The box acknowledges through the data channel: /devices/meta declares
+        ackEventCmd as a writable attribute with enum ["ACK"], and no pin is
+        required (alarm_pin is kept for signature compatibility). The cdata
+        form with a pwd body inherited from tydom2mqtt is rejected with an
+        HTTP 500 (verified on a Tyxal+ via Tydom 1.0, right pin or not, pwd
+        in the body or in the query string), while this data write is
+        accepted and clears the unacked events.
+        """
+        await self.put_devices_data(device_id, endpoint_id, "ackEventCmd", "ACK")
 
     async def get_historic_cdata(
         self,

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1366,9 +1366,10 @@ class TydomClient:
         safe_endpoint_id = quote(str(endpoint_id), safe="")
         safe_type = quote(str(type_), safe="")
         url = f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata?name=histo&type={safe_type}&indexStart={indexStart}&nbElem={nbElement}"
-        timeout = TIMEOUT_LONG_REQUEST  # Wait maximum for long operations like historical data
-        async with asyncio.timeout(timeout):
-            return await self.get_reply_to_request("GET", url)
+        # The box streams the events one message at a time (about 2 seconds
+        # apart), so the reply wait needs the long timeout; the default one
+        # (10 s) cuts the stream off after a few events.
+        return await self.get_reply_to_request("GET", url, timeout=TIMEOUT_LONG_REQUEST)
 
     async def update_firmware(self):
         """Update Tydom firmware."""


### PR DESCRIPTION
## Problem

On some installs (Tydom 1.0 + Tyxal+ CS8000 here), both alarm event services are broken:

- `deltadore_tydom.get_events` always times out after 10 s and surfaces a 500 to the caller, even though the box actually streams the events correctly:

```
WARNING ... Timeout waiting for reply to GET /devices/1/endpoints/1/cdata?name=histo&type=UNACKED_EVENTS&indexStart=0&nbElem=10 (transaction_id: ..., timeout: 10.0s)
```

- `deltadore_tydom.acknowledge_events` silently does nothing: the box rejects the `PUT .../cdata?name=ackEventCmd` request with an HTTP 500, and since the write is fire-and-forget the service still reports success.

## Root cause (verified with debug logs on a live install)

### get_events

The box answers an histo request in three phases:

1. An immediate empty-body HTTP response echoing the request URI (`Uri-Origin: /devices/X/endpoints/Y/cdata`). It hits the "Unknown message type received ...: b''" warning and is otherwise ignored (which is fine, but noisy).
2. One `/devices/cdata` message per event, roughly 2 seconds apart, accumulated by `parse_devices_cdata()` under the request's transaction id.
3. A final sentinel element with `values.index == 255` (0xFF) and invalid event data (`{"name": "inconnu", "date": "2031-15-31T31:63:00"}`) marking the end of the enumeration.

Three bugs combine against this sequence:

- `parse_devices_cdata()` only completes a reply on an `EOR` flag, which this firmware never sends. The end-of-reply sentinel (`index == 255`) is not recognized, so the reply is never marked done and the caller times out. Worse, the sentinel is appended to the events, so even a would-be successful reply would include a bogus "inconnu" event.
- `get_historic_cdata()` wraps the wait in `asyncio.timeout(TIMEOUT_LONG_REQUEST)` (30 s) but forgets to pass the timeout down to `get_reply_to_request()`, which then uses its 10 s default. At ~2 s per streamed event, anything beyond 4 events cannot complete in time even with the sentinel fix, and the outer 30 s wrapper is dead code (the inner timeout always fires first).
- When the box rejects a request outright (e.g. `type=ALL` on this firmware gets `HTTP/1.1 500` back), the error response is routed to the html no-op and the pending transaction is never resolved, so the caller waits the full timeout for an answer that already arrived.

### acknowledge_events

The `{"pwd": "..."}` JSON body (inherited from tydom2mqtt) is rejected by the box with an HTTP 500. Also tested and rejected on real hardware: `{"value": "ACK", "pwd": "..."}`, and the pin as a query parameter (`?name=ackEventCmd&pwd=...`), with the right pin or a wrong one. Meanwhile `/devices/meta` declares `ackEventCmd` as a writable **data** attribute with `enum_values: ["ACK"]`, and writing it through the standard data channel (`PUT /devices/X/endpoints/Y/data` with `[{"name": "ackEventCmd", "value": "ACK"}]`, no pin involved) is accepted: the alarm beeps and the UNACKED_EVENTS list is cleared.

## Fix

- `MessageHandler.parse_devices_cdata()`: treat an element with `values.index == 255` as end-of-reply, exactly like `EOR` (which is kept for firmwares that send it), and do not append it as an event.
- `TydomClient.get_historic_cdata()`: pass `timeout=TIMEOUT_LONG_REQUEST` to `get_reply_to_request()` and drop the redundant outer `asyncio.timeout` wrapper (the inner handler also does the pending-reply cleanup, which the outer wrapper did not).
- `MessageHandler.route_response()`: log HTTP error replies from the box with their body (they were silently dropped in the html no-op), and resolve the pending transaction immediately on an error status instead of letting it time out; log the empty-body acknowledgment of a pending request at debug level instead of the "Unknown message type" warning (the data messages follow separately).
- `TydomClient.put_ackevents_cdata()`: acknowledge through the data channel (`put_devices_data` with `ackEventCmd = ACK`). No pin is involved, so the `code` field is removed from the service UI (the entity service schema still tolerates it so existing automations keep working), and `put_data()`, whose only caller was the broken cdata form, is removed.

## Validation

Deployed on a live Tydom 1.0 + Tyxal+ CS8000 install (HA 2026.7, local mode):

- Before: `get_events` with `UNACKED_EVENTS` timed out after 10 s and returned a 500, while the 3 unacked events were visible in the debug logs, followed by the index-255 sentinel; `acknowledge_events` reported success but the events stayed unacknowledged (HTTP 500 visible in the traces).
- After: `get_events` with `UNACKED_EVENTS` returns the 3 formatted events (sentinel excluded) as soon as the sentinel arrives (about 8 s for 3 events); `type=ALL` (rejected by this firmware with an HTTP 500) returns an empty list immediately instead of timing out, with a warning naming the status and the error body; `acknowledge_events` clears the list (verified empty on re-read, and the alarm beeps on acknowledgment as it does with the official app).
- `python3 -m py_compile`, `ruff check` and `ruff format --check` (ruff 0.15.18, as pinned in requirements.txt) all pass.
