### PR TITLE
Add alarm PIN to options flow and fix blank options menu (#306)

### DIFF
--- a/custom_components/deltadore_tydom/config_flow.py
+++ b/custom_components/deltadore_tydom/config_flow.py
@@ -1121,6 +1121,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         default_zone_away = ""
         default_zone_night = ""
         default_refresh_interval = "30"
+        default_pin = ""
         if CONF_ZONES_HOME in self.config_entry.data:
             default_zone_home = self.config_entry.data[CONF_ZONES_HOME]
 
@@ -1133,11 +1134,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if CONF_REFRESH_INTERVAL in self.config_entry.data:
             default_refresh_interval = self.config_entry.data[CONF_REFRESH_INTERVAL]
 
+        if CONF_PIN in self.config_entry.data:
+            default_pin = self.config_entry.data[CONF_PIN]
+
         if user_input is not None:
             default_zone_home = user_input.get(CONF_ZONES_HOME, "")
             default_zone_away = user_input.get(CONF_ZONES_AWAY, "")
             default_zone_night = user_input.get(CONF_ZONES_NIGHT, "")
             default_refresh_interval = user_input.get(CONF_REFRESH_INTERVAL, "30")
+            default_pin = user_input.get(CONF_PIN, "")
 
             try:
                 # Validate zones
@@ -1177,6 +1182,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 updated_data[CONF_ZONES_AWAY] = default_zone_away
                 updated_data[CONF_ZONES_NIGHT] = default_zone_night
                 updated_data[CONF_REFRESH_INTERVAL] = default_refresh_interval
+                updated_data[CONF_PIN] = default_pin
 
                 # Update entry
                 self.hass.config_entries.async_update_entry(
@@ -1250,6 +1256,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): selector.TextSelector(
                         selector.TextSelectorConfig(
                             type=selector.TextSelectorType.TEXT,
+                            autocomplete="off",
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_PIN,
+                        description={"suggested_value": default_pin},
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(
+                            type=selector.TextSelectorType.PASSWORD,
                             autocomplete="off",
                         )
                     ),

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -111,12 +111,17 @@
         "step": {
             "init": {
                 "title": "Delta Dore Tydom Options",
-                "description": "Choose an option"
+                "description": "Choose an option",
+                "menu_options": {
+                    "configure": "Configure (zones, refresh interval, alarm PIN)",
+                    "actions": "Actions (reload devices)"
+                }
             },
             "configure": {
                 "title": "Delta Dore Tydom Configuration",
                 "description": "Update your Tydom integration settings.",
                 "data": {
+                    "pin": "Alarm PIN (optional, required for alarm control)",
                     "refresh_interval": "Refresh interval in minutes (default: 30)",
                     "zones_away": "Active zones in away alarm mode (comma-separated, e.g., 1,2,4)",
                     "zones_home": "Active zones in home alarm mode (comma-separated, e.g., 1,2,4)",

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -112,12 +112,17 @@
         "step": {
             "init": {
                 "title": "Options Delta Dore Tydom",
-                "description": "Choisissez une option"
+                "description": "Choisissez une option",
+                "menu_options": {
+                    "configure": "Configurer (zones, intervalle de rafraîchissement, code PIN alarme)",
+                    "actions": "Actions (recharger les appareils)"
+                }
             },
             "configure": {
                 "title": "Configuration Delta Dore Tydom",
                 "description": "Mettez à jour les paramètres de votre intégration Tydom.",
                 "data": {
+                    "pin": "Code PIN de l'alarme (optionnel, requis pour le contrôle de l'alarme)",
                     "refresh_interval": "Intervalle de rafraîchissement en minutes (par défaut : 30)",
                     "zones_away": "Zones actives en mode alarme absent (séparées par des virgules, ex. : 1,2,4)",
                     "zones_home": "Zones actives en mode alarme présent (séparées par des virgules, ex. : 1,2,4)",


### PR DESCRIPTION
## Problem

Two related UX issues in the options flow:

- The alarm PIN can only be entered at initial setup. Nothing in the UI allows setting or changing it afterwards, so on an entry configured without it, alarm arming/disarming from HA has no stored PIN to fall back on and there is no way to add one short of removing and re-adding the integration.
- The options menu renders as two blank rows (#306): the `menu_options` translations for the `init` step are missing, so both entries ("configure" and "actions") show with no label.

## Fix

- Add the alarm PIN to the options `configure` form (password selector, prefilled from the config entry) and persist it with the other fields. The existing update listener reloads the entry, so the new PIN is picked up without a restart.
- Add the missing `options.step.init.menu_options` labels to `en.json` and `fr.json`, which fixes #306, and label the `pin` field of the configure form.

## Validation

- Deployed on a live install (HA 2026.7): the options menu shows both labels, the configure form shows the PIN field (prefilled on re-open), and saving reloads the integration with the updated entry data.
- `python3 -m py_compile`, `ruff check`, `ruff format --check` (ruff 0.15.18, as pinned in requirements.txt) pass; both translation files are valid JSON.
