### PR TITLE
Fix put_devices_data sending every command twice

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1168,9 +1168,6 @@ class TydomClient:
                 str(e),
             )
             raise
-        LOGGER.debug("Sending message to tydom (%s)", "PUT device data")
-        if not file_mode:
-            await self.send_bytes(a_bytes)
 
         return 0
 


### PR DESCRIPTION
## Problem

Every device command (lights, covers, climate, plugs...) is sent to the box twice.

## Root cause

In `TydomClient.put_devices_data()`, the retry-based send introduced in #270 was placed above the pre-existing unconditional send instead of replacing it:

```python
        # Send with retry mechanism
        try:
            await self.send_bytes(a_bytes, max_retries=max_retries)
        except TydomClientApiClientCommunicationError as e:
            ...
            raise
        LOGGER.debug("Sending message to tydom (%s)", "PUT device data")
        if not file_mode:
            await self.send_bytes(a_bytes)   # <- duplicate send
```

So after the first (retried) send succeeds, the same bytes are sent again, this time with `send_bytes`'s default of up to 3 more retries. Idempotent values ("set level to 50") hide the bug, but it doubles the command traffic on the websocket, and any non-idempotent command (e.g. a `levelCmd` `TOGGLE`) would fire twice.

## Fix

Drop the trailing duplicate block. `send_bytes()` already handles `file_mode` (early return) and the retry logic, so the retried call at the top is all that is needed. `put_devices_data_validated()` delegates to this method and is covered by the same fix.

## Validation

- Deployed on a live Tydom 1.0 install (HA 2026.7): `climate.set_preset_mode` on a fil-pilote zone produced exactly one `Sending command:` debug line and one `HTTP/1.1 200 OK` reply, confirming a single `PUT /devices/.../data` instead of two.
- `python3 -m py_compile`, `ruff check` and `ruff format --check` (ruff 0.15.18, as pinned in requirements.txt) all pass.
