### PR TITLE
Gestion fan speed Naviclim X3D pour Climate HA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ config/*
 !config/configuration.yaml
 # Development documentation
 PR_DESCRIPTION.md
+/.vs

--- a/custom_components/deltadore_tydom/const.py
+++ b/custom_components/deltadore_tydom/const.py
@@ -145,6 +145,101 @@ def validate_value_with_metadata(
     return True, None
 
 
+# Fan speed helpers for Naviclim (X3D) reversible air-conditioning zones.
+#
+# These HVAC zones expose two dedicated fan-speed registers (verified on a live
+# Naviclim Atlantic, see tools/traces-naviclim-atlantic.txt):
+#   speed:        numeric, permission rw, min 1, max 3, step 1  -> manual speeds
+#   speedString:  string,  permission rw, enum_values ["AUTO"]  -> automatic
+# When automatic is active the device reports speedString="AUTO" and speed=null;
+# in manual mode it reports the numeric speed (1..3). We map this onto the Home
+# Assistant fan_mode feature as ["auto", "1", "2", "3"].
+#
+# Kept here (HA-free module) so the mapping can be unit-tested in isolation and
+# reused by the climate entity.
+NAVICLIM_FAN_AUTO_ENUM = "AUTO"
+
+
+def get_naviclim_fan_modes(metadata: dict | None, auto_value: str = "auto") -> list[str]:
+    """Build the list of Home Assistant fan modes from Naviclim metadata.
+
+    Args:
+        metadata: The device ``_metadata`` dict (keyed by register name).
+        auto_value: The HA fan-mode string used for automatic speed
+            (defaults to "auto", matching ``homeassistant`` FAN_AUTO).
+
+    Returns:
+        Fan modes ordered auto first, then the numeric speeds, e.g.
+        ``["auto", "1", "2", "3"]``. Empty list when the device exposes no
+        usable fan-speed register (i.e. it is not a Naviclim-style AC).
+
+    """
+    modes: list[str] = []
+    if not isinstance(metadata, dict):
+        return modes
+
+    speed_string_meta = metadata.get("speedString")
+    if (
+        isinstance(speed_string_meta, dict)
+        and NAVICLIM_FAN_AUTO_ENUM in speed_string_meta.get("enum_values", [])
+    ):
+        modes.append(auto_value)
+
+    speed_meta = metadata.get("speed")
+    if isinstance(speed_meta, dict) and speed_meta.get("type") == "numeric":
+        try:
+            speed_min = int(float(speed_meta.get("min", 1)))
+            speed_max = int(float(speed_meta.get("max", 3)))
+        except (ValueError, TypeError):
+            speed_min, speed_max = 1, 3
+        if speed_max >= speed_min:
+            modes.extend(str(i) for i in range(speed_min, speed_max + 1))
+
+    return modes
+
+
+def get_naviclim_fan_mode(
+    speed: float | int | None,
+    speed_string: str | None,
+    fan_modes: list[str],
+    auto_value: str = "auto",
+) -> str | None:
+    """Resolve the current HA fan mode from Naviclim register values.
+
+    ``speed_string == "AUTO"`` means automatic (``speed`` is then null);
+    otherwise the numeric ``speed`` (1..3) is the active manual speed.
+
+    Args:
+        speed: Current value of the numeric ``speed`` register (or None).
+        speed_string: Current value of the ``speedString`` register (or None).
+        fan_modes: The supported fan modes (from :func:`get_naviclim_fan_modes`).
+        auto_value: The HA fan-mode string used for automatic speed.
+
+    Returns:
+        The active fan mode string, or None when fan control is unsupported.
+
+    """
+    if not fan_modes:
+        return None
+
+    if speed_string == NAVICLIM_FAN_AUTO_ENUM and auto_value in fan_modes:
+        return auto_value
+
+    if speed is not None:
+        try:
+            speed_str = str(int(float(speed)))
+        except (ValueError, TypeError):
+            speed_str = None
+        if speed_str is not None and speed_str in fan_modes:
+            return speed_str
+
+    # speed is null / unrecognised: prefer auto when the device supports it,
+    # otherwise report the first available speed so HA always has a value.
+    if auto_value in fan_modes:
+        return auto_value
+    return fan_modes[0]
+
+
 # Mapping des valeurs validity vers les intervalles de polling (en secondes)
 VALIDITY_POLLING_INTERVALS = {
     "INFINITE": None,  # Pas de polling nécessaire

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -15,6 +15,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
+    FAN_AUTO,
     HVACAction,
     HVACMode,
     PRESET_AWAY,
@@ -105,7 +106,13 @@ from .tydom.tydom_devices import (
     TydomMoment,
 )
 
-from .const import DOMAIN, LOGGER, TYDOM_UNIT_TO_HA_UNIT
+from .const import (
+    DOMAIN,
+    LOGGER,
+    TYDOM_UNIT_TO_HA_UNIT,
+    get_naviclim_fan_mode,
+    get_naviclim_fan_modes,
+)
 from .tydom.MessageHandler import device_name, groups_data
 
 
@@ -2325,6 +2332,18 @@ class HaClimate(ClimateEntity, HAEntity):
             # show a temperature control that would write a phantom setpoint.
             self._attr_supported_features &= ~ClimateEntityFeature.TARGET_TEMPERATURE
 
+        # Fan speed (Naviclim X3D reversible AC). Naviclim zones expose a numeric
+        # `speed` (1..3) for manual speeds and a `speedString` ["AUTO"] register
+        # for automatic mode; we surface these as HA fan modes ("auto", "1", "2",
+        # "3"). Non-AC thermostats and fil-pilote zones have neither register, so
+        # get_naviclim_fan_modes returns [] and the FAN_MODE feature stays off.
+        self._attr_fan_modes = get_naviclim_fan_modes(
+            self._device._metadata, FAN_AUTO
+        )
+        self._supports_fan = bool(self._attr_fan_modes)
+        if self._supports_fan:
+            self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
+
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
         await super().async_added_to_hass()
@@ -2557,6 +2576,32 @@ class HaClimate(ClimateEntity, HAEntity):
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
         await self._device.set_temperature(str(kwargs.get(ATTR_TEMPERATURE)))
+
+    @property
+    def fan_mode(self) -> str | None:
+        """Return the current fan mode (Naviclim: Auto/1/2/3)."""
+        if not getattr(self, "_supports_fan", False):
+            return None
+        return get_naviclim_fan_mode(
+            getattr(self._device, "speed", None),
+            getattr(self._device, "speedString", None),
+            self._attr_fan_modes,
+            FAN_AUTO,
+        )
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set new target fan mode (Naviclim: Auto/1/2/3)."""
+        if not getattr(self, "_supports_fan", False):
+            return
+        if fan_mode == FAN_AUTO:
+            await self._device.set_fan_auto()
+            return
+        try:
+            speed = int(fan_mode)
+        except (ValueError, TypeError):
+            LOGGER.error("Invalid fan mode requested: %s", fan_mode)
+            return
+        await self._device.set_fan_speed(speed)
 
 
 class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -348,6 +348,35 @@ class TydomBoiler(TydomDevice):
             self._id, self._endpoint, "thermicLevel", level
         )
 
+    async def set_fan_speed(self, speed) -> None:
+        """Set a manual fan speed on a Naviclim (X3D) HVAC zone.
+
+        Writes the numeric ``speed`` register (1..3 on a Naviclim). The value is
+        validated against the device metadata first so an out-of-range speed is
+        rejected before it reaches the Tydom box.
+        """
+        is_valid, error_msg = validate_value_with_metadata(self, "speed", speed)
+        if not is_valid:
+            from homeassistant.exceptions import HomeAssistantError
+
+            raise HomeAssistantError(
+                error_msg or f"Vitesse de ventilation invalide: {speed}"
+            )
+
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "speed", speed
+        )
+
+    async def set_fan_auto(self) -> None:
+        """Set automatic fan speed on a Naviclim (X3D) HVAC zone.
+
+        Writes ``speedString`` = ``"AUTO"``; the box then drives the fan speed
+        automatically and reports the numeric ``speed`` register as null.
+        """
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "speedString", "AUTO"
+        )
+
 
 class TydomWindow(TydomDevice):
     """represents a window."""


### PR DESCRIPTION
Ajout des helpers pour mapper les registres Naviclim (`speed`, `speedString`) vers les modes de ventilation Home Assistant. Intégration dans l’entité Climate pour exposer et piloter les modes de ventilation (auto, 1, 2, 3). Ajout des méthodes asynchrones pour régler la vitesse ou activer le mode automatique côté device. Mise à jour du .gitignore pour exclure .vs.