### PR TITLE
Fix multi-zone alarm handling and Night mode detection

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3234,14 +3234,21 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
                 alarm_state = getattr(self._device, "alarmState", None)
                 if alarm_state == "OFF":
                     return AlarmControlPanelState.ARMED_AWAY
-                else:
-                    return AlarmControlPanelState.TRIGGERED
+                return AlarmControlPanelState.TRIGGERED
             if alarm_mode in ("ZONE", "PART"):
                 alarm_state = getattr(self._device, "alarmState", None)
                 if alarm_state == "OFF":
+                    configured_mode = self._device.get_alarm_mode_from_zones()
+
+                    if configured_mode == "night":
+                        return AlarmControlPanelState.ARMED_NIGHT
+
+                    if configured_mode == "away":
+                        return AlarmControlPanelState.ARMED_AWAY
+
                     return AlarmControlPanelState.ARMED_HOME
-                else:
-                    return AlarmControlPanelState.TRIGGERED
+
+                return AlarmControlPanelState.TRIGGERED
         return AlarmControlPanelState.TRIGGERED
 
     @property

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -178,6 +178,21 @@ class TydomClient:
         self._zone_away = zone_away
         self._zone_night = zone_night
 
+    @property
+    def zone_home(self) -> str | None:
+        """Return the configured home alarm zones."""
+        return self._zone_home
+
+    @property
+    def zone_away(self) -> str | None:
+        """Return the configured away alarm zones."""
+        return self._zone_away
+
+    @property
+    def zone_night(self) -> str | None:
+        """Return the configured night alarm zones."""
+        return self._zone_night
+
     @staticmethod
     async def async_get_credentials(
         session: ClientSession, email: str, password: str, macaddress: str
@@ -1358,8 +1373,13 @@ class TydomClient:
                     body = json.dumps({"value": str(value), "part": str(zone_id)})
                 else:
                     cmd = "zoneCmd"
+                    zones = [
+                        int(zone.strip())
+                        for zone in str(zone_id).split(",")
+                        if zone.strip()
+                    ]
                     body = json.dumps(
-                        {"value": str(value), "pwd": str(pin), "zones": [int(zone_id)]}
+                        {"value": str(value), "pwd": str(pin), "zones": zones}
                     )
 
             safe_device_id = quote(str(device_id), safe="")

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -178,21 +178,6 @@ class TydomClient:
         self._zone_away = zone_away
         self._zone_night = zone_night
 
-    @property
-    def zone_home(self) -> str | None:
-        """Return the configured home alarm zones."""
-        return self._zone_home
-
-    @property
-    def zone_away(self) -> str | None:
-        """Return the configured away alarm zones."""
-        return self._zone_away
-
-    @property
-    def zone_night(self) -> str | None:
-        """Return the configured night alarm zones."""
-        return self._zone_night
-
     @staticmethod
     async def async_get_credentials(
         session: ClientSession, email: str, password: str, macaddress: str

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -514,6 +514,38 @@ class TydomAlarm(TydomDevice):
             return True
         return False
 
+    def get_alarm_mode_from_zones(self) -> str | None:
+        """Identify the configured alarm mode from the active zones."""
+
+        def parse_zones(value) -> set[int]:
+            if not value:
+                return set()
+
+            return {
+                int(zone.strip())
+                for zone in str(value).split(",")
+                if zone.strip()
+            }
+
+        active_zones = {
+            zone
+            for zone in range(1, 9)
+            if getattr(self, f"part{zone}State", "OFF") == "ON"
+            or getattr(self, f"zone{zone}State", "OFF") == "ON"
+        }
+
+        configured_modes = (
+            ("night", parse_zones(self._tydom_client.zone_night)),
+            ("home", parse_zones(self._tydom_client.zone_home)),
+            ("away", parse_zones(self._tydom_client.zone_away)),
+        )
+
+        for mode, configured_zones in configured_modes:
+            if configured_zones and configured_zones == active_zones:
+                return mode
+
+        return None
+
     async def alarm_disarm(self, code) -> None:
         """Disarm alarm."""
         await self._tydom_client.put_alarm_cdata(

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -535,9 +535,9 @@ class TydomAlarm(TydomDevice):
         }
 
         configured_modes = (
-            ("night", parse_zones(self._tydom_client.zone_night)),
-            ("home", parse_zones(self._tydom_client.zone_home)),
-            ("away", parse_zones(self._tydom_client.zone_away)),
+            ("night", parse_zones(self._tydom_client._zone_night)),
+            ("home", parse_zones(self._tydom_client._zone_home)),
+            ("away", parse_zones(self._tydom_client._zone_away)),
         )
 
         for mode, configured_zones in configured_modes:


### PR DESCRIPTION
## Summary

This PR fixes multi-zone partial arming and Night mode state reporting for non-legacy Tyxal alarms.

## Problem

The integration currently accepts comma-separated zone configurations (for example '1,3,4'), but the non-legacy 'zoneCmd' implementation serialises only a single integer.

Additionally, all partial arming modes ('ZONE') are always reported as 'ARMED_HOME', even when the active zones correspond to the configured Night profile. (#250 )

## Changes

- Correctly serialise comma-separated zone configurations into integer lists.
- Send all configured zones in the 'zoneCmd' payload.
- Add read-only accessors for configured Home/Away/Night zone sets.
- Determine the active partial alarm mode by comparing the active 'zoneXState' values with the configured zone sets.
- Report 'ARMED_NIGHT' when the configured Night zones are active.
- Preserve 'ARMED_HOME' as the fallback for unknown partial configurations.

## Testing

Tested successfully on my prod Tyxal installation at home.
The integration was restarted after deploying the changes and all tests were performed through the standard Home Assistant alarm controls.

My Configuration:

- Home: zone '4'
- Night: zones '1,3,4'
- Away: zones '1,2,3,4'

Verified:

- ✅ Away arms all configured zones.
- ✅ Home arms only the configured Home zone and reports **Armed Home**.
- ✅ Night arms the configured Night zones and now reports **Armed Night** instead of **Armed Home**.
- ✅ Disarming continues to work as before.

Fixes #250 .