### PR TITLE
Fix closed shutter icon

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -1825,7 +1825,7 @@ class HACover(CoverEntity, HAEntity):
         if position is None:
             return "mdi:window-shutter"
         if position == 0:
-            return "mdi:window-shutter-closed"
+            return "mdi:window-shutter"
         elif position == 100:
             return "mdi:window-shutter-open"
         else:


### PR DESCRIPTION
## Summary

- use the valid `mdi:window-shutter` icon for closed shutters
- retain `mdi:window-shutter-open` for fully open shutters

Fixes #345

## Validation

- Ruff check
- Ruff format check
- Python compilation
- Git diff check