### PR TITLE
Fix Tywell Control shutter up down stop commands

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -766,6 +766,43 @@ class TydomScene(TydomDevice):
         """Get epAct as a property to maintain compatibility."""
         return getattr(self, "_ep_act", None)
 
+    async def activate(self) -> None:
+        """Activate the scene.
+
+        Raises:
+            Exception: If activation fails, with detailed error information.
+
+        """
+        scene_id = getattr(self, "scene_id", None) or self._id
+        scene_name = getattr(self, "device_name", "Unknown")
+
+        LOGGER.info(
+            "Activating scene: id=%s, name=%s, device_id=%s",
+            scene_id,
+            scene_name,
+            self.device_id,
+        )
+
+        try:
+            # Scenarios are activated via PUT /scenarios/{id}
+            await self._tydom_client.activate_scenario(scene_id)
+            LOGGER.debug(
+                "Scene activation request sent successfully: id=%s, name=%s",
+                scene_id,
+                scene_name,
+            )
+        except Exception as e:
+            LOGGER.error(
+                "Failed to activate scene: id=%s, name=%s, device_id=%s, error=%s",
+                scene_id,
+                scene_name,
+                self.device_id,
+                e,
+                exc_info=True,
+            )
+            # Re-raise to allow Home Assistant to handle the error
+            raise
+
 
 class TydomGroup(TydomDevice):
     """Represents a Tydom group."""
@@ -826,44 +863,6 @@ class TydomGroup(TydomDevice):
                 exc_info=True,
             )
             raise
-
-    async def activate(self) -> None:
-        """Activate the scene.
-
-        Raises:
-            Exception: If activation fails, with detailed error information.
-
-        """
-        scene_id = getattr(self, "scene_id", None) or self._id
-        scene_name = getattr(self, "device_name", "Unknown")
-
-        LOGGER.info(
-            "Activating scene: id=%s, name=%s, device_id=%s",
-            scene_id,
-            scene_name,
-            self.device_id,
-        )
-
-        try:
-            # Scenarios are activated via PUT /scenarios/{id}
-            await self._tydom_client.activate_scenario(scene_id)
-            LOGGER.debug(
-                "Scene activation request sent successfully: id=%s, name=%s",
-                scene_id,
-                scene_name,
-            )
-        except Exception as e:
-            LOGGER.error(
-                "Failed to activate scene: id=%s, name=%s, device_id=%s, error=%s",
-                scene_id,
-                scene_name,
-                self.device_id,
-                e,
-                exc_info=True,
-            )
-            # Re-raise to allow Home Assistant to handle the error
-            raise
-
 
 class TydomMoment(TydomDevice):
     """Represents a Tydom moment/program."""

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -864,6 +864,7 @@ class TydomGroup(TydomDevice):
             )
             raise
 
+
 class TydomMoment(TydomDevice):
     """Represents a Tydom moment/program."""
 

--- a/tests/test_tydom_scene.py
+++ b/tests/test_tydom_scene.py
@@ -1,0 +1,92 @@
+"""Tests for TYDOM scene activation."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load the protocol code in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=MagicMock(),
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+devices_path = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "deltadore_tydom"
+    / "tydom"
+    / "tydom_devices.py"
+)
+devices_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.tydom.tydom_devices", devices_path
+)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(
+    devices_spec.name, sys.modules.get(devices_spec.name, _MISSING)
+)
+sys.modules[devices_spec.name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+TydomScene = devices_module.TydomScene
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class TydomSceneTests(IsolatedAsyncioTestCase):
+    """Exercise scene activation used by Tywell shutter controls."""
+
+    async def test_scene_activation_uses_scenario_endpoint(self) -> None:
+        """A scene delegates activation using its scenario identifier."""
+        client = MagicMock()
+        client.activate_scenario = AsyncMock()
+        scene = TydomScene(
+            client,
+            "scene_42",
+            "42",
+            "TWC_STOP",
+            "scene",
+            None,
+            None,
+            {"scene_id": 42},
+        )
+
+        await scene.activate()
+
+        client.activate_scenario.assert_awaited_once_with(42)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

- fixes a scene activation issue observed on a Tywell Control device
- restores `activate()` to `TydomScene`, where Home Assistant expects it
- fixes all three Tywell shutter scenes: `TWC_UP`, `TWC_DOWN`, and `TWC_STOP`
- removes the accidentally misplaced scene method from `TydomGroup`
- adds a regression test covering Tywell shutter scene activation
-issue screenshot :
<img width="1830" height="1278" alt="image" src="https://github.com/user-attachments/assets/09c80d8c-6005-4098-9cd0-74d9e6c35fe8" />


## Cause

When group support was added, `TydomGroup` was inserted between the `TydomScene` definition and its existing `activate()` method. Python therefore attached the method to `TydomGroup`, leaving scene entities without `activate()` and causing `scene.turn_on` etc. to fail.

## Verification

- tested successfully on my own Home Assistant instance using my Tywell Control device, after replacing tydom_devices.py manually.
- `py -m unittest discover -s tests`
- `py -m ruff check custom_components/deltadore_tydom/tydom/tydom_devices.py tests/test_tydom_scene.py`