### PR TITLE
Fix reconnect loop and serialise Tydom WebSocket recovery

### DIFF
--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -176,11 +176,10 @@ class Hub:
         """Connect to Tydom."""
         if self._shutting_down:
             raise asyncio.CancelledError()
-        connection = await self._tydom_client.async_connect()
+        connection = await self._tydom_client.async_connect_and_initialise()
         if self._shutting_down:
             await self._tydom_client.async_disconnect()
             raise asyncio.CancelledError()
-        await self._tydom_client.listen_tydom(connection)
         return connection
 
     async def async_shutdown(self) -> None:
@@ -216,7 +215,6 @@ class Hub:
                 LOGGER.warning(
                     "Timed out closing Tydom websocket after credential test"
                 )
-        self._tydom_client._connection = None
 
     def ready(self) -> bool:
         """Check if we're ready to work."""

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -123,8 +123,8 @@ class TydomClient:
         host: str = MEDIATION_URL,
         event_callback=None,
     ) -> None:
-        """Initialize client."""
-        LOGGER.debug("Initializing TydomClient Class")
+        """Initialise client."""
+        LOGGER.debug("Initialising TydomClient Class")
 
         self._hass = hass
         self.id = id
@@ -136,7 +136,11 @@ class TydomClient:
         self._zone_night = zone_night
         self._alarm_pin = alarm_pin
         self._remote_mode = self._host == MEDIATION_URL
-        self._connection = None
+        self._connection: ClientWebSocketResponse | None = None
+        self._connection_ready = False
+        self._connection_lock = asyncio.Lock()
+        self._initialising_task: asyncio.Task | None = None
+        self._shutdown_event = asyncio.Event()
         self.event_callback = event_callback
         # Some devices (like Tywatt) need polling
         self.poll_device_urls_1s = []
@@ -387,22 +391,92 @@ class TydomClient:
     def begin_shutdown(self) -> None:
         """Signal that the client must stop reconnecting and using the socket."""
         self._shutting_down = True
+        self._shutdown_event.set()
+
+    async def _wait_or_shutdown(self, delay: float) -> bool:
+        """Wait for a delay and return whether shutdown interrupted the wait."""
+        if self._shutting_down:
+            return True
+        try:
+            await asyncio.wait_for(self._shutdown_event.wait(), timeout=delay)
+        except TimeoutError:
+            return False
+        return True
+
+    async def _safe_close_connection(
+        self, connection: ClientWebSocketResponse | None
+    ) -> None:
+        """Close a websocket without allowing cleanup errors to escape."""
+        if connection is None or connection.closed:
+            return
+        try:
+            await asyncio.wait_for(connection.close(), timeout=3.0)
+        except TimeoutError:
+            LOGGER.warning("Timed out closing Tydom websocket")
+        except Exception:
+            LOGGER.exception("Error closing Tydom websocket")
+
+    def _connection_is_usable(self, connection: ClientWebSocketResponse | None) -> bool:
+        """Return whether a websocket is the active, initialised connection."""
+        return (
+            connection is not None
+            and connection is self._connection
+            and not connection.closed
+            and self._connection_ready
+        )
+
+    async def _connect_and_initialise_locked(self) -> ClientWebSocketResponse:
+        """Create and initialise the sole active websocket while holding the lock."""
+        previous = self._connection
+        self._connection = None
+        self._connection_ready = False
+        await self._safe_close_connection(previous)
+
+        candidate: ClientWebSocketResponse | None = None
+        initialising_task = asyncio.current_task()
+        try:
+            candidate = await self.async_connect()
+            self._connection = candidate
+            self._initialising_task = initialising_task
+            await self._initialise_connection(candidate)
+        except BaseException:
+            if self._connection is candidate:
+                self._connection = None
+            self._connection_ready = False
+            await self._safe_close_connection(candidate)
+            raise
+        finally:
+            if self._initialising_task is initialising_task:
+                self._initialising_task = None
+
+        if self._shutting_down:
+            if self._connection is candidate:
+                self._connection = None
+            await self._safe_close_connection(candidate)
+            raise asyncio.CancelledError()
+
+        self._connection_ready = True
+        self.online = True
+        return candidate
+
+    async def async_connect_and_initialise(self) -> ClientWebSocketResponse:
+        """Establish the initial managed websocket connection."""
+        async with self._connection_lock:
+            if self._connection_is_usable(self._connection):
+                return self._connection
+            return await self._connect_and_initialise_locked()
 
     async def async_disconnect(self) -> None:
         """Close the active websocket connection, if any."""
         self.begin_shutdown()
-        connection = self._connection
-        self._connection = None
-        if connection is not None and not connection.closed:
-            try:
-                await asyncio.wait_for(connection.close(), timeout=3.0)
-            except TimeoutError:
-                LOGGER.warning("Timed out closing Tydom websocket")
-            except Exception:
-                LOGGER.exception("Error closing Tydom websocket")
+        async with self._connection_lock:
+            connection = self._connection
+            self._connection = None
+            self._connection_ready = False
+            await self._safe_close_connection(connection)
 
-    async def listen_tydom(self, connection: ClientWebSocketResponse):
-        """Listen for Tydom messages."""
+    async def _initialise_connection(self, connection: ClientWebSocketResponse) -> None:
+        """Send initial requests on the active candidate websocket."""
         if self._shutting_down:
             return
         STRUCTURED_LOGGER.connection_event(
@@ -411,7 +485,10 @@ class TydomClient:
             host=self._host,
             mode="remote" if self._remote_mode else "local",
         )
-        self._connection = connection
+        if connection is not self._connection:
+            raise TydomClientApiClientCommunicationError(
+                "Cannot initialise a websocket that is not the active candidate"
+            )
         await self.ping()
         if self._shutting_down:
             return
@@ -443,7 +520,7 @@ class TydomClient:
 
         await self.get_scenarii()
 
-    async def _reconnect_with_backoff(self) -> None:
+    async def _reconnect_with_backoff(self) -> bool:
         """Reconnect with exponential backoff strategy.
 
         This method implements an exponential backoff reconnection strategy
@@ -464,57 +541,68 @@ class TydomClient:
 
         """
         if self._shutting_down:
-            return
-        while self._reconnect_attempts < self._max_reconnect_attempts:
-            if self._shutting_down:
-                return
-            delay = min(
-                self._reconnect_delay
-                * (self._reconnect_backoff_factor**self._reconnect_attempts),
-                self._max_reconnect_delay,
-            )
-            STRUCTURED_LOGGER.connection_event(
-                "info",
-                "reconnect_attempt",
-                attempt=self._reconnect_attempts + 1,
-                max_attempts=self._max_reconnect_attempts,
-                delay_seconds=delay,
-            )
-            await asyncio.sleep(delay)
+            return False
 
-            try:
-                self._connection = await self.async_connect()
-                await self.listen_tydom(self._connection)
+        async with self._connection_lock:
+            # Another reader or writer may have restored the connection while this
+            # coroutine was waiting for ownership of the reconnect operation.
+            if self._connection_is_usable(self._connection):
+                return True
+
+            failed_connection = self._connection
+            self._connection = None
+            self._connection_ready = False
+            await self._safe_close_connection(failed_connection)
+
+            for attempt in range(1, self._max_reconnect_attempts + 1):
+                self._reconnect_attempts = attempt
+                delay = min(
+                    self._reconnect_delay
+                    * (self._reconnect_backoff_factor ** (attempt - 1)),
+                    self._max_reconnect_delay,
+                )
+                STRUCTURED_LOGGER.connection_event(
+                    "info",
+                    "reconnect_attempt",
+                    attempt=attempt,
+                    max_attempts=self._max_reconnect_attempts,
+                    delay_seconds=delay,
+                )
+                if await self._wait_or_shutdown(delay):
+                    return False
+
+                try:
+                    await self._connect_and_initialise_locked()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    STRUCTURED_LOGGER.connection_event(
+                        "warning",
+                        "reconnect_failed",
+                        attempt=attempt,
+                        max_attempts=self._max_reconnect_attempts,
+                        error=str(e),
+                    )
+                    continue
+
                 self._reconnect_attempts = 0
-                self.online = True
                 STRUCTURED_LOGGER.connection_event(
                     "info",
                     "reconnect_success",
-                    attempt=self._reconnect_attempts + 1,
-                    total_attempts=self._reconnect_attempts + 1,
+                    attempt=attempt,
+                    total_attempts=attempt,
                 )
-                return
-            except Exception as e:
-                self._reconnect_attempts += 1
-                STRUCTURED_LOGGER.connection_event(
-                    "warning",
-                    "reconnect_failed",
-                    attempt=self._reconnect_attempts,
-                    max_attempts=self._max_reconnect_attempts,
-                    error=str(e),
-                )
+                return True
 
-        LOGGER.error(
-            "Impossible de se reconnecter après %d tentatives; "
-            "nouvelle tentative dans 60 secondes",
-            self._max_reconnect_attempts,
-        )
-        # Notifier Home Assistant de la perte de connexion
-        self.online = False
-        self._reconnect_attempts = 0
-
-        if not self._shutting_down:
-            await asyncio.sleep(60)
+            LOGGER.error(
+                "Impossible de se reconnecter après %d tentatives; "
+                "nouvelle tentative dans 60 secondes",
+                self._max_reconnect_attempts,
+            )
+            self.online = False
+            self._reconnect_attempts = 0
+            await self._wait_or_shutdown(60)
+            return False
 
     async def consume_messages(self) -> list["TydomDevice"] | None:
         """Read and parse incoming messages."""
@@ -538,27 +626,25 @@ class TydomClient:
         try:
             if self._shutting_down:
                 return None
-            if self._connection is None:
+            connection = self._connection
+            if connection is None or not self._connection_ready:
+                await self._reconnect_with_backoff()
                 return None
-            if self._connection.closed or self.pending_pings > 5:
+            if connection.closed or self.pending_pings > 5:
                 if self._shutting_down:
                     return None
                 LOGGER.warning(
                     "Reconnecting Tydom client (reason: %s)",
                     "websocket closed"
-                    if self._connection.closed
+                    if connection.closed
                     else f"{self.pending_pings} pending pings",
                 )
-
-                if not self._connection.closed:
-                    await self._connection.close()
-
+                if connection is self._connection:
+                    self._connection_ready = False
                 await self._reconnect_with_backoff()
                 return None
 
-            if self._connection is None:
-                return None
-            msg = await self._connection.receive()
+            msg = await connection.receive()
             # Masquer les informations sensibles dans les messages entrants
             msg_data_str = (
                 msg.data.decode("utf-8", errors="replace")
@@ -619,7 +705,7 @@ class TydomClient:
 
     async def send_bytes(
         self, a_bytes: bytes, max_retries: int = 3, retry_delay: float = 1.0
-    ):
+    ) -> None:
         """Send bytes to connection with intelligent retry mechanism.
 
         Args:
@@ -632,26 +718,47 @@ class TydomClient:
             return
 
         if self._shutting_down:
-            return
+            raise asyncio.CancelledError()
 
-        if self._connection is None:
-            LOGGER.warning(
-                "Cannot send message to Tydom because no connection has been established yet."
-            )
-            return
-
-        last_exception = None
+        last_exception: Exception | None = None
         for attempt in range(max_retries + 1):
+            initialising = asyncio.current_task() is self._initialising_task
+            connection = self._connection
+
+            if not initialising and not self._connection_is_usable(connection):
+                if not await self._reconnect_with_backoff():
+                    raise TydomClientApiClientCommunicationError(
+                        "No initialised Tydom connection is available"
+                    )
+                connection = self._connection
+
+            if connection is None or connection.closed:
+                raise TydomClientApiClientCommunicationError(
+                    "No open Tydom connection is available"
+                )
+
             try:
-                await self._connection.send_bytes(a_bytes)
+                await connection.send_bytes(a_bytes)
                 if attempt > 0:
                     LOGGER.info(
                         "Successfully sent message after %d retry attempt(s)",
                         attempt,
                     )
                 return
-            except (ConnectionResetError, ConnectionError, OSError) as e:
+            except (aiohttp.ClientConnectionError, ConnectionResetError, OSError) as e:
                 last_exception = e
+
+                # Initialisation owns the connection lock. Let its caller close the
+                # failed candidate and perform the next backoff attempt rather than
+                # recursively trying to acquire the same lock here.
+                if initialising:
+                    raise TydomClientApiClientCommunicationError(
+                        "Connection failed while initialising the Tydom websocket"
+                    ) from e
+
+                if connection is self._connection:
+                    self._connection_ready = False
+
                 if attempt < max_retries:
                     delay = retry_delay * (2**attempt)  # Exponential backoff
                     LOGGER.warning(
@@ -661,21 +768,8 @@ class TydomClient:
                         str(e),
                         delay,
                     )
-                    try:
-                        if self._shutting_down:
-                            return
-                        # Try to reconnect
-                        self._connection = await self.async_connect()
-                        await asyncio.sleep(delay)
-                    except Exception as reconnect_error:
-                        LOGGER.error(
-                            "Failed to reconnect (attempt %d/%d): %s",
-                            attempt + 1,
-                            max_retries + 1,
-                            reconnect_error,
-                        )
-                        if attempt < max_retries:
-                            await asyncio.sleep(delay)
+                    if await self._wait_or_shutdown(delay):
+                        raise asyncio.CancelledError()
                 else:
                     LOGGER.error(
                         "Cannot send message to Tydom after %d attempts. Connection was lost: %s",
@@ -683,6 +777,15 @@ class TydomClient:
                         str(e),
                     )
             except Exception as e:
+                if connection.closed:
+                    last_exception = e
+                    if connection is self._connection:
+                        self._connection_ready = False
+                    if initialising:
+                        raise TydomClientApiClientCommunicationError(
+                            "Connection closed while initialising the Tydom websocket"
+                        ) from e
+                    continue
                 # For other exceptions, don't retry
                 LOGGER.error(
                     "Unexpected error sending message to Tydom: %s",

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -505,11 +505,16 @@ class TydomClient:
                 )
 
         LOGGER.error(
-            "Impossible de se reconnecter après %d tentatives",
+            "Impossible de se reconnecter après %d tentatives; "
+            "nouvelle tentative dans 60 secondes",
             self._max_reconnect_attempts,
         )
         # Notifier Home Assistant de la perte de connexion
         self.online = False
+        self._reconnect_attempts = 0
+
+        if not self._shutting_down:
+            await asyncio.sleep(60)
 
     async def consume_messages(self) -> list["TydomDevice"] | None:
         """Read and parse incoming messages."""
@@ -538,7 +543,16 @@ class TydomClient:
             if self._connection.closed or self.pending_pings > 5:
                 if self._shutting_down:
                     return None
-                await self._connection.close()
+                LOGGER.warning(
+                    "Reconnecting Tydom client (reason: %s)",
+                    "websocket closed"
+                    if self._connection.closed
+                    else f"{self.pending_pings} pending pings",
+                )
+
+                if not self._connection.closed:
+                    await self._connection.close()
+
                 await self._reconnect_with_backoff()
                 return None
 
@@ -581,9 +595,9 @@ class TydomClient:
             LOGGER.exception("Unable to handle message")
             return None
 
-    def receive_pong(self):
-        """Received a pong message, decrease pending ping counts."""
-        self.pending_pings -= 1
+    def receive_pong(self) -> None:
+        """Handle a pong response and keep the pending ping counter non-negative."""
+        self.pending_pings = max(0, self.pending_pings - 1)
 
     def build_digest_headers(self, nonce):
         """Build the headers of Digest Authentication."""

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -1,0 +1,234 @@
+"""Tests for serialised Tydom websocket connection ownership."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module required to load the client in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+class _ClientConnectionError(Exception):
+    """Stand-in for aiohttp.ClientConnectionError."""
+
+
+class _WebSocketResponse:
+    """Stand-in used only to evaluate runtime annotations."""
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+aiohttp = _module(
+    "aiohttp",
+    ClientError=Exception,
+    ClientConnectionError=_ClientConnectionError,
+    ClientSession=object,
+    ClientWebSocketResponse=_WebSocketResponse,
+    WSMsgType=MagicMock(),
+)
+_module("async_timeout", timeout=MagicMock())
+_module("homeassistant")
+_module("homeassistant.helpers")
+_module("homeassistant.helpers.aiohttp_client", async_create_clientsession=MagicMock())
+_module("requests")
+_module("requests.auth", HTTPDigestAuth=MagicMock())
+_module("urllib3", encode_multipart_formdata=MagicMock())
+
+logger = MagicMock()
+structured_logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    STRUCTURED_LOGGER=structured_logger,
+    validate_value_with_metadata=MagicMock(),
+    TIMEOUT_NORMAL_REQUEST=30.0,
+    TIMEOUT_LONG_REQUEST=60.0,
+    TIMEOUT_WEBSOCKET_CONNECT=30.0,
+    TIMEOUT_WEBSOCKET_RECEIVE=20.0,
+    TIMEOUT_PING=40.0,
+)
+_module(
+    "custom_components.deltadore_tydom.tydom.const",
+    DELTADORE_API_SITES="",
+    DELTADORE_AUTH_CLIENTID="",
+    DELTADORE_AUTH_GRANT_TYPE="",
+    DELTADORE_AUTH_SCOPE="",
+    DELTADORE_AUTH_URL="",
+    MEDIATION_URL="mediation.tydom.com",
+)
+_module(
+    "custom_components.deltadore_tydom.tydom.MessageHandler",
+    MessageHandler=MagicMock(),
+)
+
+module_name = "custom_components.deltadore_tydom.tydom.tydom_client"
+client_path = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "deltadore_tydom"
+    / "tydom"
+    / "tydom_client.py"
+)
+spec = importlib.util.spec_from_file_location(module_name, client_path)
+assert spec is not None and spec.loader is not None
+client_module = importlib.util.module_from_spec(spec)
+_original_modules.setdefault(module_name, sys.modules.get(module_name, _MISSING))
+sys.modules[module_name] = client_module
+spec.loader.exec_module(client_module)
+TydomClient = client_module.TydomClient
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+def _websocket() -> MagicMock:
+    """Return a minimal open websocket mock."""
+    connection = MagicMock()
+    connection.closed = False
+
+    async def close() -> None:
+        connection.closed = True
+
+    connection.close = AsyncMock(side_effect=close)
+    connection.send_bytes = AsyncMock()
+    return connection
+
+
+class TestManagedConnection(IsolatedAsyncioTestCase):
+    """Exercise connection candidate cleanup and reconnect serialisation."""
+
+    def _client(self) -> TydomClient:
+        return TydomClient(None, "test", "001122334455", "password", host="local")
+
+    async def test_failed_initialisation_closes_candidate(self) -> None:
+        """A socket that fails initialisation must never remain active."""
+        client = self._client()
+        candidate = _websocket()
+        client.async_connect = AsyncMock(return_value=candidate)
+        client._initialise_connection = AsyncMock(
+            side_effect=RuntimeError("init failed")
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "init failed"):
+            await client.async_connect_and_initialise()
+
+        candidate.close.assert_awaited_once()
+        self.assertIsNone(client._connection)
+        self.assertFalse(client._connection_ready)
+
+    async def test_concurrent_initialisation_opens_one_socket(self) -> None:
+        """Concurrent callers must share one initialised connection."""
+        client = self._client()
+        candidate = _websocket()
+        initialisation_started = asyncio.Event()
+        finish_initialisation = asyncio.Event()
+
+        async def initialise(connection) -> None:
+            self.assertIs(connection, candidate)
+            initialisation_started.set()
+            await finish_initialisation.wait()
+
+        client.async_connect = AsyncMock(return_value=candidate)
+        client._initialise_connection = AsyncMock(side_effect=initialise)
+
+        first = asyncio.create_task(client.async_connect_and_initialise())
+        await initialisation_started.wait()
+        second = asyncio.create_task(client.async_connect_and_initialise())
+        await asyncio.sleep(0)
+        finish_initialisation.set()
+
+        first_result, second_result = await asyncio.gather(first, second)
+
+        self.assertIs(first_result, candidate)
+        self.assertIs(second_result, candidate)
+        client.async_connect.assert_awaited_once()
+        self.assertTrue(client._connection_ready)
+
+    async def test_cancelled_initialisation_closes_candidate(self) -> None:
+        """Cancellation during initialisation must also close the candidate."""
+        client = self._client()
+        candidate = _websocket()
+        initialisation_started = asyncio.Event()
+
+        async def initialise(_connection) -> None:
+            initialisation_started.set()
+            await asyncio.Event().wait()
+
+        client.async_connect = AsyncMock(return_value=candidate)
+        client._initialise_connection = AsyncMock(side_effect=initialise)
+
+        initialisation = asyncio.create_task(client.async_connect_and_initialise())
+        await initialisation_started.wait()
+        initialisation.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await initialisation
+
+        candidate.close.assert_awaited_once()
+        self.assertIsNone(client._connection)
+        self.assertFalse(client._connection_ready)
+
+    async def test_each_failed_reconnect_candidate_is_closed(self) -> None:
+        """Every failed backoff attempt must clean up its candidate socket."""
+        client = self._client()
+        candidates = [_websocket(), _websocket()]
+        client._max_reconnect_attempts = len(candidates)
+        client._reconnect_delay = 0
+        client._max_reconnect_delay = 0
+        client.async_connect = AsyncMock(side_effect=candidates)
+        client._initialise_connection = AsyncMock(
+            side_effect=RuntimeError("init failed")
+        )
+        client._wait_or_shutdown = AsyncMock(return_value=False)
+
+        self.assertFalse(await client._reconnect_with_backoff())
+
+        for candidate in candidates:
+            candidate.close.assert_awaited_once()
+        self.assertIsNone(client._connection)
+        self.assertFalse(client._connection_ready)
+
+    async def test_writer_uses_managed_reconnect_after_send_failure(self) -> None:
+        """A writer must not create or assign a replacement socket itself."""
+        client = self._client()
+        failed = _websocket()
+        replacement = _websocket()
+        failed.send_bytes = AsyncMock(side_effect=ConnectionResetError("lost"))
+        client._connection = failed
+        client._connection_ready = True
+
+        async def reconnect() -> bool:
+            client._connection = replacement
+            client._connection_ready = True
+            return True
+
+        client._reconnect_with_backoff = AsyncMock(side_effect=reconnect)
+        client._wait_or_shutdown = AsyncMock(return_value=False)
+
+        await client.send_bytes(b"request", max_retries=1, retry_delay=0)
+
+        client._reconnect_with_backoff.assert_awaited_once()
+        replacement.send_bytes.assert_awaited_once_with(b"request")

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -211,6 +211,36 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         self.assertIsNone(client._connection)
         self.assertFalse(client._connection_ready)
 
+    async def test_concurrent_reconnects_share_one_connection(self) -> None:
+        """Concurrent reconnect callers must create one replacement socket."""
+        client = self._client()
+        candidate = _websocket()
+        reconnect_started = asyncio.Event()
+        finish_reconnect = asyncio.Event()
+
+        async def connect():
+            reconnect_started.set()
+            await finish_reconnect.wait()
+            return candidate
+
+        client.async_connect = AsyncMock(side_effect=connect)
+        client._initialise_connection = AsyncMock()
+        client._wait_or_shutdown = AsyncMock(return_value=False)
+
+        first = asyncio.create_task(client._reconnect_with_backoff())
+        await reconnect_started.wait()
+        second = asyncio.create_task(client._reconnect_with_backoff())
+        await asyncio.sleep(0)
+        finish_reconnect.set()
+
+        first_result, second_result = await asyncio.gather(first, second)
+
+        self.assertTrue(first_result)
+        self.assertTrue(second_result)
+        client.async_connect.assert_awaited_once()
+        self.assertIs(client._connection, candidate)
+        self.assertTrue(client._connection_ready)
+
     async def test_writer_uses_managed_reconnect_after_send_failure(self) -> None:
         """A writer must not create or assign a replacement socket itself."""
         client = self._client()


### PR DESCRIPTION
## Summary

- Serialise initial WebSocket connection and reconnect operations through one managed connection path.
- Ensure message readers and background writers reuse the same fully initialised connection.
- Close failed or cancelled connection candidates to prevent abandoned sockets.
- Preserve exponential reconnect backoff and add a 60-second pause after exhausting all attempts.
- Log the reason for each reconnect and add focused connection ownership tests.

## Background

The reconnect implementation introduced in version 0.21 could enter a tight loop after all ten reconnect attempts failed. The attempt counter remained at its limit while the outer message listener immediately called the reconnect method again without waiting.

This produced thousands of identical error messages, increasing memory consumption until Home Assistant became unresponsive or was terminated.

WebSocket readers and background writers could also create replacement connections independently. Concurrent recovery attempts could therefore race with one another and leave unused sockets behind.

This change gives the Tydom client sole ownership of connection creation, initialisation, replacement, and shutdown.

## Changes

- Add a lock around connection creation and reconnect operations.
- Track whether the active connection has completed initialisation.
- Reuse an existing usable connection when another task has already restored it.
- Route writer recovery through the same managed reconnect path as the message reader.
- Close every failed or cancelled connection candidate.
- Prevent reconnect work from continuing during integration shutdown.
- Keep reconnect attempts throttled after a complete failed cycle.
- Prevent the pending ping counter from becoming negative.
- Add diagnostics for reconnect triggers and outcomes.
- Update the hub to use the managed connection initialisation method.
- Add unit tests covering concurrent connection ownership, candidate cleanup, cancellation, and writer recovery.

## Testing

- Six connection management unit tests pass.
- Ruff lint checks pass.
- Ruff formatting checks pass.
- The fix was tested by two users affected by #336 over two days.
- Both installations experienced genuine WebSocket closures and recovered without entering the previous error loop.
- No associated memory growth, Home Assistant crash, or manual restart was reported during testing.

Fixes #336