### PR TITLE
Fix empty Tydom acknowledgements and light state polling

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3111,7 +3111,7 @@ class HaLight(LightEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_light"
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
-        if self._device._metadata is not None and "level" in self._device._metadata:
+        if self._device.supports_brightness:
             self._attr_color_mode = ColorMode.BRIGHTNESS
             if self._attr_supported_color_modes is None:
                 self._attr_supported_color_modes = set()
@@ -3152,6 +3152,8 @@ class HaLight(LightEntity, HAEntity):
     @property
     def brightness(self) -> int | None:
         """Return the current brightness."""
+        if not self._device.supports_brightness:
+            return None
         if hasattr(self._device, "level"):
             level = getattr(self._device, "level", None)
             if level is not None:
@@ -3186,7 +3188,7 @@ class HaLight(LightEntity, HAEntity):
     async def async_turn_on(self, **kwargs):
         """Turn device on."""
         brightness = None
-        if ATTR_BRIGHTNESS in kwargs:
+        if self._device.supports_brightness and ATTR_BRIGHTNESS in kwargs:
             brightness = math.ceil(
                 ranged_value_to_percentage(
                     self.BRIGHTNESS_SCALE, kwargs[ATTR_BRIGHTNESS]

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -178,20 +178,17 @@ class MessageHandler:
                         event.set()
                 return None
 
-            if (
-                status is not None
-                and transaction_id
-                and transaction_id in self._end_reply_events
-            ):
-                if not parsed_message.body:
-                    # Empty acknowledgment of a pending request; the data
-                    # arrives in separate messages, so just wait for them.
-                    LOGGER.debug(
-                        "Empty acknowledgment received for request '%s' (%s).",
-                        transaction_id,
-                        uri_origin,
-                    )
-                    return None
+            if status is not None and not parsed_message.body:
+                # Successful GET/PUT requests can be acknowledged with an empty
+                # body while the updated state arrives in a separate push. This
+                # also happens for requests using the gateway's reserved
+                # transaction id "0", which are not tracked as pending replies.
+                LOGGER.debug(
+                    "Empty acknowledgment received for request '%s' (%s).",
+                    transaction_id,
+                    uri_origin,
+                )
+                return None
 
             try:
                 return await self.parse_response(

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -183,6 +183,11 @@ class MessageHandler:
                 # body while the updated state arrives in a separate push. This
                 # also happens for requests using the gateway's reserved
                 # transaction id "0", which are not tracked as pending replies.
+                # A ping is itself completed by this empty 200 response, so it
+                # must still reach the liveness bookkeeping even though there is
+                # no body to parse.
+                if uri_origin == "/ping":
+                    self.tydom_client.receive_pong()
                 LOGGER.debug(
                     "Empty acknowledgment received for request '%s' (%s).",
                     transaction_id,

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -506,7 +506,7 @@ class TydomLight(TydomDevice):
                 self._id, self._endpoint, "level", str(brightness)
             )
         self._tydom_client.add_poll_device_url_1s(
-            f"/devices/{self._id}/endpoints/{self._endpoint}/cdata"
+            f"/devices/{self._id}/endpoints/{self._endpoint}/data"
         )
 
     async def turn_off(self) -> None:
@@ -530,7 +530,7 @@ class TydomLight(TydomDevice):
             )
 
         self._tydom_client.add_poll_device_url_1s(
-            f"/devices/{self._id}/endpoints/{self._endpoint}/cdata"
+            f"/devices/{self._id}/endpoints/{self._endpoint}/data"
         )
 
 

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -469,6 +469,27 @@ class TydomGarage(TydomDevice):
 class TydomLight(TydomDevice):
     """represents a light."""
 
+    @property
+    def supports_brightness(self) -> bool:
+        """Return whether level metadata exposes intermediate light levels."""
+        if not isinstance(self._metadata, dict):
+            return False
+
+        level_metadata = self._metadata.get("level")
+        if not isinstance(level_metadata, dict):
+            return False
+
+        try:
+            minimum = float(level_metadata.get("min", 0))
+            maximum = float(level_metadata.get("max", 100))
+            step = float(level_metadata["step"])
+        except (KeyError, TypeError, ValueError):
+            # Preserve brightness support for gateways that advertise level
+            # without complete numeric constraints.
+            return True
+
+        return step > 0 and maximum - minimum > step
+
     async def turn_on(self, brightness) -> None:
         """Turn on the light with specified brightness."""
         # Validate brightness value with metadata

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -120,6 +120,22 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertIsNone(devices)
         logger.warning.assert_not_called()
 
+    async def test_empty_ping_acknowledgement_updates_liveness(self) -> None:
+        """The gateway's bodyless ping response must clear a pending ping."""
+        client = MagicMock()
+        handler = MessageHandler(client, b"")
+
+        devices = await handler.route_response(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Uri-Origin: /ping\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: 0\r\n"
+            b"Transac-Id: 123\r\n\r\n"
+        )
+
+        self.assertIsNone(devices)
+        client.receive_pong.assert_called_once_with()
+
     async def test_light_commands_poll_regular_data_endpoint(self) -> None:
         """Light state refreshes must use the supported data endpoint."""
         client = MagicMock()

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -77,6 +77,33 @@ for name, original in _original_modules.items():
 class ProtocolResponseTests(IsolatedAsyncioTestCase):
     """Exercise response acknowledgements and light refresh polling."""
 
+    def test_light_brightness_requires_intermediate_levels(self) -> None:
+        """Binary level metadata must not advertise variable brightness."""
+        client = MagicMock()
+        binary_light = TydomLight(
+            client,
+            "10_20",
+            "20",
+            "Binary light",
+            "light",
+            "10",
+            {"level": {"min": 0, "max": 100, "step": 100}},
+            {"level": 0},
+        )
+        dimmable_light = TydomLight(
+            client,
+            "11_21",
+            "21",
+            "Dimmable light",
+            "light",
+            "11",
+            {"level": {"min": 0, "max": 100, "step": 1}},
+            {"level": 0},
+        )
+
+        self.assertFalse(binary_light.supports_brightness)
+        self.assertTrue(dimmable_light.supports_brightness)
+
     async def test_empty_success_response_is_treated_as_acknowledgement(self) -> None:
         """An empty successful response must not be reported as an unknown message."""
         logger.reset_mock()

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -1,0 +1,136 @@
+"""Tests for Tydom protocol response handling."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, call
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load the protocol code in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+root = Path(__file__).parents[1]
+tydom_path = root / "custom_components" / "deltadore_tydom" / "tydom"
+
+devices_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.tydom.tydom_devices",
+    tydom_path / "tydom_devices.py",
+)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(
+    devices_spec.name, sys.modules.get(devices_spec.name, _MISSING)
+)
+sys.modules[devices_spec.name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.tydom.MessageHandler",
+    tydom_path / "MessageHandler.py",
+)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(
+    handler_spec.name, sys.modules.get(handler_spec.name, _MISSING)
+)
+sys.modules[handler_spec.name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+TydomLight = devices_module.TydomLight
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class ProtocolResponseTests(IsolatedAsyncioTestCase):
+    """Exercise response acknowledgements and light refresh polling."""
+
+    async def test_empty_success_response_is_treated_as_acknowledgement(self) -> None:
+        """An empty successful response must not be reported as an unknown message."""
+        logger.reset_mock()
+        handler = MessageHandler(MagicMock(), b"")
+
+        devices = await handler.route_response(
+            b"HTTP/1.1 200 OK\r\n"
+            b"Uri-Origin: /devices/20/endpoints/10/data\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: 0\r\n"
+            b"Transac-Id: 0\r\n\r\n"
+        )
+
+        self.assertIsNone(devices)
+        logger.warning.assert_not_called()
+
+    async def test_light_commands_poll_regular_data_endpoint(self) -> None:
+        """Light state refreshes must use the supported data endpoint."""
+        client = MagicMock()
+        client.put_devices_data = AsyncMock()
+        light = TydomLight(
+            client,
+            "10_20",
+            "20",
+            "Kitchen",
+            "light",
+            "10",
+            {"levelCmd": {"enum_values": ["ON", "OFF"]}},
+            {"level": 0},
+        )
+
+        await light.turn_on(None)
+        await light.turn_on(42)
+        await light.turn_off()
+
+        self.assertEqual(
+            client.put_devices_data.await_args_list,
+            [
+                call("20", "10", "levelCmd", "ON"),
+                call("20", "10", "level", "42"),
+                call("20", "10", "levelCmd", "OFF"),
+            ],
+        )
+        self.assertEqual(
+            client.add_poll_device_url_1s.call_args_list,
+            [
+                call("/devices/20/endpoints/10/data"),
+                call("/devices/20/endpoints/10/data"),
+                call("/devices/20/endpoints/10/data"),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes three Tydom protocol-response problems:

- Successful responses with an empty body and `Transac-Id: 0` were incorrectly logged as unknown messages.
- Light commands refreshed state using an invalid bare `/cdata` request, resulting in HTTP 404 responses.
- Valid empty `/ping` acknowledgements did not clear the liveness counter, causing a false reconnect every 2.5 minutes.

## Problem

### Empty successful responses

The gateway can acknowledge a request with `200 OK`, an empty body, and its reserved transaction ID `0`. The resulting device state is delivered separately.

These acknowledgements were passed to the payload parser because transaction ID `0` was not registered as a pending request.

A representative, sanitized example:

```text
HTTP/1.1 200 OK
Uri-Origin: /devices/<device>/endpoints/<endpoint>/data
Content-Length: 0
Transac-Id: 0

WARNING (...) Unknown message type received
/devices/<device>/endpoints/<endpoint>/data: b''
```

The supplied real-world log contained 237 occurrences of this warning.

### Empty ping acknowledgements caused reconnect loops

The same early return for a bodyless successful response also bypassed the `/ping` response handler. The gateway was replying normally, but `receive_pong()` was never called, so `pending_pings` increased until the watchdog replaced a healthy connection.

A representative extract from the follow-up live test:

```text
2026-07-26 13:47:13.466 DEBUG Sending message to tydom (GET /ping)
2026-07-26 13:47:13.474 DEBUG HTTP/1.1 200 OK
Uri-Origin: /ping
Content-Length: 0
2026-07-26 13:47:13.475 DEBUG Empty acknowledgment received (...) (/ping).

2026-07-26 13:48:13.540 WARNING Reconnecting Tydom client
(reason: 6 pending pings)
```

The 25-minute sample contained 59 successful empty ping acknowledgements but still triggered 10 false reconnects, consistently about 150 seconds apart. Each reconnect succeeded on its first attempt, further confirming that the websocket and gateway were reachable.
### Invalid light refresh endpoint

After turning a light on or off, or changing its brightness, the integration scheduled this request:

```http
GET /devices/<device>/endpoints/<endpoint>/cdata
```

The gateway rejected it:

```text
DEBUG (...) Sending message to tydom
(GET /devices/<light-a>/endpoints/<light-a>/cdata)

INFO (...) HTTP/1.1 404 Not Found
Uri-Origin: /devices/<light-a>/endpoints/<light-a>/cdata

WARNING (...) Request '<transaction-id>'
(/devices/<light-a>/endpoints/<light-a>/cdata)
rejected with HTTP status 404
```

A separate light produced the same response:

```text
DEBUG (...) Sending message to tydom
(GET /devices/<light-b>/endpoints/<light-b>/cdata)

INFO (...) HTTP/1.1 404 Not Found
Uri-Origin: /devices/<light-b>/endpoints/<light-b>/cdata

WARNING (...) Request '<transaction-id>'
(/devices/<light-b>/endpoints/<light-b>/cdata)
rejected with HTTP status 404
```

The supplied log contained 34 such responses across 22 distinct light endpoints. Every HTTP 404 was caused by the same bare `/cdata` request.

## Why `/cdata` is not the correct endpoint

`/cdata` is used by Tydom for specific command-data operations. Valid uses in the integration are qualified requests such as:

```text
/devices/<device>/endpoints/<endpoint>/cdata?name=alarmCmd
/devices/<device>/endpoints/<endpoint>/cdata?name=histo&type=...
```

It is not the normal endpoint for reading a light's current state.

The integration's established single-device polling implementation uses:

```http
GET /devices/<device>/endpoints/<endpoint>/data
```

The response router also explicitly recognises this `/data` form and converts its response into the normal device-state structure.

Therefore, the bare `/cdata` request used by `TydomLight` was inconsistent with both:

- The integration's existing device polling protocol
- The gateway's observed behaviour, which returned HTTP 404 for every such request

The correct light refresh endpoint is:

```http
GET /devices/<device>/endpoints/<endpoint>/data
```

## Resolution

### Handle empty acknowledgements

Successful HTTP responses with an empty body are now treated as acknowledgements before payload parsing.

This also covers responses using the gateway's reserved transaction ID `0`, which are not registered as pending replies.

The acknowledgement is logged at debug level while the integration waits for the separate state update.

Existing HTTP error handling remains unchanged.

### Clear liveness on an empty ping acknowledgement

A successful empty response whose `Uri-Origin` is `/ping` now calls the normal pong bookkeeping before returning from the generic empty-acknowledgement path.

Other empty acknowledgements keep their existing behaviour: they are accepted without being sent to JSON/device-state parsing, while state updates may arrive separately.
### Poll light state through `/data`

The delayed refresh after each of the following light operations now uses `/data`:

- Turn on
- Set brightness
- Turn off

The commands themselves are unchanged.

## Testing

Added focused regression tests confirming that:

- A `200 OK` response with an empty body and `Transac-Id: 0` is accepted as an acknowledgement.
- The response does not produce an unknown-message warning.
- A bodyless `200 OK` response for `/ping` invokes the liveness bookkeeping exactly once.
- Turning a light on sends `levelCmd=ON`.
- Changing brightness sends the requested `level`.
- Turning a light off sends `levelCmd=OFF`.
- All three operations schedule their refresh through `/data`.

Local validation:

```text
Ran 11 tests: OK
Ruff lint: passed
Ruff formatting check: passed
git diff --check: passed
```

## Behavioural impact

This does not change the commands sent to lights or normal device-state parsing.

It removes misleading warnings for valid empty acknowledgements, prevents false reconnect loops after acknowledged pings, and prevents unsupported bare `/cdata` light-state requests.

## Live testing (sanitized)

The fixes were deployed and tested on a live TYDOM installation running `v0.27`.

Interactive light testing covered both dimmable and non-dimmable devices. The initial test build exposed a regression where a binary-level light (for example, a TYXIA 5610 rather than a variable TYXIA 5630) incorrectly received a brightness slider. The capability detection was corrected, the fix was redeployed, and the tester confirmed that the non-dimmable entity now exposes only on/off while variable lights retain brightness control.

The supplied logs were reviewed repeatedly during the afternoon. An earlier 25-minute capture exposed the empty-ping liveness bug documented above. After that correction was added, a final sanitized soak covered approximately 3 hours 53 minutes (`14:07:05` to `18:00:13`) and recorded:

- 409 valid empty acknowledgements accepted without payload parsing.
- 0 `Unknown message type received` warnings for those acknowledgements.
- 0 reconnects caused by accumulated pending pings.
- 0 WebSocket reconnects during the soak.
- 0 HTTP 404 responses.
- 0 requests to the invalid bare `/cdata` endpoint.
- 314 valid single-endpoint `/data` polls processed during normal operation.

This provides live confirmation of the empty-acknowledgement and ping-liveness fixes in addition to the focused automated tests. Raw logs are intentionally omitted because they contain installation-specific identifiers and protocol payloads; only sanitized counts, durations, device classes, and outcomes are recorded here.

Refs #258