### PR TITLE
Fix adaptive polling device and endpoint identifier order

### DIFF
--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -669,18 +669,18 @@ class Hub:
         """Rebuild polling cache efficiently.
 
         This method scans all devices and their metadata to build a cache
-        mapping (device_id, attribute_name) to polling intervals based on
+        mapping (device_key, attribute_name) to polling intervals based on
         the validity metadata. The cache is rebuilt periodically to account
         for metadata changes.
 
-        The cache structure: {(device_id, attr_name): interval_seconds}
+        The cache structure: {(device_key, attr_name): interval_seconds}
         - Devices with validity=INFINITE or upToDate are not cached (no polling)
         - Devices with validity=ES_SUPERVISION are cached with 300s interval
         - Devices with validity=SENSOR_SUPERVISION are cached with 60s interval
         - Devices with validity=SYNCHRO_SUPERVISION are cached with 30s interval
         """
         new_cache: dict[tuple[str, str], int] = {}
-        for device_id, device in self.devices.items():
+        for device_key, device in self.devices.items():
             if not hasattr(device, "_metadata") or device._metadata is None:
                 continue
             for attr_name, attr_metadata in device._metadata.items():
@@ -688,7 +688,7 @@ class Hub:
                     validity = attr_metadata.get("validity")
                     interval = get_polling_interval_for_validity(validity)
                     if interval is not None:
-                        new_cache[(device_id, attr_name)] = interval
+                        new_cache[(device_key, attr_name)] = interval
 
         # Update cache atomically
         self._polling_cache = new_cache
@@ -716,10 +716,10 @@ class Hub:
 
             # Group devices by interval from cache
             interval_groups: dict[int, list[tuple[str, str]]] = {}
-            for (device_id, attr_name), interval in self._polling_cache.items():
+            for (device_key, attr_name), interval in self._polling_cache.items():
                 if interval not in interval_groups:
                     interval_groups[interval] = []
-                interval_groups[interval].append((device_id, attr_name))
+                interval_groups[interval].append((device_key, attr_name))
 
             # Poll devices according to their intervals
             if interval_groups:
@@ -728,15 +728,15 @@ class Hub:
                 shortest_interval = sorted_intervals[0]
 
                 # Poll devices that need the shortest interval
-                for device_id, _attr_name in interval_groups[shortest_interval]:
-                    if device_id in self.devices:
-                        device = self.devices[device_id]
+                for device_key, _attr_name in interval_groups[shortest_interval]:
+                    if device_key in self.devices:
+                        device = self.devices[device_key]
                         if hasattr(device, "_tydom_client"):
                             try:
-                                await device._tydom_client.poll_device_data(device_id)
+                                await device._tydom_client.poll_device_data(device_key)
                             except Exception as e:
                                 LOGGER.warning(
-                                    "Error polling device %s: %s", device_id, e
+                                    "Error polling device %s: %s", device_key, e
                                 )
 
                 # Sleep for the shortest interval

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -132,7 +132,7 @@ class Hub:
         # Polling cache for optimization
         self._polling_cache: dict[
             tuple[str, str], int
-        ] = {}  # (device_id, attr_name) -> interval
+        ] = {}  # (device_key, attr_name) -> interval
         self._polling_cache_timestamp = 0
         self._polling_cache_ttl = 300  # 5 minutes
 
@@ -733,7 +733,9 @@ class Hub:
                         device = self.devices[device_key]
                         if hasattr(device, "_tydom_client"):
                             try:
-                                await device._tydom_client.poll_device_data(device_key)
+                                await device._tydom_client.poll_device_data(
+                                    device._id, device.device_endpoint
+                                )
                             except Exception as e:
                                 LOGGER.warning(
                                     "Error polling device %s: %s", device_key, e

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1128,15 +1128,20 @@ class TydomClient:
         req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
-    async def poll_device_data(self, device_key):
+    async def poll_device_data(self, device_id, endpoint_id=None):
         """Poll data for a single device.
 
-        Accepts either a plain device id or the composite
-        "<endpoint_id>_<device_id>" key used by the hub device registry.
+        The hub passes the protocol device and endpoint ids explicitly.
+        Plain device ids and composite "<endpoint_id>_<device_id>" registry
+        keys remain supported for compatibility.
         """
-        endpoint_id, separator, device_id = str(device_key).partition("_")
-        if not separator:
-            device_id = endpoint_id
+        if endpoint_id is None:
+            parsed_endpoint, separator, parsed_device = str(device_id).partition("_")
+            if separator:
+                device_id = parsed_device
+                endpoint_id = parsed_endpoint
+            else:
+                endpoint_id = device_id
         safe_device = quote(str(device_id), safe="")
         safe_endpoint = quote(str(endpoint_id), safe="")
         await self.get_poll_device_data(

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1128,18 +1128,19 @@ class TydomClient:
         req = "GET"
         await self.send_message(method=req, msg=msg_type)
 
-    async def poll_device_data(self, device_id):
+    async def poll_device_data(self, device_key):
         """Poll data for a single device.
 
         Accepts either a plain device id or the composite
-        "<device_id>_<endpoint_id>" key used by the hub device registry.
+        "<endpoint_id>_<device_id>" key used by the hub device registry.
         """
-        dev_id, _, endpoint_id = str(device_id).partition("_")
-        endpoint_id = endpoint_id or dev_id
-        safe_dev = quote(str(dev_id), safe="")
+        endpoint_id, separator, device_id = str(device_key).partition("_")
+        if not separator:
+            device_id = endpoint_id
+        safe_device = quote(str(device_id), safe="")
         safe_endpoint = quote(str(endpoint_id), safe="")
         await self.get_poll_device_data(
-            f"/devices/{safe_dev}/endpoints/{safe_endpoint}/data"
+            f"/devices/{safe_device}/endpoints/{safe_endpoint}/data"
         )
 
     def add_poll_device_url_1s(self, url):

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -262,3 +262,32 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
 
         client._reconnect_with_backoff.assert_awaited_once()
         replacement.send_bytes.assert_awaited_once_with(b"request")
+
+
+class TestDevicePolling(IsolatedAsyncioTestCase):
+    """Exercise adaptive polling URL construction."""
+
+    def _client(self) -> TydomClient:
+        return TydomClient(None, "test", "001122334455", "password", host="local")
+
+    async def test_composite_key_uses_endpoint_then_device_order(self) -> None:
+        """A registry key must put the device id in the URL device position."""
+        client = self._client()
+        client.get_poll_device_data = AsyncMock()
+
+        await client.poll_device_data("0_8")
+
+        client.get_poll_device_data.assert_awaited_once_with(
+            "/devices/8/endpoints/0/data"
+        )
+
+    async def test_plain_device_id_uses_same_endpoint_id(self) -> None:
+        """A plain device id must retain the legacy device endpoint form."""
+        client = self._client()
+        client.get_poll_device_data = AsyncMock()
+
+        await client.poll_device_data("8")
+
+        client.get_poll_device_data.assert_awaited_once_with(
+            "/devices/8/endpoints/8/data"
+        )

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -270,15 +270,26 @@ class TestDevicePolling(IsolatedAsyncioTestCase):
     def _client(self) -> TydomClient:
         return TydomClient(None, "test", "001122334455", "password", host="local")
 
-    async def test_composite_key_uses_endpoint_then_device_order(self) -> None:
-        """A registry key must put the device id in the URL device position."""
+    async def test_explicit_protocol_ids_use_correct_url_positions(self) -> None:
+        """Canonical device and endpoint ids must retain their URL positions."""
         client = self._client()
         client.get_poll_device_data = AsyncMock()
 
-        await client.poll_device_data("0_8")
+        await client.poll_device_data(8, 0)
 
         client.get_poll_device_data.assert_awaited_once_with(
             "/devices/8/endpoints/0/data"
+        )
+
+    async def test_composite_key_uses_endpoint_then_device_order(self) -> None:
+        """A legacy registry-key call must use endpoint-then-device order."""
+        client = self._client()
+        client.get_poll_device_data = AsyncMock()
+
+        await client.poll_device_data("3_42")
+
+        client.get_poll_device_data.assert_awaited_once_with(
+            "/devices/42/endpoints/3/data"
         )
 
     async def test_plain_device_id_uses_same_endpoint_id(self) -> None:


### PR DESCRIPTION
## Summary

Fix adaptive polling requests that reverse TYDOM device and endpoint identifiers.

Closes #351.

## Problem

Devices are stored in the integration registry using composite keys in this order:

```text
<endpoint_id>_<device_id>
```

For example, endpoint `0` belonging to device `8` is stored as:

```text
0_8
```

Adaptive polling interpreted this key in the opposite order and generated:

```text
/devices/0/endpoints/8/data
```

The correct TYDOM request is:

```text
/devices/8/endpoints/0/data
```

This caused repeated HTTP 404 responses during adaptive polling.

## Resolution

- Pass the protocol device and endpoint identifiers explicitly from the hub.
- Parse legacy composite keys as `<endpoint_id>_<device_id>`.
- Preserve compatibility with plain, non-composite identifiers.
- Rename polling variables and update documentation to clarify the registry-key format.
- Add regression tests for explicit IDs, composite keys, and plain device IDs.

## Testing

Added tests confirming that:

- Device `8`, endpoint `0` produces `/devices/8/endpoints/0/data`.
- Composite key `3_42` produces `/devices/42/endpoints/3/data`.
- A plain device identifier retains the legacy same-ID endpoint behavior.

Local validation:

```text
Focused tests passed
Ruff lint passed
Ruff formatting passed
git diff --check passed
```

## Live testing

The fix was deployed by @Coldness00.

Their follow-up logs confirm that adaptive polling now uses the correct path:

```text
/devices/8/endpoints/0/data
```

The remaining empty-response warning and bare `/cdata` 404 are separate protocol-response issues addressed by #350.