### PR TITLE
Add dedicated remote control button events

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -83,7 +83,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.components.number import NumberEntity
 from homeassistant.components.select import SelectEntity
-from homeassistant.components.event import EventEntity
+from homeassistant.components.event import EventDeviceClass, EventEntity
 
 from .tydom.tydom_devices import (
     Tydom,
@@ -104,6 +104,7 @@ from .tydom.tydom_devices import (
     TydomScene,
     TydomGroup,
     TydomMoment,
+    TydomRemoteControl,
 )
 
 from .const import (
@@ -5699,6 +5700,146 @@ class HASelect(SelectEntity, HAEntity):
         """Change the selected option."""
         await self._device._tydom_client.put_devices_data(
             self._device._id, self._device._endpoint, self._attribute_name, option
+        )
+
+
+class HARemoteEvent(EventEntity, HAEntity):
+    """Representation of a physical remote-control button."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = ["press_end", "long_press_end"]
+    _attr_icon = "mdi:remote"
+
+    def __init__(self, device: TydomRemoteControl, hass) -> None:
+        """Initialise a remote-control button event."""
+        self.hass = hass
+        self._device = device
+        self._device._ha_device = self
+        self._last_event_sequence = device.event_sequence
+        self._attr_unique_id = f"{self._device.device_id}_remote_event"
+        button_number = device.button_number
+        self._attr_name = (
+            f"Button {button_number}" if button_number is not None else device.device_name
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for fresh actions from this physical button endpoint."""
+        await super().async_added_to_hass()
+        self._device.register_callback(self._handle_device_update)
+        self._device._ha_device = self
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the remote-action callback."""
+        self._device.remove_callback(self._handle_device_update)
+        if hasattr(self._device, "_ha_device") and self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    def _handle_device_update(self) -> None:
+        """Emit one Home Assistant event for each fresh TYDOM action."""
+        sequence = self._device.event_sequence
+        if sequence <= self._last_event_sequence:
+            return
+
+        self._last_event_sequence = sequence
+        action = str(getattr(self._device, "action", "IDLE"))
+        if action == "IDLE":
+            return
+
+        event_type = "long_press_end" if action.endswith("_LONG") else "press_end"
+        self._trigger_event(
+            event_type,
+            {
+                "action": action,
+                "configured_action": self._device._configured_action,
+            },
+        )
+        self.async_write_ha_state()
+
+    def get_sensors(self) -> list:
+        """Do not expose transient actions as ordinary sensors."""
+        return []
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Group every button under the physical remote control."""
+        return self._enrich_device_info(
+            {
+                "identifiers": {
+                    (DOMAIN, f"remote_control_{self._device.physical_device_id}")
+                },
+                "name": self._device.remote_name,
+                "manufacturer": "Delta Dore",
+                "model": self._device.remote_model,
+            }
+        )
+
+
+class HARemoteBattery(BinarySensorEntity, HAEntity):
+    """Battery-defect diagnostic shared by all endpoints of one remote."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.BATTERY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Battery fault"
+
+    def __init__(self, device: TydomRemoteControl, hass) -> None:
+        """Initialise the physical remote battery diagnostic."""
+        self.hass = hass
+        self._device = device
+        self._devices: dict[str, TydomRemoteControl] = {}
+        self._callbacks: dict[str, Any] = {}
+        self._battery_defect: bool | None = None
+        self._attr_unique_id = (
+            f"remote_control_{device.physical_device_id}_battery_defect"
+        )
+        self.add_device(device)
+
+    def add_device(self, device: TydomRemoteControl) -> None:
+        """Include another button endpoint in the physical battery diagnostic."""
+        if device.device_id in self._devices:
+            return
+
+        self._devices[device.device_id] = device
+
+        def handle_update() -> None:
+            value = getattr(device, "battDefect", None)
+            if value is not None:
+                self._battery_defect = bool(value)
+            self.async_write_ha_state()
+
+        self._callbacks[device.device_id] = handle_update
+        device.register_callback(handle_update)
+        initial_value = getattr(device, "battDefect", None)
+        if initial_value is not None:
+            self._battery_defect = bool(initial_value)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks from every endpoint of the physical remote."""
+        for device_id, device in self._devices.items():
+            device.remove_callback(self._callbacks[device_id])
+        await super().async_will_remove_from_hass()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether TYDOM reports a remote battery defect."""
+        return self._battery_defect
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach the diagnostic to the same physical remote as its buttons."""
+        return self._enrich_device_info(
+            {
+                "identifiers": {
+                    (DOMAIN, f"remote_control_{self._device.physical_device_id}")
+                },
+                "name": self._device.remote_name,
+                "manufacturer": "Delta Dore",
+                "model": self._device.remote_model,
+            }
         )
 
 

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5721,7 +5721,9 @@ class HARemoteEvent(EventEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_remote_event"
         button_number = device.button_number
         self._attr_name = (
-            f"Button {button_number}" if button_number is not None else device.device_name
+            f"Button {button_number}"
+            if button_number is not None
+            else device.device_name
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -60,6 +60,7 @@ from .ha_entities import (
 )
 
 from .const import LOGGER, get_polling_interval_for_validity, STRUCTURED_LOGGER
+from .remote_registry_migration import migrate_legacy_remote_endpoint
 
 
 class Hub:
@@ -573,11 +574,14 @@ class Hub:
         if self.add_switch_callback is not None:
             self.add_switch_callback([ha_device])
 
-    async def _create_remote_control_device(
-        self, device: TydomRemoteControl
-    ) -> None:
+    async def _create_remote_control_device(self, device: TydomRemoteControl) -> None:
         """Create an event entity for a remote button and one battery diagnostic."""
         LOGGER.debug("Create remote-control button %s", device.device_id)
+        migrate_legacy_remote_endpoint(
+            self._hass,
+            self._entry.entry_id,
+            device.device_id,
+        )
         ha_device = HARemoteEvent(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
         if self.add_event_callback is not None:

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -30,6 +30,7 @@ from .tydom.tydom_devices import (
     TydomScene,
     TydomGroup,
     TydomMoment,
+    TydomRemoteControl,
 )
 from .ha_entities import (
     HATydom,
@@ -54,6 +55,8 @@ from .ha_entities import (
     HAReloadButton,
     HAGroup,
     HAMoment,
+    HARemoteBattery,
+    HARemoteEvent,
 )
 
 from .const import LOGGER, get_polling_interval_for_validity, STRUCTURED_LOGGER
@@ -127,6 +130,7 @@ class Hub:
 
         self.online = True
         self._reload_button_created = False
+        self._remote_battery_entities: dict[str, HARemoteBattery] = {}
         self._shutting_down = False
 
         # Polling cache for optimization
@@ -156,6 +160,7 @@ class Hub:
             TydomScene: self._create_scene_device,
             TydomGroup: self._create_group_device,
             TydomMoment: self._create_moment_device,
+            TydomRemoteControl: self._create_remote_control_device,
             TydomDevice: self._create_generic_device,
         }
 
@@ -568,6 +573,25 @@ class Hub:
         if self.add_switch_callback is not None:
             self.add_switch_callback([ha_device])
 
+    async def _create_remote_control_device(
+        self, device: TydomRemoteControl
+    ) -> None:
+        """Create an event entity for a remote button and one battery diagnostic."""
+        LOGGER.debug("Create remote-control button %s", device.device_id)
+        ha_device = HARemoteEvent(device, self._hass)
+        self.ha_devices[device.device_id] = ha_device
+        if self.add_event_callback is not None:
+            self.add_event_callback([ha_device])
+
+        battery = self._remote_battery_entities.get(device.physical_device_id)
+        if battery is None:
+            battery = HARemoteBattery(device, self._hass)
+            self._remote_battery_entities[device.physical_device_id] = battery
+            if self.add_binary_sensor_callback is not None:
+                self.add_binary_sensor_callback([battery])
+        else:
+            battery.add_device(device)
+
     async def _create_generic_device(self, device: TydomDevice) -> None:
         """Create generic sensor device."""
         LOGGER.debug("Create generic sensor %s", device.device_id)
@@ -649,9 +673,9 @@ class Hub:
         while not self._shutting_down:
             await self._tydom_client.get_info()
             await self._tydom_client.put_api_mode()
-            await self._tydom_client.get_groups()
             await self._tydom_client.post_refresh()
             await self._tydom_client.get_configs_file()
+            await self._tydom_client.get_groups()
             await self._tydom_client.get_devices_meta()
             await self._tydom_client.get_devices_cmeta()
             await self._tydom_client.get_devices_data()
@@ -759,6 +783,7 @@ class Hub:
         # Vider les dictionnaires d'appareils
         self.devices.clear()
         self.ha_devices.clear()
+        self._remote_battery_entities.clear()
         # Réinitialiser le flag pour recréer le bouton après le rechargement
         self._reload_button_created = False
 
@@ -785,9 +810,9 @@ class Hub:
         # Recharger toutes les métadonnées et données comme au démarrage
         await self._tydom_client.get_info()
         await self._tydom_client.put_api_mode()
-        await self._tydom_client.get_groups()
         await self._tydom_client.post_refresh()
         await self._tydom_client.get_configs_file()
+        await self._tydom_client.get_groups()
         await self._tydom_client.get_devices_meta()
         await self._tydom_client.get_devices_cmeta()
         await self._tydom_client.get_devices_data()

--- a/custom_components/deltadore_tydom/remote_registry_migration.py
+++ b/custom_components/deltadore_tydom/remote_registry_migration.py
@@ -1,0 +1,74 @@
+"""Registry migration for dedicated remote-control entities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .const import DOMAIN, LOGGER
+
+
+def remove_legacy_remote_endpoint(
+    device_registry: Any,
+    entity_registry: Any,
+    config_entry_id: str,
+    endpoint_unique_id: str,
+) -> list[str]:
+    """Remove one obsolete generic endpoint when it is safe to do so."""
+    legacy_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, endpoint_unique_id)}
+    )
+    if legacy_device is None:
+        return []
+
+    if config_entry_id not in getattr(legacy_device, "config_entries", set()):
+        return []
+
+    allowed_unique_ids = {
+        f"{endpoint_unique_id}_sensor",
+        f"{endpoint_unique_id}_action",
+        f"{endpoint_unique_id}_battDefect",
+    }
+    attached_entities = [
+        (entity_id, entity)
+        for entity_id, entity in entity_registry.entities.items()
+        if entity.device_id == legacy_device.id
+    ]
+    if any(
+        entity.platform != DOMAIN or entity.unique_id not in allowed_unique_ids
+        for _, entity in attached_entities
+    ):
+        LOGGER.warning(
+            "Keeping legacy remote-control device %s because it has "
+            "unrecognised entities",
+            legacy_device.id,
+        )
+        return []
+
+    removed_entity_ids = [entity_id for entity_id, _ in attached_entities]
+    for entity_id in removed_entity_ids:
+        entity_registry.async_remove(entity_id)
+    device_registry.async_remove_device(legacy_device.id)
+
+    LOGGER.info(
+        "Removed legacy generic remote-control endpoint %s (%d entities)",
+        endpoint_unique_id,
+        len(removed_entity_ids),
+    )
+    return removed_entity_ids
+
+
+def migrate_legacy_remote_endpoint(
+    hass: Any,
+    config_entry_id: str,
+    endpoint_unique_id: str,
+) -> list[str]:
+    """Remove the generic registry records replaced by a remote event entity."""
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+
+    return remove_legacy_remote_endpoint(
+        dr.async_get(hass),
+        er.async_get(hass),
+        config_entry_id,
+        endpoint_unique_id,
+    )

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -613,6 +613,17 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
+            case "plug":
+                return TydomPlug(
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata.get(uid),
+                    data,
+                )
             case "remoteControl":
                 return TydomRemoteControl(
                     tydom_client,
@@ -624,17 +635,6 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                     remote_control_info.get(uid),
-                )
-            case "plug":
-                return TydomPlug(
-                    tydom_client,
-                    uid,
-                    device_id,
-                    name,
-                    last_usage,
-                    endpoint,
-                    device_metadata.get(uid),
-                    data,
                 )
             case _:
                 LOGGER.info(

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -24,6 +24,7 @@ from .tydom_devices import (
     TydomGate,
     TydomLight,
     TydomPlug,
+    TydomRemoteControl,
     TydomShutter,
     TydomSmoke,
     TydomWindow,
@@ -56,6 +57,59 @@ device_metadata = {}
 scenario_metadata = {}  # Store scenario metadata from /configs/file
 groups_metadata = {}  # Store group metadata from /configs/file: {group_id: {"usage": "light", "name": "TOTAL"}}
 groups_data = {}  # Store groups data: {group_id: {"devices": [device_ids], "name": group_name}}
+endpoint_config = {}  # Store endpoint-specific configuration from /configs/file
+remote_control_info = {}  # Store physical remote and button details by endpoint UID
+
+_REMOTE_CONTROL_MODELS = {
+    "tl2000": "TL 2000 TYXAL+",
+    "rcu_tyxia1410": "TYXIA 1410",
+}
+
+
+def _remote_control_model(tutorial_id: str) -> str:
+    """Return a friendly model name from a TYDOM tutorial identifier."""
+    for prefix, model in _REMOTE_CONTROL_MODELS.items():
+        if tutorial_id.startswith(prefix):
+            return model
+    return "Delta Dore remote control"
+
+
+def _refresh_remote_control_info() -> None:
+    """Combine endpoint configuration with related-endpoint group metadata."""
+    remote_control_info.clear()
+
+    for unique_id, config in endpoint_config.items():
+        if config.get("usage") != "remoteControl":
+            continue
+
+        physical_device_id = str(config["device_id"])
+        group_id = None
+        group_name = f"Remote control {physical_device_id}"
+        group_tutorial_id = ""
+
+        for candidate_id, group in groups_data.items():
+            group_metadata = groups_metadata.get(candidate_id, {})
+            group_usage = group.get("usage") or group_metadata.get("usage")
+            if group_usage != "remoteControl":
+                continue
+            if physical_device_id in group.get("devices", []):
+                group_id = candidate_id
+                group_name = (
+                    group_metadata.get("name") or group.get("name") or group_name
+                )
+                group_tutorial_id = str(group_metadata.get("tutorial_id", ""))
+                break
+
+        endpoint_tutorial_id = str(config.get("tutorial_id", ""))
+        tutorial_id = group_tutorial_id or endpoint_tutorial_id
+        remote_control_info[unique_id] = {
+            "physical_device_id": physical_device_id,
+            "group_id": group_id,
+            "name": group_name,
+            "model": _remote_control_model(tutorial_id),
+            "button_number": config.get("button_number"),
+            "configured_action": config.get("configured_action", "TOGGLE"),
+        }
 
 
 class Reply(TypedDict):
@@ -559,6 +613,18 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
+            case "remoteControl":
+                return TydomRemoteControl(
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata.get(uid),
+                    data,
+                    remote_control_info.get(uid),
+                )
             case "plug":
                 return TydomPlug(
                     tydom_client,
@@ -602,6 +668,24 @@ class MessageHandler:
             device_name[device_unique_id] = i["name"]
             device_type[device_unique_id] = i["last_usage"] or "unknown"
             device_endpoint[device_unique_id] = i["id_endpoint"]
+            widget_behavior = i.get("widget_behavior") or {}
+            tutorial_id = str(widget_behavior.get("tutorial_id", ""))
+            button_match = re.search(
+                r"BUTTON(\d+)", str(i.get("name", ""))
+            ) or re.search(r"_btn_(\d+)$", tutorial_id)
+            endpoint_config[device_unique_id] = {
+                "device_id": i["id_device"],
+                "endpoint_id": i["id_endpoint"],
+                "usage": i.get("last_usage") or "unknown",
+                "tutorial_id": tutorial_id,
+                "configured_action": widget_behavior.get("action", "TOGGLE"),
+                "button_number": (
+                    int(button_match.group(1)) if button_match is not None else None
+                ),
+            }
+
+            if i.get("last_usage") == "remoteControl" and button_match is not None:
+                device_name[device_unique_id] = f"Button {button_match.group(1)}"
 
             if i["last_usage"] == "alarm":
                 device_name[device_unique_id] = "Tyxal Alarm"
@@ -632,6 +716,9 @@ class MessageHandler:
                     groups_metadata[group_id_str] = {
                         "usage": group.get("usage", ""),
                         "name": group.get("name", f"Group {group_id}"),
+                        "tutorial_id": (group.get("widget_behavior") or {}).get(
+                            "tutorial_id", ""
+                        ),
                     }
                     LOGGER.debug(
                         "Stored group metadata: id=%s, usage=%s, name=%s",
@@ -640,6 +727,7 @@ class MessageHandler:
                         groups_metadata[group_id_str]["name"],
                     )
 
+        _refresh_remote_control_info()
         LOGGER.debug("Configuration updated")
         return []
 
@@ -1111,6 +1199,13 @@ class MessageHandler:
                             "usage": group_usage,
                         }
 
+                        if group_usage == "remoteControl":
+                            LOGGER.debug(
+                                "Skipping non-controllable remote-control group %s",
+                                group_id_str,
+                            )
+                            continue
+
                         # Create TydomGroup device
                         # Import here to avoid circular import
                         from .tydom_devices import TydomGroup
@@ -1134,6 +1229,7 @@ class MessageHandler:
                     "Found and created %d groups",
                     len(groups) if isinstance(groups, list) else 0,
                 )
+                _refresh_remote_control_info()
         return devices
 
     async def parse_moments_file(self, parsed, transaction_id):

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -507,11 +507,11 @@ class TydomClient:
         # await self.post_refresh()
 
         # await self.get_info()
+        await self.post_refresh()
+        await self.get_configs_file()
         await self.get_groups()
         if self._shutting_down:
             return
-        await self.post_refresh()
-        await self.get_configs_file()
         await self.get_devices_meta()
         await self.get_devices_cmeta()
         await self.get_devices_data()

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -201,6 +201,77 @@ class TydomSmoke(TydomDevice):
     """Represents an smoke detector sensor."""
 
 
+class TydomRemoteControl(TydomDevice):
+    """Represent one button endpoint of a physical remote control."""
+
+    def __init__(
+        self,
+        tydom_client: TydomClient,
+        uid: str,
+        device_id: str,
+        name: str,
+        device_type: str,
+        endpoint: str | None,
+        metadata: dict | None,
+        data: dict | None,
+        remote_info: dict | None = None,
+    ) -> None:
+        """Initialise a remote-control button endpoint."""
+        super().__init__(
+            tydom_client,
+            uid,
+            device_id,
+            name,
+            device_type,
+            endpoint,
+            metadata,
+            data,
+        )
+        info = remote_info or {}
+        self._physical_device_id = str(info.get("physical_device_id", device_id))
+        self._remote_name = str(
+            info.get("name", f"Remote control {self._physical_device_id}")
+        )
+        self._remote_model = str(
+            info.get("model", "Delta Dore remote control")
+        )
+        self._button_number = info.get("button_number")
+        self._configured_action = str(info.get("configured_action", "TOGGLE"))
+        self._event_sequence = 0
+
+    @property
+    def physical_device_id(self) -> str:
+        """Return the identifier shared by every button on the remote."""
+        return self._physical_device_id
+
+    @property
+    def remote_name(self) -> str:
+        """Return the configured name of the physical remote."""
+        return self._remote_name
+
+    @property
+    def remote_model(self) -> str:
+        """Return the remote-control model inferred from TYDOM configuration."""
+        return self._remote_model
+
+    @property
+    def button_number(self) -> int | None:
+        """Return the physical button number represented by this endpoint."""
+        return self._button_number
+
+    @property
+    def event_sequence(self) -> int:
+        """Return a monotonically increasing sequence for fresh button actions."""
+        return self._event_sequence
+
+    async def update_device(self, device) -> None:
+        """Record fresh remote actions before publishing the endpoint update."""
+        action = getattr(device, "action", None)
+        if action is not None and action != "IDLE":
+            self._event_sequence += 1
+        await super().update_device(device)
+
+
 class TydomBoiler(TydomDevice):
     """Represents a Boiler."""
 

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -232,9 +232,7 @@ class TydomRemoteControl(TydomDevice):
         self._remote_name = str(
             info.get("name", f"Remote control {self._physical_device_id}")
         )
-        self._remote_model = str(
-            info.get("model", "Delta Dore remote control")
-        )
+        self._remote_model = str(info.get("model", "Delta Dore remote control"))
         self._button_number = info.get("button_number")
         self._configured_action = str(info.get("configured_action", "TOGGLE"))
         self._event_sequence = 0

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import sys
 import types
 from unittest import IsolatedAsyncioTestCase
+from unittest import TestCase
 from unittest.mock import MagicMock
 
 
@@ -33,6 +34,7 @@ for package_name in (
 logger = MagicMock()
 _module(
     "custom_components.deltadore_tydom.const",
+    DOMAIN="deltadore_tydom",
     LOGGER=logger,
     validate_value_with_metadata=MagicMock(return_value=(True, None)),
 )
@@ -62,6 +64,23 @@ handler_spec.loader.exec_module(handler_module)
 
 MessageHandler = handler_module.MessageHandler
 TydomRemoteControl = devices_module.TydomRemoteControl
+
+migration_name = "custom_components.deltadore_tydom.remote_registry_migration"
+migration_path = (
+    root
+    / "custom_components"
+    / "deltadore_tydom"
+    / "remote_registry_migration.py"
+)
+migration_spec = importlib.util.spec_from_file_location(migration_name, migration_path)
+assert migration_spec is not None and migration_spec.loader is not None
+migration_module = importlib.util.module_from_spec(migration_spec)
+_original_modules.setdefault(
+    migration_name, sys.modules.get(migration_name, _MISSING)
+)
+sys.modules[migration_name] = migration_module
+migration_spec.loader.exec_module(migration_module)
+remove_legacy_remote_endpoint = migration_module.remove_legacy_remote_endpoint
 
 for name, original in _original_modules.items():
     if original is _MISSING:
@@ -287,6 +306,134 @@ class TestRemoteControl(IsolatedAsyncioTestCase):
 
         self.assertEqual(device.event_sequence, 1)
         callback.assert_called_once_with()
+
+
+class _Registry:
+    """Minimal registry used by migration tests."""
+
+    def __init__(self, values) -> None:
+        """Initialise registry values."""
+        self.entities = values
+        self.devices = values
+        self.removed: list[str] = []
+
+    def async_get_device(self, *, identifiers):
+        """Return the device whose identifiers match."""
+        return next(
+            (
+                device
+                for device in self.devices.values()
+                if device.identifiers & identifiers
+            ),
+            None,
+        )
+
+    def async_remove(self, entity_id: str) -> None:
+        """Remove an entity."""
+        self.removed.append(entity_id)
+        self.entities.pop(entity_id)
+
+    def async_remove_device(self, device_id: str) -> None:
+        """Remove a device."""
+        self.removed.append(device_id)
+        self.devices.pop(device_id)
+
+
+class TestRemoteRegistryMigration(TestCase):
+    """Exercise guarded cleanup of obsolete generic endpoints."""
+
+    endpoint_unique_id = "100_100"
+
+    def _device(self, **overrides):
+        device = types.SimpleNamespace(
+            id="legacy-device",
+            identifiers={("deltadore_tydom", self.endpoint_unique_id)},
+            config_entries={"entry"},
+        )
+        for name, value in overrides.items():
+            setattr(device, name, value)
+        return device
+
+    def _entity(self, unique_id: str, **overrides):
+        entity = types.SimpleNamespace(
+            device_id="legacy-device",
+            platform="deltadore_tydom",
+            unique_id=unique_id,
+        )
+        for name, value in overrides.items():
+            setattr(entity, name, value)
+        return entity
+
+    def test_removes_only_expected_generic_entities_and_device(self) -> None:
+        """Known generic records are removed before dedicated entities load."""
+        device_registry = _Registry({"legacy-device": self._device()})
+        entity_registry = _Registry(
+            {
+                "sensor.button": self._entity(
+                    f"{self.endpoint_unique_id}_sensor"
+                ),
+                "sensor.action": self._entity(
+                    f"{self.endpoint_unique_id}_action"
+                ),
+                "sensor.battery": self._entity(
+                    f"{self.endpoint_unique_id}_battDefect"
+                ),
+            }
+        )
+
+        removed = remove_legacy_remote_endpoint(
+            device_registry,
+            entity_registry,
+            "entry",
+            self.endpoint_unique_id,
+        )
+
+        self.assertEqual(
+            removed,
+            ["sensor.button", "sensor.action", "sensor.battery"],
+        )
+        self.assertEqual(device_registry.removed, ["legacy-device"])
+
+    def test_keeps_device_with_unrecognised_entity(self) -> None:
+        """Unexpected entities prevent any destructive migration."""
+        device_registry = _Registry({"legacy-device": self._device()})
+        entity_registry = _Registry(
+            {
+                "sensor.custom": self._entity("custom_unique_id"),
+            }
+        )
+
+        removed = remove_legacy_remote_endpoint(
+            device_registry,
+            entity_registry,
+            "entry",
+            self.endpoint_unique_id,
+        )
+
+        self.assertEqual(removed, [])
+        self.assertEqual(entity_registry.removed, [])
+        self.assertEqual(device_registry.removed, [])
+
+    def test_keeps_device_from_another_config_entry(self) -> None:
+        """Migration cannot touch another configured gateway."""
+        device_registry = _Registry(
+            {
+                "legacy-device": self._device(
+                    config_entries={"another-entry"}
+                )
+            }
+        )
+        entity_registry = _Registry({})
+
+        removed = remove_legacy_remote_endpoint(
+            device_registry,
+            entity_registry,
+            "entry",
+            self.endpoint_unique_id,
+        )
+
+        self.assertEqual(removed, [])
+        self.assertEqual(device_registry.removed, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -1,0 +1,295 @@
+"""Tests for dedicated TYDOM remote-control support."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module required to load the protocol code."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+root = Path(__file__).parents[1]
+devices_name = "custom_components.deltadore_tydom.tydom.tydom_devices"
+devices_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "tydom_devices.py"
+)
+devices_spec = importlib.util.spec_from_file_location(devices_name, devices_path)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(devices_name, sys.modules.get(devices_name, _MISSING))
+sys.modules[devices_name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_name = "custom_components.deltadore_tydom.tydom.MessageHandler"
+handler_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "MessageHandler.py"
+)
+handler_spec = importlib.util.spec_from_file_location(handler_name, handler_path)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(handler_name, sys.modules.get(handler_name, _MISSING))
+sys.modules[handler_name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+TydomRemoteControl = devices_module.TydomRemoteControl
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class TestRemoteControl(IsolatedAsyncioTestCase):
+    """Exercise physical remote and per-button discovery."""
+
+    def setUp(self) -> None:
+        """Reset global protocol metadata."""
+        for mapping_name in (
+            "device_name",
+            "device_type",
+            "device_metadata",
+            "groups_metadata",
+            "groups_data",
+            "endpoint_config",
+            "remote_control_info",
+        ):
+            getattr(handler_module, mapping_name).clear()
+        logger.reset_mock()
+        self.handler = MessageHandler(MagicMock(), b"")
+
+    async def _configure_remote(
+        self,
+        *,
+        device_id: int,
+        group_id: int,
+        group_name: str,
+        tutorial_id: str,
+        button_count: int,
+    ) -> list[int]:
+        """Apply configuration and related-endpoint group payloads."""
+        endpoint_ids = [device_id + (index * 25) for index in range(button_count)]
+        endpoints = [
+            {
+                "id_device": device_id,
+                "id_endpoint": endpoint_id,
+                "name": f"CG_DD_COMMON_BUTTON{index}",
+                "first_usage": "remoteControl",
+                "last_usage": "remoteControl",
+                "widget_behavior": {
+                    "action": "TOGGLE",
+                    "tutorial_id": f"{tutorial_id}_btn_{index}",
+                },
+            }
+            for index, endpoint_id in enumerate(endpoint_ids, start=1)
+        ]
+        await self.handler.parse_config_data(
+            {
+                "endpoints": endpoints,
+                "groups": [
+                    {
+                        "id": group_id,
+                        "name": group_name,
+                        "usage": "remoteControl",
+                        "type": "relatedendpoints",
+                        "widget_behavior": {"tutorial_id": tutorial_id},
+                    }
+                ],
+            },
+            None,
+        )
+
+        group_devices = await self.handler.parse_groups_file(
+            {
+                "groups": [
+                    {
+                        "id": group_id,
+                        "devices": [
+                            {
+                                "id": device_id,
+                                "endpoints": [{"id": value} for value in endpoint_ids],
+                            }
+                        ],
+                    }
+                ]
+            },
+            None,
+        )
+
+        self.assertEqual(group_devices, [])
+        return endpoint_ids
+
+    async def test_tl2000_buttons_share_one_physical_remote(self) -> None:
+        """Two TL 2000 endpoints retain button identity and physical grouping."""
+        device_id = 1693549636
+        endpoint_ids = await self._configure_remote(
+            device_id=device_id,
+            group_id=303212258,
+            group_name="Télécommande Jo",
+            tutorial_id="tl2000",
+            button_count=2,
+        )
+
+        for endpoint_id in endpoint_ids:
+            unique_id = f"{endpoint_id}_{device_id}"
+            handler_module.device_metadata[unique_id] = {
+                "battDefect": {"type": "boolean"},
+                "action": {"type": "string"},
+            }
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": device_id,
+                    "endpoints": [
+                        {
+                            "id": endpoint_id,
+                            "error": 0,
+                            "data": [
+                                {
+                                    "name": "battDefect",
+                                    "validity": "upToDate",
+                                    "value": False,
+                                },
+                                {
+                                    "name": "action",
+                                    "validity": "upToDate",
+                                    "value": "IDLE",
+                                },
+                            ],
+                        }
+                        for endpoint_id in endpoint_ids
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 2)
+        self.assertTrue(all(isinstance(device, TydomRemoteControl) for device in devices))
+        self.assertEqual([device.button_number for device in devices], [1, 2])
+        self.assertEqual(
+            {device.physical_device_id for device in devices}, {str(device_id)}
+        )
+        self.assertEqual(
+            {device.remote_name for device in devices}, {"Télécommande Jo"}
+        )
+        self.assertEqual(
+            {device.remote_model for device in devices}, {"TL 2000 TYXAL+"}
+        )
+
+    async def test_tyxia_1410_has_four_button_endpoints(self) -> None:
+        """TYXIA 1410 discovery exposes four buttons under one remote."""
+        device_id = 1693573310
+        endpoint_ids = await self._configure_remote(
+            device_id=device_id,
+            group_id=1558462107,
+            group_name="Télécommande C3",
+            tutorial_id="rcu_tyxia1410",
+            button_count=4,
+        )
+
+        self.assertEqual(
+            [
+                handler_module.remote_control_info[
+                    f"{endpoint_id}_{device_id}"
+                ]["button_number"]
+                for endpoint_id in endpoint_ids
+            ],
+            [1, 2, 3, 4],
+        )
+        self.assertEqual(
+            {
+                handler_module.remote_control_info[
+                    f"{endpoint_id}_{device_id}"
+                ]["model"]
+                for endpoint_id in endpoint_ids
+            },
+            {"TYXIA 1410"},
+        )
+
+    async def test_only_fresh_non_idle_action_advances_event_sequence(self) -> None:
+        """Polling without a fresh action must not repeat the previous press."""
+        device = TydomRemoteControl(
+            MagicMock(),
+            "endpoint_device",
+            "device",
+            "Button 1",
+            "remoteControl",
+            "endpoint",
+            None,
+            {"action": "IDLE"},
+            {"physical_device_id": "device", "button_number": 1},
+        )
+        callback = MagicMock()
+        device.register_callback(callback)
+
+        pressed = TydomRemoteControl(
+            MagicMock(),
+            "endpoint_device",
+            "device",
+            "Button 1",
+            "remoteControl",
+            "endpoint",
+            None,
+            {"action": "TOGGLE"},
+            {"physical_device_id": "device", "button_number": 1},
+        )
+        await device.update_device(pressed)
+
+        self.assertEqual(device.event_sequence, 1)
+        self.assertEqual(device.action, "TOGGLE")
+        callback.assert_called_once_with()
+
+        callback.reset_mock()
+        expired = TydomRemoteControl(
+            MagicMock(),
+            "endpoint_device",
+            "device",
+            "Button 1",
+            "remoteControl",
+            "endpoint",
+            None,
+            None,
+            {"physical_device_id": "device", "button_number": 1},
+        )
+        await device.update_device(expired)
+
+        self.assertEqual(device.event_sequence, 1)
+        callback.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

`remoteControl` endpoints previously fell back to generic sensors, producing one device per button with raw `CG_DD_COMMON_BUTTON*` names.

This change:

- groups button endpoints under the physical remote using its TYDOM group name;
- identifies TL 2000 TYXAL+ and TYXIA 1410 models from tutorial metadata;
- exposes each button as a Home Assistant event entity with `press_end` and `long_press_end`;
- exposes one shared battery-fault diagnostic per remote;
- removes only the obsolete generic registry entries that match the known endpoint entities, retaining anything unrecognised.

## Evidence

Relevant fields extracted from `/configs/file`; :

```text
group name="<house-keys remote>", usage="remoteControl", tutorial_id="tl2000"
endpoint name="CG_DD_COMMON_BUTTON1", usage="remoteControl", tutorial_id="tl2000_btn_1"

group name="<Citroën C3 remote>", usage="remoteControl", tutorial_id="rcu_tyxia1410"
endpoint name="CG_DD_COMMON_BUTTON1", usage="remoteControl", tutorial_id="rcu_tyxia1410_btn_1"

Unknown usage: remoteControl
```

## Testing

- Tested two-button TL 2000 TYXAL+ and four-button TYXIA 1410 remotes in Home Assistant.
- Confirmed the configured remote names, models, button counts and shared battery diagnostics.
- Confirmed `press_end` from button 1 on both the house-keys and Citroën C3 remotes.
- Confirmed all four real remotes were grouped correctly after restart.
- Added discovery, update de-duplication and guarded registry-migration tests.
- `ruff check custom_components/`
- `ruff format custom_components/ --check`
- 13 tests passed.
