### PR TITLE
Add TYXIA 4910 switch support for the 'other' group usage

### DIFF
--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -21,7 +21,7 @@ from .tydom.tydom_devices import (
     TydomGate,
     TydomGarage,
     TydomLight,
-    TydomOnOffSwitch,
+    TydomSwitch,
     TydomPlug,
     TydomAlarm,
     TydomWeather,
@@ -149,7 +149,7 @@ class Hub:
             TydomGate: self._create_gate_device,
             TydomGarage: self._create_garage_device,
             TydomLight: self._create_light_device,
-            TydomOnOffSwitch: self._create_switch_device,
+            TydomSwitch: self._create_switch_device,
             TydomPlug: self._create_switch_device,
             TydomAlarm: self._create_alarm_device,
             TydomWeather: self._create_weather_device,
@@ -498,7 +498,7 @@ class Hub:
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(ha_device.get_sensors())
 
-    async def _create_switch_device(self, device: TydomPlug | TydomOnOffSwitch) -> None:
+    async def _create_switch_device(self, device: TydomPlug | TydomSwitch) -> None:
         """Create a switch device for a controllable binary output."""
         LOGGER.debug("Create switch %s", device.device_id)
         ha_device = HASwitch(device, self._hass)

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -21,6 +21,7 @@ from .tydom.tydom_devices import (
     TydomGate,
     TydomGarage,
     TydomLight,
+    TydomOnOffSwitch,
     TydomPlug,
     TydomAlarm,
     TydomWeather,
@@ -148,6 +149,7 @@ class Hub:
             TydomGate: self._create_gate_device,
             TydomGarage: self._create_garage_device,
             TydomLight: self._create_light_device,
+            TydomOnOffSwitch: self._create_switch_device,
             TydomPlug: self._create_switch_device,
             TydomAlarm: self._create_alarm_device,
             TydomWeather: self._create_weather_device,
@@ -496,8 +498,8 @@ class Hub:
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(ha_device.get_sensors())
 
-    async def _create_switch_device(self, device: TydomPlug) -> None:
-        """Create switch device for generic third-party plugs (e.g. Hue via Zigbee)."""
+    async def _create_switch_device(self, device: TydomPlug | TydomOnOffSwitch) -> None:
+        """Create a switch device for a controllable binary output."""
         LOGGER.debug("Create switch %s", device.device_id)
         ha_device = HASwitch(device, self._hass)
         self.ha_devices[device.device_id] = ha_device

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -23,6 +23,7 @@ from .tydom_devices import (
     TydomGarage,
     TydomGate,
     TydomLight,
+    TydomOnOffSwitch,
     TydomPlug,
     TydomShutter,
     TydomSmoke,
@@ -53,9 +54,38 @@ device_name = {}
 device_endpoint = {}
 device_type = {}
 device_metadata = {}
+device_tutorial_id = {}
 scenario_metadata = {}  # Store scenario metadata from /configs/file
 groups_metadata = {}  # Store group metadata from /configs/file: {group_id: {"usage": "light", "name": "TOTAL"}}
 groups_data = {}  # Store groups data: {group_id: {"devices": [device_ids], "name": group_name}}
+
+
+def _is_tyxia_4910_other(uid: str) -> bool:
+    """Identify a binary TYXIA 4910 configured under the TYDOM 'others' usage."""
+    if str(device_tutorial_id.get(uid, "")).lower() != "9_tyxia_modulaire_serie4900":
+        return False
+
+    metadata = device_metadata.get(uid)
+    if not isinstance(metadata, dict):
+        return False
+
+    level = metadata.get("level")
+    level_cmd = metadata.get("levelCmd")
+    if not isinstance(level, dict) or not isinstance(level_cmd, dict):
+        return False
+
+    commands = level_cmd.get("enum_values")
+    if not isinstance(commands, list) or not {"ON", "OFF"}.issubset(commands):
+        return False
+
+    try:
+        return (
+            float(level.get("min")) == 0
+            and float(level.get("max")) == 100
+            and float(level.get("step")) == 100
+        )
+    except (TypeError, ValueError):
+        return False
 
 
 class Reply(TypedDict):
@@ -570,6 +600,17 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
+            case "others" if _is_tyxia_4910_other(uid):
+                return TydomOnOffSwitch(
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata.get(uid),
+                    data,
+                )
             case _:
                 LOGGER.info(
                     "Unknown usage : %s for device_id %s, uid %s - creating generic sensor",
@@ -602,6 +643,10 @@ class MessageHandler:
             device_name[device_unique_id] = i["name"]
             device_type[device_unique_id] = i["last_usage"] or "unknown"
             device_endpoint[device_unique_id] = i["id_endpoint"]
+            widget_behavior = i.get("widget_behavior") or {}
+            device_tutorial_id[device_unique_id] = widget_behavior.get(
+                "tutorial_id", ""
+            )
 
             if i["last_usage"] == "alarm":
                 device_name[device_unique_id] = "Tyxal Alarm"

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -23,7 +23,7 @@ from .tydom_devices import (
     TydomGarage,
     TydomGate,
     TydomLight,
-    TydomOnOffSwitch,
+    TydomSwitch,
     TydomPlug,
     TydomShutter,
     TydomSmoke,
@@ -601,7 +601,7 @@ class MessageHandler:
                     data,
                 )
             case "others" if _is_tyxia_4910_other(uid):
-                return TydomOnOffSwitch(
+                return TydomSwitch(
                     tydom_client,
                     uid,
                     device_id,

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -49,16 +49,6 @@ Some firmwares never send an EOR flag; they mark the end of the enumeration
 with a last element carrying index 255 and invalid event data instead.
 """
 
-# Device dict for parsing
-device_name = {}
-device_endpoint = {}
-device_type = {}
-device_metadata = {}
-device_tutorial_id = {}
-scenario_metadata = {}  # Store scenario metadata from /configs/file
-groups_metadata = {}  # Store group metadata from /configs/file: {group_id: {"usage": "light", "name": "TOTAL"}}
-groups_data = {}  # Store groups data: {group_id: {"devices": [device_ids], "name": group_name}}
-
 
 def _is_tyxia_4910_other(uid: str) -> bool:
     """Identify a binary TYXIA 4910 configured under the TYDOM 'others' usage."""
@@ -86,6 +76,17 @@ def _is_tyxia_4910_other(uid: str) -> bool:
         )
     except (TypeError, ValueError):
         return False
+
+
+# Device dict for parsing
+device_name = {}
+device_endpoint = {}
+device_type = {}
+device_metadata = {}
+device_tutorial_id = {}
+scenario_metadata = {}  # Store scenario metadata from /configs/file
+groups_metadata = {}  # Store group metadata from /configs/file: {group_id: {"usage": "light", "name": "TOTAL"}}
+groups_data = {}  # Store groups data: {group_id: {"devices": [device_ids], "name": group_name}}
 
 
 class Reply(TypedDict):
@@ -589,8 +590,8 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
-            case "plug":
-                return TydomPlug(
+            case "others" if _is_tyxia_4910_other(uid):
+                return TydomSwitch(
                     tydom_client,
                     uid,
                     device_id,
@@ -600,8 +601,8 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
-            case "others" if _is_tyxia_4910_other(uid):
-                return TydomSwitch(
+            case "plug":
+                return TydomPlug(
                     tydom_client,
                     uid,
                     device_id,
@@ -639,14 +640,13 @@ class MessageHandler:
             LOGGER.debug(
                 "config_data device parsed : %s - %s", device_unique_id, i["name"]
             )
+            device_tutorial_id[device_unique_id] = (i.get("widget_behavior") or {}).get(
+                "tutorial_id", ""
+            )
 
             device_name[device_unique_id] = i["name"]
             device_type[device_unique_id] = i["last_usage"] or "unknown"
             device_endpoint[device_unique_id] = i["id_endpoint"]
-            widget_behavior = i.get("widget_behavior") or {}
-            device_tutorial_id[device_unique_id] = widget_behavior.get(
-                "tutorial_id", ""
-            )
 
             if i["last_usage"] == "alarm":
                 device_name[device_unique_id] = "Tyxal Alarm"

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -708,7 +708,7 @@ class TydomPlug(TydomDevice):
         )
 
 
-class TydomOnOffSwitch(TydomDevice):
+class TydomSwitch(TydomDevice):
     """Represent a binary TYXIA output configured under the 'others' usage."""
 
     @property

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -708,6 +708,40 @@ class TydomPlug(TydomDevice):
         )
 
 
+class TydomOnOffSwitch(TydomDevice):
+    """Represent a binary TYXIA output configured under the 'others' usage."""
+
+    @property
+    def productName(self) -> str:
+        """Return the model inferred from the binary series-4900 profile."""
+        return getattr(self, "_product_name", "TYXIA 4910")
+
+    @productName.setter
+    def productName(self, value: str) -> None:
+        """Retain a model explicitly supplied by TYDOM."""
+        self._product_name = value
+
+    async def turn_on(self) -> None:
+        """Turn the binary output on."""
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "levelCmd", "ON"
+        )
+        self._schedule_state_refresh()
+
+    async def turn_off(self) -> None:
+        """Turn the binary output off."""
+        await self._tydom_client.put_devices_data(
+            self._id, self._endpoint, "levelCmd", "OFF"
+        )
+        self._schedule_state_refresh()
+
+    def _schedule_state_refresh(self) -> None:
+        """Poll the regular data endpoint after a command."""
+        self._tydom_client.add_poll_device_url_1s(
+            f"/devices/{self._id}/endpoints/{self._endpoint}/data"
+        )
+
+
 class TydomScene(TydomDevice):
     """Represents a scene/scenario."""
 

--- a/tests/test_tyxia_4910.py
+++ b/tests/test_tyxia_4910.py
@@ -63,7 +63,7 @@ handler_spec.loader.exec_module(handler_module)
 MessageHandler = handler_module.MessageHandler
 TydomDevice = devices_module.TydomDevice
 TydomLight = devices_module.TydomLight
-TydomOnOffSwitch = devices_module.TydomOnOffSwitch
+TydomSwitch = devices_module.TydomSwitch
 
 for name, original in _original_modules.items():
     if original is _MISSING:
@@ -155,7 +155,7 @@ class Tyxia4910Tests(IsolatedAsyncioTestCase):
             {"level": 0},
         )
 
-        self.assertIsInstance(device, TydomOnOffSwitch)
+        self.assertIsInstance(device, TydomSwitch)
         self.assertEqual(device.productName, "TYXIA 4910")
         self.assertEqual(device.level, 0)
 

--- a/tests/test_tyxia_4910.py
+++ b/tests/test_tyxia_4910.py
@@ -1,0 +1,226 @@
+"""Tests for a TYXIA 4910 configured under the TYDOM 'others' usage."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load the protocol code in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+protocol_path = (
+    Path(__file__).parents[1] / "custom_components" / "deltadore_tydom" / "tydom"
+)
+devices_name = "custom_components.deltadore_tydom.tydom.tydom_devices"
+devices_spec = importlib.util.spec_from_file_location(
+    devices_name, protocol_path / "tydom_devices.py"
+)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(devices_name, sys.modules.get(devices_name, _MISSING))
+sys.modules[devices_name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_name = "custom_components.deltadore_tydom.tydom.MessageHandler"
+handler_spec = importlib.util.spec_from_file_location(
+    handler_name, protocol_path / "MessageHandler.py"
+)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(handler_name, sys.modules.get(handler_name, _MISSING))
+sys.modules[handler_name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+TydomDevice = devices_module.TydomDevice
+TydomLight = devices_module.TydomLight
+TydomOnOffSwitch = devices_module.TydomOnOffSwitch
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class Tyxia4910Tests(IsolatedAsyncioTestCase):
+    """Exercise the captured binary series-4900 profile."""
+
+    def setUp(self) -> None:
+        """Reset module-level protocol state between tests."""
+        handler_module.device_name.clear()
+        handler_module.device_endpoint.clear()
+        handler_module.device_type.clear()
+        handler_module.device_metadata.clear()
+        handler_module.device_tutorial_id.clear()
+        logger.reset_mock()
+
+    async def _configure(self, *, step: int = 100) -> str:
+        """Install the sanitised configuration and metadata from issue 229."""
+        uid = "20_10"
+        await MessageHandler.parse_config_data(
+            {
+                "endpoints": [
+                    {
+                        "id_device": 10,
+                        "id_endpoint": 20,
+                        "name": "Binary output",
+                        "last_usage": "others",
+                        "widget_behavior": {
+                            "tutorial_id": "9_Tyxia_modulaire_serie4900"
+                        },
+                    }
+                ]
+            },
+            "transaction",
+        )
+        handler = MessageHandler(MagicMock(), b"")
+        await handler.parse_devices_metadata(
+            [
+                {
+                    "id": 10,
+                    "endpoints": [
+                        {
+                            "id": 20,
+                            "metadata": [
+                                {
+                                    "name": "levelCmd",
+                                    "enum_values": [
+                                        "ON",
+                                        "OFF",
+                                        "STOP",
+                                        "FAVORIT1",
+                                        "FAVORIT2",
+                                        "TOGGLE",
+                                    ],
+                                },
+                                {
+                                    "name": "level",
+                                    "min": 0,
+                                    "max": 100,
+                                    "step": step,
+                                    "unit": "%",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "transaction",
+        )
+        return uid
+
+    async def test_binary_other_profile_creates_tyxia_4910_switch(self) -> None:
+        """The captured 'others' profile becomes a controllable switch."""
+        uid = await self._configure()
+        client = MagicMock()
+        client.put_devices_data = AsyncMock()
+
+        device = await MessageHandler.get_device(
+            client,
+            "others",
+            uid,
+            "10",
+            "Binary output",
+            "20",
+            {"level": 0},
+        )
+
+        self.assertIsInstance(device, TydomOnOffSwitch)
+        self.assertEqual(device.productName, "TYXIA 4910")
+        self.assertEqual(device.level, 0)
+
+        await device.turn_on()
+        client.put_devices_data.assert_awaited_once_with("10", "20", "levelCmd", "ON")
+        client.add_poll_device_url_1s.assert_called_once_with(
+            "/devices/10/endpoints/20/data"
+        )
+
+        client.put_devices_data.reset_mock()
+        client.add_poll_device_url_1s.reset_mock()
+        await device.turn_off()
+        client.put_devices_data.assert_awaited_once_with("10", "20", "levelCmd", "OFF")
+        client.add_poll_device_url_1s.assert_called_once_with(
+            "/devices/10/endpoints/20/data"
+        )
+
+    async def test_variable_series_4900_profile_is_not_reclassified(self) -> None:
+        """A series-4900 dimmer is not inferred to be a TYXIA 4910."""
+        uid = await self._configure(step=1)
+
+        device = await MessageHandler.get_device(
+            MagicMock(),
+            "others",
+            uid,
+            "10",
+            "Variable output",
+            "20",
+            {"level": 50},
+        )
+
+        self.assertIs(type(device), TydomDevice)
+
+    async def test_unidentified_other_usage_remains_generic(self) -> None:
+        """Unrelated devices using 'others' continue through generic discovery."""
+        uid = "40_30"
+        handler_module.device_metadata[uid] = {
+            "levelCmd": {"enum_values": ["ON", "OFF"]},
+            "level": {"min": 0, "max": 100, "step": 100},
+        }
+
+        device = await MessageHandler.get_device(
+            MagicMock(),
+            "others",
+            uid,
+            "30",
+            "Unknown output",
+            "40",
+            {"level": 0},
+        )
+
+        self.assertIs(type(device), TydomDevice)
+
+    async def test_light_usage_keeps_existing_light_entity(self) -> None:
+        """A TYXIA 4910 configured as lighting retains the light path."""
+        uid = await self._configure()
+
+        device = await MessageHandler.get_device(
+            MagicMock(),
+            "light",
+            uid,
+            "10",
+            "Lighting output",
+            "20",
+            {"level": 0},
+        )
+
+        self.assertIsInstance(device, TydomLight)


### PR DESCRIPTION
## Summary

Add support for TYXIA 4910 modules configured in the TYDOM application as:

- Category: `Others`
- Function: `On/Off`
- Profile: `light`

These devices currently report `last_usage: others`, so the integration treats them as generic devices rather than controllable entities.

Closes #229.

## Implementation

- Capture `widget_behavior.tutorial_id` from the TYDOM configuration.
- Recognize an `others` endpoint only when it matches the binary series-4900 profile:
  - tutorial ID `9_Tyxia_modulaire_serie4900`
  - `levelCmd` supports `ON` and `OFF`
  - `level` has a range of 0-100 with a step of 100
- Represent the matched endpoint internally as a `TydomSwitch` and expose it through the existing Home Assistant switch entity.
- Send `levelCmd: ON` and `levelCmd: OFF`, then request a state refresh.
- Preserve the existing light behavior when the module is configured under `light`.
- Leave unrelated `others` devices as generic devices.

## Automated testing

Added regression coverage for:

- Detection of the captured binary TYXIA 4910 profile.
- ON and OFF command payloads and post-command refresh.
- Avoiding reclassification of a variable-output series-4900 device.
- Avoiding reclassification of an unidentified `others` device.
- Preserving the existing `light` discovery path.

Results:

```text
pytest tests -q
11 passed
```

Ruff lint, Ruff formatting, and `git diff --check` also pass.

## Manual testing

Tested successfully by @PATGAR64 using:

- Home Assistant Green
- Home Assistant Core 2026.7.4
- aarch64
- Delta Dore Tydom integration v0.27 with the patched integration files

Confirmed behavior:

- The TYXIA 4910 configured under `Others` appears as a switch.
- Its ON/OFF state is displayed correctly.
- Commands from Home Assistant work correctly.
- State changes are reflected correctly in Home Assistant.

Test confirmation: https://github.com/CyrilP/hass-deltadore-tydom-component/issues/229#issuecomment-5104916749

Full redacted debug log: https://github.com/CyrilP/hass-deltadore-tydom-component/issues/229#issuecomment-5105504405

Relevant log excerpts:

```text
Device operation: create | device_id=<redacted> | type=others | name=BCL ECS
Create switch <redacted>
```

The log also confirms the profile used for detection:

```text
last_usage: others
tutorial_id: 9_Tyxia_modulaire_serie4900
levelCmd enum_values: ON, OFF, STOP, FAVORIT1, FAVORIT2, TOGGLE
level: min=0, max=100, step=100
```