### PR TITLE
Allow user-controlled removal of Tydom devices

### DIFF
--- a/custom_components/deltadore_tydom/__init__.py
+++ b/custom_components/deltadore_tydom/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN, Platform
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from . import hub
 from .const import (
@@ -20,6 +21,7 @@ from .const import (
     CONF_REFRESH_INTERVAL,
     LOGGER,
 )
+from .device_removal import can_remove_device
 
 # Config schema for hassfest validation
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -392,6 +394,33 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_entry: DeviceEntry,
+) -> bool:
+    """Allow the user to remove a device owned by this TYDOM config entry."""
+    can_remove = can_remove_device(
+        device_entry,
+        config_entry.entry_id,
+    )
+
+    if can_remove:
+        LOGGER.info(
+            "Allowing user-requested removal of TYDOM device registry entry %s; "
+            "it may be rediscovered if the gateway still advertises it",
+            device_entry.id,
+        )
+    else:
+        LOGGER.warning(
+            "Refusing removal of device registry entry %s because it is not "
+            "owned by this TYDOM config entry",
+            device_entry.id,
+        )
+
+    return can_remove
 
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/deltadore_tydom/device_removal.py
+++ b/custom_components/deltadore_tydom/device_removal.py
@@ -1,0 +1,38 @@
+"""Authorise user-requested removal of TYDOM registry devices."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .const import DOMAIN
+
+
+def _device_config_entry_ids(device_entry: Any) -> set[str]:
+    """Return config entry IDs across old and new device-registry models."""
+    config_entry_id = getattr(device_entry, "config_entry_id", None)
+    if config_entry_id is not None:
+        return {str(config_entry_id)}
+
+    return {
+        str(entry_id) for entry_id in getattr(device_entry, "config_entries", set())
+    }
+
+
+def _tydom_identifier_values(device_entry: Any) -> set[str]:
+    """Return this integration's identifiers from a device-registry entry."""
+    return {
+        str(value)
+        for domain, value in getattr(device_entry, "identifiers", set())
+        if domain == DOMAIN
+    }
+
+
+def can_remove_device(
+    device_entry: Any,
+    config_entry_id: str,
+) -> bool:
+    """Allow the user to remove a device owned by this TYDOM config entry."""
+    if str(config_entry_id) not in _device_config_entry_ids(device_entry):
+        return False
+
+    return bool(_tydom_identifier_values(device_entry))

--- a/tests/test_device_removal.py
+++ b/tests/test_device_removal.py
@@ -1,0 +1,95 @@
+"""Tests for user-controlled removal of TYDOM registry devices."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import TestCase
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load the helper in isolation."""
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in ("custom_components", "custom_components.deltadore_tydom"):
+    package = _module(package_name)
+    package.__path__ = []
+
+_module(
+    "custom_components.deltadore_tydom.const",
+    DOMAIN="deltadore_tydom",
+)
+
+root = Path(__file__).parents[1]
+helper_path = root / "custom_components" / "deltadore_tydom" / "device_removal.py"
+helper_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.device_removal",
+    helper_path,
+)
+assert helper_spec is not None and helper_spec.loader is not None
+helper_module = importlib.util.module_from_spec(helper_spec)
+sys.modules[helper_spec.name] = helper_module
+helper_spec.loader.exec_module(helper_module)
+
+can_remove_device = helper_module.can_remove_device
+
+
+class FakeDeviceEntry:
+    """Minimal Home Assistant device-registry entry."""
+
+    def __init__(
+        self,
+        identifiers: set[tuple[str, str]],
+        config_entries: set[str] | None = None,
+        config_entry_id: str | None = None,
+    ) -> None:
+        """Initialise registry ownership and identifiers."""
+        self.identifiers = identifiers
+        if config_entry_id is not None:
+            self.config_entry_id = config_entry_id
+        else:
+            self.config_entries = config_entries or set()
+
+
+class DeviceRemovalTests(TestCase):
+    """Validate user-requested removal ownership safeguards."""
+
+    def test_allows_integration_owned_device(self) -> None:
+        """An owned device may be removed even while TYDOM still supplies it."""
+        entry = FakeDeviceEntry({("deltadore_tydom", "10_20")}, {"entry"})
+
+        self.assertTrue(can_remove_device(entry, "entry"))
+
+    def test_refuses_device_owned_by_another_config_entry(self) -> None:
+        """One gateway must not approve removal for another gateway."""
+        entry = FakeDeviceEntry({("deltadore_tydom", "30_40")}, {"other"})
+
+        self.assertFalse(can_remove_device(entry, "entry"))
+
+    def test_refuses_entry_without_tydom_identifier(self) -> None:
+        """Unrelated registry entries must never be approved."""
+        entry = FakeDeviceEntry({("another_domain", "30_40")}, {"entry"})
+
+        self.assertFalse(can_remove_device(entry, "entry"))
+
+    def test_supports_single_config_entry_device_registry_model(self) -> None:
+        """The Home Assistant 2026.8 ownership model is also supported."""
+        entry = FakeDeviceEntry(
+            {("deltadore_tydom", "30_40")},
+            config_entry_id="entry",
+        )
+
+        self.assertTrue(can_remove_device(entry, "entry"))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

Home Assistant currently offers only **Disable device** for devices created by this integration. It cannot offer **Remove device** because the integration does not implement Home Assistant's device-removal callback.

This can leave obsolete registry devices that users cannot clean up individually, for example after:

- a device is removed or reconfigured;
- an entity changes domain, such as a cover becoming a button;
- entities are regrouped under another physical device, such as TWC controls moving under Tywell Control;
- an earlier version creates duplicate or entity-less device entries.

Without individual device removal, the only practical way to obtain a clean discovery is to remove the entire TYDOM or Tywell integration entry and add it again. That forces Home Assistant to pull the current device list from scratch, but is unnecessarily disruptive when the user only needs to remove one obsolete or duplicate registry device.

This change implements `async_remove_config_entry_device`, allowing users to remove individual TYDOM devices explicitly through Home Assistant's device menu.

## Changes

- Add Home Assistant's config-entry device-removal callback.
- Authorise removal only when the selected device belongs to the requesting TYDOM config entry and carries a Delta Dore TYDOM registry identifier.
- Support both the existing `config_entries` ownership collection and the single `config_entry_id` model introduced for Home Assistant 2026.8.
- Log accepted and rejected removal requests without exposing installation data.

## Behaviour and limitations

When the user selects **Remove device**:

- Home Assistant removes the selected device and its associated entities from its registries.
- No delete command is sent to the TYDOM gateway or application.
- If the gateway continues to advertise the device, Home Assistant may rediscover and recreate it during a later refresh or restart.
- The existing **Disable device** option remains available.

Removal is available for both entity-bearing and entity-less TYDOM devices, matching the user-controlled behaviour offered by other Home Assistant integrations.

## Safety and scope

Removal is always initiated and confirmed by the user. The integration performs no automatic registry cleanup during setup.

A TYDOM config entry cannot authorise removal of a device belonging to another gateway or integration. This avoids potentially destructive automatic cleanup while still making obsolete entries removable.

## Testing

Four focused automated tests cover:

- removal of an integration-owned device, including one still advertised by TYDOM;
- rejection of a device belonging to another config entry;
- rejection of a registry entry without a TYDOM identifier;
- compatibility with the Home Assistant 2026.8 single-config-entry device model.

Verification results:

- All 11 tests on the standalone branch pass.
- Ruff lint passes.
- Ruff formatting passes.

## Live testing

The feature was deployed on a live Home Assistant installation using the combined TYDOM test runtime.

During testing:

- Home Assistant exposed the **Remove device** action for TYDOM devices.
- 16 user-requested removals were authorised.
- No removals were refused.
- No callback exceptions or device-registry errors occurred.
- No immediate recreation of the removed devices was observed in the logs.

The feature was used to clean up obsolete entity-less device entries left after earlier entity regrouping.