### PR TITLE
Fix metadata-driven climate commands for heating controllers

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -463,6 +463,11 @@ class TydomBoiler(TydomDevice):
                 "coolSetpoint"
             ):
                 return "coolSetpoint"
+            if getattr(self, "useMode", None) in {
+                "MANUAL",
+                "OVERRIDE",
+            } and self._is_writable("overrideSetpoint"):
+                return "overrideSetpoint"
             if self._is_writable("heatSetpoint"):
                 return "heatSetpoint"
         return "setpoint"

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -440,6 +440,33 @@ class TydomBoiler(TydomDevice):
             self._metadata is not None and "authorization" in self._metadata
         ) or hasattr(self, "authorization")
 
+    def _is_writable(self, name: str) -> bool:
+        """Return whether metadata advertises a writable register."""
+        if self._metadata is None:
+            return False
+        register = self._metadata.get(name)
+        return isinstance(register, dict) and "w" in register.get("permission", "")
+
+    def _supports_command_value(self, name: str, value: str) -> bool:
+        """Return whether metadata advertises a writable command value."""
+        command = (self._metadata or {}).get(name)
+        return (
+            self._is_writable(name)
+            and isinstance(command, dict)
+            and value in command.get("enum_values", [])
+        )
+
+    def _temperature_command_name(self) -> str:
+        """Select the writable setpoint register for the current HVAC direction."""
+        if self._uses_zone_authorization():
+            if getattr(self, "authorization", None) == "COOLING" and self._is_writable(
+                "coolSetpoint"
+            ):
+                return "coolSetpoint"
+            if self._is_writable("heatSetpoint"):
+                return "heatSetpoint"
+        return "setpoint"
+
     async def set_hvac_mode(self, mode):
         """Set hvac mode (ANTI_FROST/NORMAL/STOP)."""
         LOGGER.debug("setting hvac mode to %s", mode)
@@ -460,6 +487,13 @@ class TydomBoiler(TydomDevice):
             return
 
         if self._uses_zone_authorization():
+            command_mode = "HEATING" if mode == "NORMAL" else mode
+            if self._supports_command_value("comfortMode", command_mode):
+                await self._tydom_client.put_devices_data(
+                    self._id, self._endpoint, "comfortMode", command_mode
+                )
+                return
+
             if mode == "STOP":
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "thermicLevel", "STOP"
@@ -574,7 +608,9 @@ class TydomBoiler(TydomDevice):
     async def set_temperature(self, temperature):
         """Set target temperature."""
         setpoint_attribute = (
-            self.area_setpoint_attribute() if hasattr(self, "area_id") else "setpoint"
+            self.area_setpoint_attribute()
+            if hasattr(self, "area_id")
+            else self._temperature_command_name()
         )
         # Validate value with metadata
         is_valid, error_msg = validate_value_with_metadata(
@@ -593,7 +629,7 @@ class TydomBoiler(TydomDevice):
             )
         else:
             await self._tydom_client.put_devices_data(
-                self._id, self._endpoint, "setpoint", temperature
+                self._id, self._endpoint, setpoint_attribute, temperature
             )
 
     async def set_thermic_level(self, level):

--- a/tests/test_tyxia_1137_controls.py
+++ b/tests/test_tyxia_1137_controls.py
@@ -1,0 +1,211 @@
+"""Tests for metadata-driven TYXIA 1137 climate commands."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load device code in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+
+def _validate_value(device, attribute_name, value, metadata=None):
+    """Validate the numeric range needed by these tests."""
+    metadata = metadata or device._metadata
+    attribute = metadata.get(attribute_name, {}) if metadata else {}
+    numeric_value = float(value)
+    if "min" in attribute and numeric_value < attribute["min"]:
+        return False, "below minimum"
+    if "max" in attribute and numeric_value > attribute["max"]:
+        return False, "above maximum"
+    return True, None
+
+
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=MagicMock(),
+    validate_value_with_metadata=_validate_value,
+)
+
+devices_path = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "deltadore_tydom"
+    / "tydom"
+    / "tydom_devices.py"
+)
+devices_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.tydom.tydom_devices", devices_path
+)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(
+    devices_spec.name, sys.modules.get(devices_spec.name, _MISSING)
+)
+sys.modules[devices_spec.name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+TydomBoiler = devices_module.TydomBoiler
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+def _metadata() -> dict[str, dict]:
+    """Return the relevant metadata captured from the issue #355 device."""
+    return {
+        "authorization": {
+            "permission": "r",
+            "enum_values": ["STOP", "HEATING"],
+        },
+        "comfortMode": {
+            "permission": "w",
+            "enum_values": ["STOP", "HEATING"],
+        },
+        "heatSetpoint": {
+            "permission": "rw",
+            "type": "numeric",
+            "min": 5.0,
+            "max": 30.0,
+        },
+        "setpoint": {
+            "permission": "rw",
+            "type": "numeric",
+            "min": 5.0,
+            "max": 30.0,
+        },
+        "thermicLevel": {
+            "permission": "rw",
+            "enum_values": ["STOP", "NO_REGUL", "ANTI_FROST"],
+        },
+    }
+
+
+def _boiler(
+    metadata: dict[str, dict] | None = None,
+    data: dict[str, object] | None = None,
+) -> tuple[object, AsyncMock]:
+    """Create a boiler with a mocked TYDOM client."""
+    client = AsyncMock()
+    boiler = TydomBoiler(
+        client,
+        "1715082810_1715082810",
+        "1715082810",
+        "TYXIA 1137",
+        "boiler",
+        "1715082810",
+        metadata,
+        data,
+    )
+    return boiler, client
+
+
+class Tyxia1137ControlTests(IsolatedAsyncioTestCase):
+    """Validate the command registers exposed by the TYXIA 1137."""
+
+    async def test_stop_uses_writable_comfort_mode(self) -> None:
+        """OFF must use comfortMode rather than the live thermicLevel state."""
+        boiler, client = _boiler(_metadata(), {"authorization": "HEATING"})
+
+        await boiler.set_hvac_mode("STOP")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "comfortMode", "STOP"
+        )
+        client.put_home_hvac_mode.assert_not_awaited()
+
+    async def test_heat_uses_writable_comfort_mode(self) -> None:
+        """HEAT must use the device command paired with authorization."""
+        boiler, client = _boiler(_metadata(), {"authorization": "STOP"})
+
+        await boiler.set_hvac_mode("NORMAL")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "comfortMode", "HEATING"
+        )
+        client.put_home_hvac_mode.assert_not_awaited()
+
+    async def test_temperature_uses_heat_setpoint(self) -> None:
+        """Heating targets must be written to the advertised heatSetpoint."""
+        boiler, client = _boiler(_metadata(), {"authorization": "HEATING"})
+
+        await boiler.set_temperature("20.0")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "heatSetpoint", "20.0"
+        )
+
+    async def test_existing_generic_setpoint_path_is_preserved(self) -> None:
+        """Devices without zone authorisation must retain generic setpoint."""
+        metadata = {
+            "setpoint": {
+                "permission": "rw",
+                "type": "numeric",
+                "min": 5.0,
+                "max": 30.0,
+            }
+        }
+        boiler, client = _boiler(metadata, {})
+
+        await boiler.set_temperature("20.0")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "setpoint", "20.0"
+        )
+
+    async def test_read_only_heat_setpoint_is_not_used_as_a_command(self) -> None:
+        """A reported-only heatSetpoint must not replace writable setpoint."""
+        metadata = _metadata()
+        metadata["heatSetpoint"]["permission"] = "r"
+        boiler, client = _boiler(metadata, {"authorization": "HEATING"})
+
+        await boiler.set_temperature("20.0")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "setpoint", "20.0"
+        )
+
+    async def test_existing_zone_fallback_is_preserved(self) -> None:
+        """Zones without a writable comfortMode keep their existing route."""
+        metadata = _metadata()
+        metadata.pop("comfortMode")
+        boiler, client = _boiler(metadata, {"authorization": "HEATING"})
+
+        await boiler.set_hvac_mode("STOP")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "thermicLevel", "STOP"
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/test_tyxia_1137_controls.py
+++ b/tests/test_tyxia_1137_controls.py
@@ -101,6 +101,12 @@ def _metadata() -> dict[str, dict]:
             "min": 5.0,
             "max": 30.0,
         },
+        "overrideSetpoint": {
+            "permission": "rw",
+            "type": "numeric",
+            "min": 5.0,
+            "max": 30.0,
+        },
         "thermicLevel": {
             "permission": "rw",
             "enum_values": ["STOP", "NO_REGUL", "ANTI_FROST"],
@@ -152,9 +158,51 @@ class Tyxia1137ControlTests(IsolatedAsyncioTestCase):
         )
         client.put_home_hvac_mode.assert_not_awaited()
 
-    async def test_temperature_uses_heat_setpoint(self) -> None:
-        """Heating targets must be written to the advertised heatSetpoint."""
-        boiler, client = _boiler(_metadata(), {"authorization": "HEATING"})
+    async def test_manual_temperature_uses_override_setpoint(self) -> None:
+        """Manual targets must use the writable override register."""
+        boiler, client = _boiler(
+            _metadata(), {"authorization": "HEATING", "useMode": "MANUAL"}
+        )
+
+        await boiler.set_temperature("20.0")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "overrideSetpoint", "20.0"
+        )
+
+    async def test_active_override_uses_override_setpoint(self) -> None:
+        """An active timed override must continue through its override register."""
+        boiler, client = _boiler(
+            _metadata(), {"authorization": "HEATING", "useMode": "OVERRIDE"}
+        )
+
+        await boiler.set_temperature("20.0")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "overrideSetpoint", "20.0"
+        )
+
+    async def test_scheduled_temperature_keeps_heat_setpoint(self) -> None:
+        """Scheduled heating targets must retain the advertised heat register."""
+        boiler, client = _boiler(
+            _metadata(), {"authorization": "HEATING", "useMode": "SCHED"}
+        )
+
+        await boiler.set_temperature("20.0")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "1715082810", "1715082810", "heatSetpoint", "20.0"
+        )
+
+    async def test_read_only_override_setpoint_falls_back_to_heat_setpoint(
+        self,
+    ) -> None:
+        """A reported-only override register must not be used as a command."""
+        metadata = _metadata()
+        metadata["overrideSetpoint"]["permission"] = "r"
+        boiler, client = _boiler(
+            metadata, {"authorization": "HEATING", "useMode": "MANUAL"}
+        )
 
         await boiler.set_temperature("20.0")
 


### PR DESCRIPTION
## Summary

Fix climate commands for heating controllers which expose separate state, scheduled setpoint and manual override registers, such as the TYXIA 1137 reported in #355.

The implementation is capability-driven and contains no model names, device identifiers or endpoint-specific behaviour.

Fixes #355.

## Problem

The metadata and real-device tests supplied in #355 show that this controller exposes:

- `authorization` as its read-only `STOP`/`HEATING` state;
- `comfortMode` as its writable `STOP`/`HEATING` command;
- `heatSetpoint` as a writable heating setpoint;
- `overrideSetpoint` as a writable manual override setpoint;
- `useMode` to identify whether the controller is scheduled or manually overridden.

The integration previously sent `thermicLevel=STOP` and the generic `setpoint` command. Those requests could receive HTTP 200 without being applied by the controller.

Testing on the reported TYXIA 1137 confirmed that `comfortMode` correctly controls heating and stop in both directions. A subsequent `heatSetpoint=20.0` request was accepted by the gateway but not applied by the device.

A capture of the same change from the official Tydom application then showed `heatSetpoint`, `setpoint` and `overrideSetpoint` being updated together while the controller reported `useMode=MANUAL`. This PR therefore selects the explicit writable override register for manual operation rather than assuming that the normal heating setpoint is always the active command.

## Changes

- Detect writable command registers from each device's metadata.
- Use `comfortMode=STOP` and `comfortMode=HEATING` when those values are advertised as writable.
- Use writable `overrideSetpoint` when `useMode` is `MANUAL` or `OVERRIDE`.
- Retain writable `heatSetpoint` for scheduled heating operation.
- Use writable `coolSetpoint` for cooling when applicable.
- Fall back to the existing generic `setpoint`, `thermicLevel` and home HVAC routes when the more specific capabilities are unavailable.
- Validate temperatures against the metadata for the register which will actually be written.
- Preserve the existing `/areas` command path for area-backed Tywell Control climates.

## Compatibility

Command selection is based on TYDOM metadata and live state rather than the TYXIA 1137 model name. The selected register must be writable, and mode commands must include the requested value in their advertised enumeration.

Devices which do not expose these capabilities retain their existing paths. Other heating controllers exposing the same protocol capabilities can therefore use the correction without appliance-specific hard-coding.

## Testing

Added nine regression tests covering:

- heating to stop through writable `comfortMode`;
- stop to heating through writable `comfortMode`;
- manual and override targets through `overrideSetpoint`;
- scheduled targets through `heatSetpoint`;
- fallback from a read-only `overrideSetpoint` to `heatSetpoint`;
- retention of the generic `setpoint` path;
- rejection of a read-only `heatSetpoint` as a command register;
- retention of the existing `thermicLevel` fallback.

Local validation after rebasing onto v0.28:

- 65 repository tests passed;
- Ruff checks passed for the changed files;
- Ruff formatting passed for the changed files;
- `git diff --check` passed.

### Real-device validation

The correction was tested on the TYXIA 1137 reported in #355 using Tydom 4.20.2 and the v0.28 combined test branch.

The reporter confirmed:

- heating → stop works in Home Assistant, on the TYXIA 1137 and in the Tydom application;
- stop → heating works in all three places;
- changing the target from 19 °C to 20 °C remains stable in Home Assistant;
- the 20 °C target remains stable after switching off and back to heating;
- the physical TYXIA 1137 and the Tydom application both retain the 20 °C target;
- non-regression checks across the reporter's other integration devices passed.

Sanitised extracts from the supplied debug logs show the commands and resulting device state. Device and endpoint identifiers have been removed:

```text
2026-07-31 15:09:46.687 Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=HEATING
2026-07-31 15:09:46.955 Device data: authorization=HEATING

2026-07-31 15:09:57.140 Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=STOP
2026-07-31 15:09:57.405 Device data: authorization=STOP

2026-07-31 15:10:01.864 Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=HEATING
2026-07-31 15:10:02.131 Device data: authorization=HEATING

2026-08-01 12:11:26.377 Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=overrideSetpoint, value=20.0
2026-08-01 12:11:27.748 Device data: heatSetpoint=20.0, setpoint=20.0, overrideSetpoint=20.0
```

Each command also received an HTTP 200 acknowledgement from TYDOM. The reporter considers the issue resolved following these tests.