### PR TITLE
Add area-backed climate support for TRV 1.0 thermostats

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2313,6 +2313,7 @@ class HaClimate(ClimateEntity, HAEntity):
         self._device._ha_device = self
         self._attr_unique_id = f"{self._device.device_id}_climate"
         self._attr_name = "Thermostat" if self._device.is_derived_area_climate else None
+        self._is_area_trv = self._device.is_area_trv
         self._enable_turn_on_off_backwards_compatibility = False
 
         self.dict_modes_ha_to_dd = {
@@ -2544,6 +2545,22 @@ class HaClimate(ClimateEntity, HAEntity):
         if self._supports_fan:
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 
+        if self._is_area_trv:
+            self._attr_hvac_modes = [HVACMode.HEAT]
+            self._attr_preset_modes = []
+            self._attr_fan_modes = []
+            self._supports_fan = False
+            self._attr_supported_features &= ~(
+                ClimateEntityFeature.TURN_OFF
+                | ClimateEntityFeature.TURN_ON
+                | ClimateEntityFeature.PRESET_MODE
+                | ClimateEntityFeature.FAN_MODE
+            )
+            # The reporter's physical TRV endpoints do not include
+            # localSetpoint metadata, but the linked area still accepts the
+            # local override command.
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+
     def get_sensors(self):
         """Avoid duplicating the source controller's sensors on area proxies."""
         if self._device.is_derived_area_climate:
@@ -2611,6 +2628,9 @@ class HaClimate(ClimateEntity, HAEntity):
 
     def _resolve_hvac_mode(self) -> HVACMode:
         """Derive HA HVAC mode from Tydom thermostat registers."""
+        if self._is_area_trv:
+            return HVACMode.HEAT
+
         if getattr(self, "_is_filpilote", False):
             # Derive from thermicLevel (the live pilot-wire order), not hvacMode:
             # the app/schedule set thermicLevel while hvacMode stays NORMAL.
@@ -2656,6 +2676,13 @@ class HaClimate(ClimateEntity, HAEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running action."""
+        if self._is_area_trv:
+            return (
+                HVACAction.HEATING
+                if getattr(self._device, "waterFlowReq", False)
+                else HVACAction.IDLE
+            )
+
         if getattr(self, "_is_filpilote", False):
             # No temperature feedback exists, so we cannot distinguish heating
             # from idle: report OFF when the order is STOP, HEATING otherwise.
@@ -2682,6 +2709,12 @@ class HaClimate(ClimateEntity, HAEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
+        if self._is_area_trv:
+            for attribute in ("regTemperature", "devTemperature"):
+                temperature = getattr(self._device, attribute, None)
+                if temperature is not None:
+                    return float(temperature)
+
         if hasattr(self._device, "temperature"):
             temp = getattr(self._device, "temperature", None)
             if temp is not None:
@@ -2747,6 +2780,9 @@ class HaClimate(ClimateEntity, HAEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
+        if self._is_area_trv:
+            return
+
         if getattr(self, "_is_filpilote", False):
             # OFF -> pilot-wire STOP. HEAT -> keep the current heating order, or
             # default to Comfort when coming from STOP; the level is chosen via

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2315,6 +2315,7 @@ class HaClimate(ClimateEntity, HAEntity):
         self._device._ha_device = self
         self._attr_unique_id = f"{self._device.device_id}_climate"
         self._attr_name = "Thermostat" if self._device.is_derived_area_climate else None
+        self._is_area_trv = self._device.is_area_trv
         self._enable_turn_on_off_backwards_compatibility = False
 
         self.dict_modes_ha_to_dd = {
@@ -2546,6 +2547,22 @@ class HaClimate(ClimateEntity, HAEntity):
         if self._supports_fan:
             self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
 
+        if self._is_area_trv:
+            self._attr_hvac_modes = [HVACMode.HEAT]
+            self._attr_preset_modes = []
+            self._attr_fan_modes = []
+            self._supports_fan = False
+            self._attr_supported_features &= ~(
+                ClimateEntityFeature.TURN_OFF
+                | ClimateEntityFeature.TURN_ON
+                | ClimateEntityFeature.PRESET_MODE
+                | ClimateEntityFeature.FAN_MODE
+            )
+            # The reporter's physical TRV endpoints do not include
+            # localSetpoint metadata, but the linked area still accepts the
+            # local override command.
+            self._attr_supported_features |= ClimateEntityFeature.TARGET_TEMPERATURE
+
     def get_sensors(self):
         """Avoid duplicating the source controller's sensors on area proxies."""
         if self._device.is_derived_area_climate:
@@ -2613,6 +2630,9 @@ class HaClimate(ClimateEntity, HAEntity):
 
     def _resolve_hvac_mode(self) -> HVACMode:
         """Derive HA HVAC mode from Tydom thermostat registers."""
+        if self._is_area_trv:
+            return HVACMode.HEAT
+
         if getattr(self, "_is_filpilote", False):
             # Derive from thermicLevel (the live pilot-wire order), not hvacMode:
             # the app/schedule set thermicLevel while hvacMode stays NORMAL.
@@ -2658,6 +2678,13 @@ class HaClimate(ClimateEntity, HAEntity):
     @property
     def hvac_action(self) -> HVACAction | None:
         """Return the current running action."""
+        if self._is_area_trv:
+            return (
+                HVACAction.HEATING
+                if getattr(self._device, "waterFlowReq", False)
+                else HVACAction.IDLE
+            )
+
         if getattr(self, "_is_filpilote", False):
             # No temperature feedback exists, so we cannot distinguish heating
             # from idle: report OFF when the order is STOP, HEATING otherwise.
@@ -2684,6 +2711,12 @@ class HaClimate(ClimateEntity, HAEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
+        if self._is_area_trv:
+            for attribute in ("regTemperature", "devTemperature"):
+                temperature = getattr(self._device, attribute, None)
+                if temperature is not None:
+                    return float(temperature)
+
         if hasattr(self._device, "temperature"):
             temp = getattr(self._device, "temperature", None)
             if temp is not None:
@@ -2749,6 +2782,9 @@ class HaClimate(ClimateEntity, HAEntity):
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target hvac mode."""
+        if self._is_area_trv:
+            return
+
         if getattr(self, "_is_filpilote", False):
             # OFF -> pilot-wire STOP. HEAT -> keep the current heating order, or
             # default to Comfort when coming from STOP; the level is chosen via

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1377,7 +1377,20 @@ class TydomClient:
 
     async def put_area_data(self, area_id, name, value, max_retries: int = 2) -> int:
         """Set one attribute on an area-backed device."""
-        body = json.dumps([{"name": name, "value": value}])
+        return await self.put_area_data_attributes(
+            area_id, {name: value}, max_retries=max_retries
+        )
+
+    async def put_area_data_attributes(
+        self,
+        area_id,
+        attributes: dict,
+        max_retries: int = 2,
+    ) -> int:
+        """Set one or more attributes atomically on an area-backed device."""
+        body = json.dumps(
+            [{"name": name, "value": value} for name, value in attributes.items()]
+        )
         safe_area_id = quote(str(area_id), safe="")
         path = f"/areas/{safe_area_id}/data"
         str_request = (
@@ -1389,10 +1402,9 @@ class TydomClient:
         )
         a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
         LOGGER.debug(
-            "Sending area command: area_id=%s, name=%s, value=%s",
+            "Sending area command: area_id=%s, attributes=%s",
             area_id,
-            name,
-            value,
+            list(attributes),
         )
         if not file_mode:
             await self.send_bytes(a_bytes, max_retries=max_retries)

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1373,7 +1373,20 @@ class TydomClient:
 
     async def put_area_data(self, area_id, name, value, max_retries: int = 2) -> int:
         """Set one attribute on an area-backed device."""
-        body = json.dumps([{"name": name, "value": value}])
+        return await self.put_area_data_attributes(
+            area_id, {name: value}, max_retries=max_retries
+        )
+
+    async def put_area_data_attributes(
+        self,
+        area_id,
+        attributes: dict,
+        max_retries: int = 2,
+    ) -> int:
+        """Set one or more attributes atomically on an area-backed device."""
+        body = json.dumps(
+            [{"name": name, "value": value} for name, value in attributes.items()]
+        )
         safe_area_id = quote(str(area_id), safe="")
         path = f"/areas/{safe_area_id}/data"
         str_request = (
@@ -1385,10 +1398,9 @@ class TydomClient:
         )
         a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
         LOGGER.debug(
-            "Sending area command: area_id=%s, name=%s, value=%s",
+            "Sending area command: area_id=%s, attributes=%s",
             area_id,
-            name,
-            value,
+            list(attributes),
         )
         if not file_mode:
             await self.send_bytes(a_bytes, max_retries=max_retries)

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -589,6 +589,11 @@ class TydomBoiler(TydomDevice):
     """Represents a Boiler."""
 
     @property
+    def is_area_trv(self) -> bool:
+        """Return whether this is a radiator thermostat linked to an area."""
+        return self._type == "sh_hvac" and hasattr(self, "area_id")
+
+    @property
     def is_derived_area_climate(self) -> bool:
         """Return whether this climate proxies a passive controller's area."""
         return self.device_id.endswith("_area_climate")
@@ -603,7 +608,14 @@ class TydomBoiler(TydomDevice):
     def area_setpoint_attribute(self) -> str:
         """Return the setpoint register advertised for the current area mode."""
         authorization = getattr(self, "authorization", None)
-        if authorization == "COOLING":
+        if self.is_area_trv:
+            candidates = (
+                "currentSetpoint",
+                "localSetpoint",
+                "masterAbsSetpoint",
+                "masterSchedSetpoint",
+            )
+        elif authorization == "COOLING":
             candidates = ("coolSetpoint", "setpoint", "heatSetpoint")
         elif authorization == "HEATING":
             candidates = ("heatSetpoint", "setpoint", "coolSetpoint")
@@ -624,6 +636,17 @@ class TydomBoiler(TydomDevice):
         """Return live area limits, falling back to controller metadata."""
         if not hasattr(self, "area_id"):
             return (None, None)
+
+        if self.is_area_trv:
+            local_setpoint = (self._metadata or {}).get("localSetpoint", {})
+            return (
+                float(local_setpoint["min"])
+                if local_setpoint.get("min") is not None
+                else None,
+                float(local_setpoint["max"])
+                if local_setpoint.get("max") is not None
+                else None,
+            )
 
         authorization = getattr(self, "authorization", None)
         if authorization == "COOLING":
@@ -677,6 +700,10 @@ class TydomBoiler(TydomDevice):
         if not hasattr(self, "area_id"):
             return None
 
+        if self.is_area_trv:
+            step = (self._metadata or {}).get("localSetpoint", {}).get("step")
+            return float(step) if step is not None else None
+
         authorization = getattr(self, "authorization", None)
         if authorization == "COOLING":
             metadata_names = ("coolSetpoint", "setpoint")
@@ -700,6 +727,9 @@ class TydomBoiler(TydomDevice):
         """Return the HVAC modes advertised by an area-backed thermostat."""
         if not hasattr(self, "area_id"):
             return set()
+
+        if self.is_area_trv:
+            return {"HEATING"}
 
         # A linked thermal receiver always provides stop and heating. Cooling is
         # exposed only when TYDOM reports it in metadata or live state.
@@ -759,6 +789,15 @@ class TydomBoiler(TydomDevice):
         LOGGER.debug("setting hvac mode to %s", mode)
         # Mode changes must not clear or replace the setpoint. TYDOM retains
         # the user's last setpoint and restores it when heating resumes.
+        if self.is_area_trv:
+            if mode not in ("NORMAL", "HEATING"):
+                LOGGER.warning(
+                    "Area TRV %s does not support individual HVAC mode %s",
+                    self.device_id,
+                    mode,
+                )
+            return
+
         if hasattr(self, "area_id"):
             area_modes = {
                 "NORMAL": "HEATING",
@@ -880,6 +919,26 @@ class TydomBoiler(TydomDevice):
 
     async def set_temperature(self, temperature):
         """Set target temperature."""
+        if self.is_area_trv:
+            is_valid, error_msg = validate_value_with_metadata(
+                self, "localSetpoint", temperature
+            )
+            if not is_valid:
+                from homeassistant.exceptions import HomeAssistantError
+
+                raise HomeAssistantError(
+                    error_msg or f"Température invalide: {temperature}"
+                )
+            await self._tydom_client.put_area_data_attributes(
+                self.area_id,
+                {
+                    "localSetpoint": temperature,
+                    "localSetpRemainingTimeStr": "UNTIL_SCHED",
+                    "localMode": "LOCAL_SETPOINT",
+                },
+            )
+            return
+
         setpoint_attribute = (
             self.area_setpoint_attribute()
             if hasattr(self, "area_id")

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -599,6 +599,11 @@ class TydomBoiler(TydomDevice):
     """Represents a Boiler."""
 
     @property
+    def is_area_trv(self) -> bool:
+        """Return whether this is a radiator thermostat linked to an area."""
+        return self._type == "sh_hvac" and hasattr(self, "area_id")
+
+    @property
     def is_derived_area_climate(self) -> bool:
         """Return whether this climate proxies a passive controller's area."""
         return self.device_id.endswith("_area_climate")
@@ -613,7 +618,14 @@ class TydomBoiler(TydomDevice):
     def area_setpoint_attribute(self) -> str:
         """Return the setpoint register advertised for the current area mode."""
         authorization = getattr(self, "authorization", None)
-        if authorization == "COOLING":
+        if self.is_area_trv:
+            candidates = (
+                "currentSetpoint",
+                "localSetpoint",
+                "masterAbsSetpoint",
+                "masterSchedSetpoint",
+            )
+        elif authorization == "COOLING":
             candidates = ("coolSetpoint", "setpoint", "heatSetpoint")
         elif authorization == "HEATING":
             candidates = ("heatSetpoint", "setpoint", "coolSetpoint")
@@ -634,6 +646,17 @@ class TydomBoiler(TydomDevice):
         """Return live area limits, falling back to controller metadata."""
         if not hasattr(self, "area_id"):
             return (None, None)
+
+        if self.is_area_trv:
+            local_setpoint = (self._metadata or {}).get("localSetpoint", {})
+            return (
+                float(local_setpoint["min"])
+                if local_setpoint.get("min") is not None
+                else None,
+                float(local_setpoint["max"])
+                if local_setpoint.get("max") is not None
+                else None,
+            )
 
         authorization = getattr(self, "authorization", None)
         if authorization == "COOLING":
@@ -687,6 +710,10 @@ class TydomBoiler(TydomDevice):
         if not hasattr(self, "area_id"):
             return None
 
+        if self.is_area_trv:
+            step = (self._metadata or {}).get("localSetpoint", {}).get("step")
+            return float(step) if step is not None else None
+
         authorization = getattr(self, "authorization", None)
         if authorization == "COOLING":
             metadata_names = ("coolSetpoint", "setpoint")
@@ -710,6 +737,9 @@ class TydomBoiler(TydomDevice):
         """Return the HVAC modes advertised by an area-backed thermostat."""
         if not hasattr(self, "area_id"):
             return set()
+
+        if self.is_area_trv:
+            return {"HEATING"}
 
         # A linked thermal receiver always provides stop and heating. Cooling is
         # exposed only when TYDOM reports it in metadata or live state.
@@ -769,6 +799,15 @@ class TydomBoiler(TydomDevice):
         LOGGER.debug("setting hvac mode to %s", mode)
         # Mode changes must not clear or replace the setpoint. TYDOM retains
         # the user's last setpoint and restores it when heating resumes.
+        if self.is_area_trv:
+            if mode not in ("NORMAL", "HEATING"):
+                LOGGER.warning(
+                    "Area TRV %s does not support individual HVAC mode %s",
+                    self.device_id,
+                    mode,
+                )
+            return
+
         if hasattr(self, "area_id"):
             area_modes = {
                 "NORMAL": "HEATING",
@@ -890,6 +929,26 @@ class TydomBoiler(TydomDevice):
 
     async def set_temperature(self, temperature):
         """Set target temperature."""
+        if self.is_area_trv:
+            is_valid, error_msg = validate_value_with_metadata(
+                self, "localSetpoint", temperature
+            )
+            if not is_valid:
+                from homeassistant.exceptions import HomeAssistantError
+
+                raise HomeAssistantError(
+                    error_msg or f"Température invalide: {temperature}"
+                )
+            await self._tydom_client.put_area_data_attributes(
+                self.area_id,
+                {
+                    "localSetpoint": temperature,
+                    "localSetpRemainingTimeStr": "UNTIL_SCHED",
+                    "localMode": "LOCAL_SETPOINT",
+                },
+            )
+            return
+
         setpoint_attribute = (
             self.area_setpoint_attribute()
             if hasattr(self, "area_id")

--- a/tests/test_area_thermostats.py
+++ b/tests/test_area_thermostats.py
@@ -118,6 +118,43 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         )
         return devices[0]
 
+    async def _discover_trv(self, metadata: dict | None = None):
+        """Return an area-linked TRV matching the issue #259 protocol shape."""
+        handler_module.device_name["10_20"] = "Radiator head"
+        handler_module.device_type["10_20"] = "sh_hvac"
+        handler_module.device_metadata["10_20"] = metadata or {
+            "regTemperature": {"permission": "r"},
+            "waterFlowReq": {"permission": "r"},
+        }
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "link": {"type": "area", "id": 7},
+                            "data": [
+                                {
+                                    "name": "regTemperature",
+                                    "value": 19.25,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "waterFlowReq",
+                                    "value": True,
+                                    "validity": "upToDate",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            None,
+        )
+        return devices[0]
+
     async def test_area_link_discovers_re2020_thermostat(self) -> None:
         """The linked endpoint is retained as an area-backed boiler."""
         device = await self._discover()
@@ -748,6 +785,67 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         self.assertEqual(devices[0].device_id, "10_20")
         self.assertEqual(devices[0].authorization, "HEATING")
         self.assertEqual(devices[0].setpoint, 21.0)
+
+    async def test_trv_uses_shared_area_state_routing(self) -> None:
+        """TRV target state follows its area while retaining physical identity."""
+        trv = await self._discover_trv()
+
+        devices = await self.handler.parse_areas_data(
+            [
+                {
+                    "id": 7,
+                    "data": [
+                        {
+                            "name": "currentSetpoint",
+                            "value": 20.5,
+                            "validity": "upToDate",
+                        }
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertTrue(trv.is_area_trv)
+        self.assertEqual(trv.area_hvac_modes(), {"HEATING"})
+        self.assertEqual(trv.regTemperature, 19.25)
+        self.assertTrue(trv.waterFlowReq)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].device_id, trv.device_id)
+        self.assertEqual(devices[0].area_setpoint_attribute(), "currentSetpoint")
+        self.assertEqual(devices[0].currentSetpoint, 20.5)
+
+    async def test_trv_override_does_not_require_local_setpoint_metadata(self) -> None:
+        """Issue #259 TRVs can set a target without device-level area metadata."""
+        trv = await self._discover_trv()
+        self.client.put_area_data_attributes = AsyncMock()
+
+        await trv.set_temperature("20.5")
+
+        self.client.put_area_data_attributes.assert_awaited_once_with(
+            "7",
+            {
+                "localSetpoint": "20.5",
+                "localSetpRemainingTimeStr": "UNTIL_SCHED",
+                "localMode": "LOCAL_SETPOINT",
+            },
+        )
+
+    async def test_trv_uses_local_setpoint_limits_when_advertised(self) -> None:
+        """Optional TRV metadata controls the Home Assistant range and step."""
+        trv = await self._discover_trv(
+            {
+                "localSetpoint": {
+                    "permission": "rw",
+                    "min": 5.0,
+                    "max": 30.0,
+                    "step": 0.5,
+                }
+            }
+        )
+
+        self.assertEqual(trv.area_temperature_limits(), (5.0, 30.0))
+        self.assertEqual(trv.area_temperature_step(), 0.5)
 
     async def test_single_area_uri_is_routed_as_area_data(self) -> None:
         """A pushed /areas/{id}/data update must not enter the device parser."""

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -570,6 +570,30 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         client._reconnect_with_backoff.assert_awaited_once()
         replacement.send_bytes.assert_awaited_once_with(b"request")
 
+    async def test_area_attributes_are_sent_in_one_request(self) -> None:
+        """A TRV local override must be an atomic area-level command."""
+        client = self._client()
+        client.send_bytes = AsyncMock()
+
+        await client.put_area_data_attributes(
+            1761575990,
+            {
+                "localSetpoint": "20.5",
+                "localSetpRemainingTimeStr": "UNTIL_SCHED",
+                "localMode": "LOCAL_SETPOINT",
+            },
+        )
+
+        request = client.send_bytes.await_args.args[0].decode("ascii")
+        self.assertIn("PUT /areas/1761575990/data HTTP/1.1", request)
+        self.assertIn('"name": "localSetpoint", "value": "20.5"', request)
+        self.assertIn(
+            '"name": "localSetpRemainingTimeStr", "value": "UNTIL_SCHED"',
+            request,
+        )
+        self.assertIn('"name": "localMode", "value": "LOCAL_SETPOINT"', request)
+        client.send_bytes.assert_awaited_once()
+
 
 class TestDevicePolling(IsolatedAsyncioTestCase):
     """Exercise adaptive polling URL construction."""

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -517,6 +517,30 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         client._reconnect_with_backoff.assert_awaited_once()
         replacement.send_bytes.assert_awaited_once_with(b"request")
 
+    async def test_area_attributes_are_sent_in_one_request(self) -> None:
+        """A TRV local override must be an atomic area-level command."""
+        client = self._client()
+        client.send_bytes = AsyncMock()
+
+        await client.put_area_data_attributes(
+            1761575990,
+            {
+                "localSetpoint": "20.5",
+                "localSetpRemainingTimeStr": "UNTIL_SCHED",
+                "localMode": "LOCAL_SETPOINT",
+            },
+        )
+
+        request = client.send_bytes.await_args.args[0].decode("ascii")
+        self.assertIn("PUT /areas/1761575990/data HTTP/1.1", request)
+        self.assertIn('"name": "localSetpoint", "value": "20.5"', request)
+        self.assertIn(
+            '"name": "localSetpRemainingTimeStr", "value": "UNTIL_SCHED"',
+            request,
+        )
+        self.assertIn('"name": "localMode", "value": "LOCAL_SETPOINT"', request)
+        client.send_bytes.assert_awaited_once()
+
 
 class TestDevicePolling(IsolatedAsyncioTestCase):
     """Exercise adaptive polling URL construction."""


### PR DESCRIPTION
## Summary

Adds Home Assistant climate support for Delta Dore TRV 1.0 radiator thermostats reported as `sh_hvac` endpoints.

The TRV's measured temperature is physical-device data, whereas its setpoint and override state belong to the linked TYDOM area. This PR follows that explicit link; it contains no installation-specific identifiers.

Closes #259.

## Changes

- recognise `sh_hvac` endpoints with an explicit TYDOM area link;
- retain each radiator head's physical device and entity identity;
- expose a heat-only climate entity with current temperature, target temperature, and heating/idle action;
- use `regTemperature` (then `devTemperature`) for the current temperature and `waterFlowReq` for the action;
- write a local override atomically to `/areas/{area_id}/data` using the numeric `localSetpoint`, `localSetpRemainingTimeStr: UNTIL_SCHED`, and `localMode: LOCAL_SETPOINT` values;
- dynamically apply TRV capabilities when the physical endpoint and area state are discovered in either order.

Individual off, cooling, fan, and preset controls are intentionally not exposed: the supplied protocol data does not advertise them as independent per-head operations.

## Why this follow-up is needed

The latest live log confirms that all read-side values are present, including `regTemperature`, `currentSetpoint`, `localSetpoint`, and `waterFlowReq`. However, a TRV physical endpoint has no device-level setpoint metadata. If Home Assistant creates the entity before the linked area response has been processed, the entity can retain the generic heat/off presentation instead of exposing the target-temperature control.

The capability decision is now derived from the live area link, and the command sends a JSON number rather than a string.

## Testing

Focused validation of the updated branch:

- 30 targeted area-thermostat and climate-entity tests pass;
- Ruff lint and formatting checks pass;
- `git diff --check` passes.

The regression coverage includes routing area state, the atomic local override, optional limits and step metadata, and a late area-link scenario that verifies Home Assistant exposes the target-temperature feature and emits a numeric command.

## Hardware testing requested

The updated test branch is [`test/issue-259-trv-climate`](https://github.com/Sleinous/hass-deltadore-tydom-component/tree/test/issue-259-trv-climate).

Please confirm that a TRV shows a target-temperature control, changing it updates the radiator and TYDOM app, the new target is received back by Home Assistant, and the override ends at the next scheduled change.
