### PR TITLE
Fix global disarm commands for legacy alarms

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1423,17 +1423,19 @@ class TydomClient:
         legacy_zones=False,
     ):
         """Configure alarm mode."""
-        if legacy_zones:
-            if zone_id is not None:
-                zones_array = zone_id.split(",")
-                for zone in zones_array:
-                    await self._put_alarm_cdata(
-                        device_id, endpoint_id, alarm_pin, value, zone, legacy_zones
-                    )
-        else:
-            await self._put_alarm_cdata(
-                device_id, endpoint_id, alarm_pin, value, zone_id, legacy_zones
-            )
+        if legacy_zones and zone_id not in (None, ""):
+            zones_array = str(zone_id).split(",")
+            for zone in zones_array:
+                await self._put_alarm_cdata(
+                    device_id, endpoint_id, alarm_pin, value, zone, legacy_zones
+                )
+            return
+
+        # Global legacy commands such as disarm have no zone. They still use
+        # alarmCmd and must not be dropped by the legacy zone dispatcher.
+        await self._put_alarm_cdata(
+            device_id, endpoint_id, alarm_pin, value, zone_id, legacy_zones
+        )
 
     async def _put_alarm_cdata(
         self,

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import sys
 import types
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 _MISSING = object()
 _original_modules: dict[str, object] = {}
@@ -122,6 +122,51 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
 
     def _client(self) -> TydomClient:
         return TydomClient(None, "test", "001122334455", "password", host="local")
+
+    async def test_legacy_alarm_disarm_uses_global_alarm_command(self) -> None:
+        """A zone-capable legacy alarm must not drop a global disarm."""
+        client = self._client()
+        client._put_alarm_cdata = AsyncMock()
+
+        await client.put_alarm_cdata(
+            "20",
+            "10",
+            "123456",
+            "OFF",
+            None,
+            legacy_zones=True,
+        )
+
+        client._put_alarm_cdata.assert_awaited_once_with(
+            "20",
+            "10",
+            "123456",
+            "OFF",
+            None,
+            True,
+        )
+
+    async def test_legacy_alarm_zone_commands_are_still_split(self) -> None:
+        """Legacy arm commands must continue to address each configured part."""
+        client = self._client()
+        client._put_alarm_cdata = AsyncMock()
+
+        await client.put_alarm_cdata(
+            "20",
+            "10",
+            "123456",
+            "ON",
+            "1,3",
+            legacy_zones=True,
+        )
+
+        self.assertEqual(
+            client._put_alarm_cdata.await_args_list,
+            [
+                call("20", "10", "123456", "ON", "1", True),
+                call("20", "10", "123456", "ON", "3", True),
+            ],
+        )
 
     async def test_failed_initialisation_closes_candidate(self) -> None:
         """A socket that fails initialisation must never remain active."""


### PR DESCRIPTION
## Summary

Fix global disarm commands for legacy alarm systems, including the CSX40 connected through a Tydom 1.0 gateway.

Legacy partial-zone commands continue to use their existing per-zone handling, while global commands without a zone - particularly disarm - are now forwarded correctly.

## Problem

When an alarm is recognised as using legacy zones, `put_alarm_cdata()` only sends a command when `zone_id` is present.

Partial arming commands contain one or more zone identifiers and therefore work. However, disarming is a global command:

- value: `OFF`
- zone: `None`
- command register: `alarmCmd`

Because no zone is supplied, the legacy dispatcher previously exited without calling `_put_alarm_cdata()`. No request was sent to the gateway, so the CSX40 remained armed.

## Fix

- Retain the existing comma-separated dispatch for legacy partial-zone commands.
- Return after all requested legacy zones have been processed.
- Forward global legacy commands when `zone_id` is absent or empty.
- Reuse the existing `_put_alarm_cdata()` implementation, which selects `alarmCmd` and includes the configured alarm PIN.
- Leave modern `zoneCmd` handling and legacy per-zone `partCmd` handling unchanged.

The behaviour is based on command capabilities rather than a hard-coded CSX40 model check, so other legacy alarm systems using the same protocol layout can benefit from the correction.

## Testing

Automated regression tests verify that:

- a global legacy `OFF` command is forwarded once with no zone;
- legacy commands containing multiple partial zones are still split and sent to every requested zone.

The problem was also reproduced on a real CSX40 before preparing the correction.

The dedicated test branch was then installed by the original reporter, who confirmed that disarming now works on their CSX40:

> J'ai essayé ton correctif et je peux enfin désarmer l'alarme !

https://github.com/CyrilP/hass-deltadore-tydom-component/issues/286#issuecomment-5136527199

Fixes #286