### PR TITLE
Add native TySense Sun irradiance support

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3547,7 +3547,6 @@ class HaSun(SensorEntity, HAEntity):
     _attr_native_unit_of_measurement = "W/m²"
 
     sensor_classes = {"battDefect": BinarySensorDeviceClass.PROBLEM}
-    filtered_attrs = ["configSensor", "configTemp"]
 
     def __init__(self, device: TydomSun, hass) -> None:
         """Initialise a Tysense Sun sensor."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -101,6 +101,7 @@ from .tydom.tydom_devices import (
     TydomWeather,
     TydomWater,
     TydomThermo,
+    TydomSun,
     TydomScene,
     TydomGroup,
     TydomMoment,
@@ -3534,6 +3535,60 @@ class HaThermo(SensorEntity, HAEntity):
         if "model" in device_info:
             info["model"] = device_info["model"]
         return info
+
+
+class HaSun(SensorEntity, HAEntity):
+    """Representation of a Tysense Sun irradiance sensor."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_device_class = SensorDeviceClass.IRRADIANCE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = "W/m²"
+
+    sensor_classes = {"battDefect": BinarySensorDeviceClass.PROBLEM}
+    filtered_attrs = ["configSensor", "configTemp"]
+
+    def __init__(self, device: TydomSun, hass) -> None:
+        """Initialise a Tysense Sun sensor."""
+        self.hass = hass
+        self._device = device
+        self._device._ha_device = self
+        # Reuse the generic lightPower sensor identifier so its entity registry
+        # entry and recorder history can survive the dedicated implementation.
+        self._attr_unique_id = f"{self._device.device_id}_lightPower"
+        self._attr_name = None
+        self._registered_sensors = ["lightPower"]
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh the entity on every device push."""
+        await super().async_added_to_hass()
+        self._device.register_callback(self.async_write_ha_state)
+        self._device._ha_device = self
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the push callback."""
+        self._device.remove_callback(self.async_write_ha_state)
+        if hasattr(self._device, "_ha_device") and self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return solar irradiance in watts per square metre."""
+        return getattr(self._device, "lightPower", None)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information for the physical Tysense Sun probe."""
+        return self._enrich_device_info(
+            {
+                "identifiers": {(DOMAIN, self._device.device_id)},
+                "name": self._device.device_name,
+                "manufacturer": "Delta Dore",
+                "model": "Tysense Sun",
+            }
+        )
 
 
 class HASensor(SensorEntity, HAEntity):

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -27,6 +27,7 @@ from .tydom.tydom_devices import (
     TydomWeather,
     TydomWater,
     TydomThermo,
+    TydomSun,
     TydomDevice,
     TydomScene,
     TydomGroup,
@@ -50,6 +51,7 @@ from .ha_entities import (
     HaWeather,
     HaMoisture,
     HaThermo,
+    HaSun,
     HASensor,
     HAScene,
     HASwitch,
@@ -161,6 +163,7 @@ class Hub:
             TydomWeather: self._create_weather_device,
             TydomWater: self._create_water_device,
             TydomThermo: self._create_thermo_device,
+            TydomSun: self._create_sun_device,
             TydomScene: self._create_scene_device,
             TydomGroup: self._create_group_device,
             TydomMoment: self._create_moment_device,
@@ -572,6 +575,15 @@ class Hub:
         """Create thermostat device."""
         LOGGER.debug("Create thermo %s", device.device_id)
         ha_device = HaThermo(device, self._hass)
+        self.ha_devices[device.device_id] = ha_device
+        if self.add_sensor_callback is not None:
+            self.add_sensor_callback([ha_device])
+            self.add_sensor_callback(ha_device.get_sensors())
+
+    async def _create_sun_device(self, device: TydomSun) -> None:
+        """Create a Tysense Sun irradiance sensor."""
+        LOGGER.debug("Create Tysense Sun %s", device.device_id)
+        ha_device = HaSun(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
         if self.add_sensor_callback is not None:
             self.add_sensor_callback([ha_device])

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -32,6 +32,7 @@ from .tydom_devices import (
     TydomWeather,
     TydomWater,
     TydomThermo,
+    TydomSun,
     TydomScene,
 )
 
@@ -648,6 +649,17 @@ class MessageHandler:
                 )
             case "others" if _is_tyxia_4910_other(uid):
                 return TydomSwitch(
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata.get(uid),
+                    data,
+                )
+            case "sensorSun":
+                return TydomSun(
                     tydom_client,
                     uid,
                     device_id,

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -813,6 +813,10 @@ class TydomThermo(TydomDevice):
     """Represents a thermometer."""
 
 
+class TydomSun(TydomDevice):
+    """Represents a Tysense Sun irradiance sensor."""
+
+
 class TydomPlug(TydomDevice):
     """Represents a generic third-party smart plug (e.g. Zigbee Philips Hue plug).
 

--- a/tests/test_tysense_sun.py
+++ b/tests/test_tysense_sun.py
@@ -1,0 +1,197 @@
+"""Tests for dedicated Tysense Sun protocol support."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module required to load the protocol code."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+root = Path(__file__).parents[1]
+devices_name = "custom_components.deltadore_tydom.tydom.tydom_devices"
+devices_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "tydom_devices.py"
+)
+devices_spec = importlib.util.spec_from_file_location(devices_name, devices_path)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(devices_name, sys.modules.get(devices_name, _MISSING))
+sys.modules[devices_name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_name = "custom_components.deltadore_tydom.tydom.MessageHandler"
+handler_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "MessageHandler.py"
+)
+handler_spec = importlib.util.spec_from_file_location(handler_name, handler_path)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(handler_name, sys.modules.get(handler_name, _MISSING))
+sys.modules[handler_name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+TydomSun = devices_module.TydomSun
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class TestTySenseSun(IsolatedAsyncioTestCase):
+    """Exercise discovery and live state for Tysense Sun probes."""
+
+    def setUp(self) -> None:
+        """Reset global protocol metadata."""
+        handler_module.device_name.clear()
+        handler_module.device_type.clear()
+        handler_module.device_metadata.clear()
+        logger.reset_mock()
+        self.handler = MessageHandler(MagicMock(), b"")
+
+    @staticmethod
+    def _payload(device_id: int, irradiance: int) -> list[dict]:
+        """Build a payload matching the two live Tysense Sun captures."""
+        return [
+            {
+                "id": device_id,
+                "endpoints": [
+                    {
+                        "id": device_id,
+                        "error": 0,
+                        "data": [
+                            {
+                                "name": "battDefect",
+                                "validity": "upToDate",
+                                "value": False,
+                            },
+                            {
+                                "name": "configSensor",
+                                "validity": "upToDate",
+                                "value": 8,
+                            },
+                            {
+                                "name": "lightPower",
+                                "validity": "upToDate",
+                                "value": irradiance,
+                            },
+                            {
+                                "name": "configTemp",
+                                "validity": "upToDate",
+                                "value": 0,
+                            },
+                        ],
+                    }
+                ],
+            }
+        ]
+
+    async def test_sensor_sun_creates_a_dedicated_device(self) -> None:
+        """The sensorSun usage must no longer fall back to a generic sensor."""
+        device_id = 1752177761
+        unique_id = f"{device_id}_{device_id}"
+        handler_module.device_name[unique_id] = "Sonde Soleil Ouest"
+        handler_module.device_type[unique_id] = "sensorSun"
+        handler_module.device_metadata[unique_id] = {
+            "lightPower": {
+                "type": "numeric",
+                "permission": "r",
+                "validity": "SENSOR_SUPERVISION",
+                "min": 0,
+                "max": 65534,
+                "step": 1,
+                "unit": "W/m2",
+            }
+        }
+
+        devices = await self.handler.parse_devices_data(
+            self._payload(device_id, 45), None
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertIsInstance(devices[0], TydomSun)
+        self.assertEqual(devices[0].device_id, unique_id)
+        self.assertEqual(devices[0].device_name, "Sonde Soleil Ouest")
+        self.assertEqual(devices[0].lightPower, 45)
+        self.assertFalse(devices[0].battDefect)
+        self.assertEqual(devices[0]._metadata["lightPower"]["unit"], "W/m2")
+        self.assertFalse(
+            any(
+                call.args and "Unknown usage" in str(call.args[0])
+                for call in logger.info.call_args_list
+            )
+        )
+
+    async def test_two_sun_probes_remain_independent(self) -> None:
+        """Separate façade probes must retain their own values and identities."""
+        devices = []
+        for device_id, name, irradiance in (
+            (1752177761, "Sonde Soleil Ouest", 45),
+            (1771919164, "Sonde Soleil Est", 528),
+        ):
+            unique_id = f"{device_id}_{device_id}"
+            handler_module.device_name[unique_id] = name
+            handler_module.device_type[unique_id] = "sensorSun"
+            devices.extend(
+                await self.handler.parse_devices_data(
+                    self._payload(device_id, irradiance), None
+                )
+            )
+
+        self.assertEqual(
+            [(device.device_name, device.lightPower) for device in devices],
+            [("Sonde Soleil Ouest", 45), ("Sonde Soleil Est", 528)],
+        )
+
+    async def test_expired_irradiance_is_not_published_as_fresh(self) -> None:
+        """An expired measurement must not overwrite the last valid reading."""
+        device_id = 1752177761
+        unique_id = f"{device_id}_{device_id}"
+        handler_module.device_name[unique_id] = "Sonde Soleil Ouest"
+        handler_module.device_type[unique_id] = "sensorSun"
+        payload = self._payload(device_id, 45)
+        payload[0]["endpoints"][0]["data"][2]["validity"] = "expired"
+
+        devices = await self.handler.parse_devices_data(payload, None)
+
+        self.assertEqual(len(devices), 1)
+        self.assertIsInstance(devices[0], TydomSun)
+        self.assertFalse(hasattr(devices[0], "lightPower"))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/test_tysense_sun.py
+++ b/tests/test_tysense_sun.py
@@ -146,6 +146,8 @@ class TestTySenseSun(IsolatedAsyncioTestCase):
         self.assertEqual(devices[0].device_name, "Sonde Soleil Ouest")
         self.assertEqual(devices[0].lightPower, 45)
         self.assertFalse(devices[0].battDefect)
+        self.assertEqual(devices[0].configSensor, 8)
+        self.assertEqual(devices[0].configTemp, 0)
         self.assertEqual(devices[0]._metadata["lightPower"]["unit"], "W/m2")
         self.assertFalse(
             any(


### PR DESCRIPTION
## Summary

Add native Home Assistant support for Delta Dore TySense Sun irradiance sensors.

TYDOM exposes these devices using the `sensorSun` usage and reports solar irradiance through the `lightPower` attribute.

## Problem

The integration currently treats `sensorSun` as an unknown usage and routes it through the generic sensor fallback.

Although `lightPower` may consequently appear as a secondary raw sensor, it does not receive the appropriate Home Assistant metadata:

- no irradiance device class;
- no measurement state class;
- no standard `W/m²` unit;
- the generic primary entity may remain `unknown`.

This prevents Home Assistant from representing the device as a proper solar irradiance sensor.

## Changes

- Add a dedicated `TydomSun` protocol device for the TYDOM `sensorSun` usage.
- Add a dedicated `HaSun` Home Assistant entity.
- Expose `lightPower` as the primary sensor value.
- Use `SensorDeviceClass.IRRADIANCE`.
- Use `SensorStateClass.MEASUREMENT`.
- Publish the value in `W/m²`.
- Retain `configSensor` and `configTemp` as separate configuration sensors.
- Retain `battDefect` as a problem binary sensor.
- Ignore expired irradiance readings instead of publishing them as current measurements.
- Support multiple TySense Sun probes independently.

Discovery is based on the TYDOM `sensorSun` usage and advertised metadata rather than hard-coded device identifiers.

## Entity compatibility

The dedicated irradiance entity reuses the existing generic `lightPower` unique ID:

```text
<device_id>_lightPower
```

This allows an existing entity-registry entry and its recorder history to be retained when upgrading from the generic implementation.

## Verification

The feature was deployed and tested on a live Home Assistant installation with two physical TySense Sun probes assigned to different façades.

Live testing confirmed that:

- both probes are discovered independently;
- each probe exposes its own irradiance entity;
- values are published in `W/m²`;
- measurements update throughout the day;
- Home Assistant records the values correctly in history;
- irradiance returns to `0 W/m²` after sunset;
- the East probe recorded daytime values reaching approximately `195 W/m²` in the supplied Home Assistant history.

Sanitised protocol captures also retained separate readings for the East and West probes and advertised `lightPower` as a read-only measurement in `W/m2`, with a range of `0–65534` and a step of `1`.

Automated validation:

- 3 focused TySense Sun tests pass;
- all 36 repository tests pass;
- Ruff lint passes;
- Ruff formatting check passes;
- `git diff --check` passes.

Focused tests cover discovery, independent probe identities and readings, preservation of the existing `lightPower` unique ID, retention of configuration values, and rejection of expired irradiance measurements.