### PR TITLE
Fix unlinked Tywell Control sensor discovery

### DIFF
--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -160,6 +160,27 @@ _AREA_CONTROL_ATTRIBUTES = {
     "coolSetpoint",
 }
 
+_TYWELL_CONTROL_SENSOR_ATTRIBUTES = {
+    "hygroIn",
+    "isReference",
+    "shutterCmd",
+    "synchroRadio",
+}
+
+
+def _is_physical_tywell_control_endpoint(
+    metadata: dict | None, data: dict | None
+) -> bool:
+    """Return whether an unlinked endpoint exposes physical Tywell controls.
+
+    Some installations advertise the wall controller itself as
+    ``re2020ControlBoiler`` without linking it to an area. Its controller-only
+    capabilities distinguish it from an orphaned thermal proxy, which must not
+    create a misleading climate entity.
+    """
+    attributes = set(metadata or {}) | set(data or {})
+    return bool(attributes & _TYWELL_CONTROL_SENSOR_ATTRIBUTES)
+
 
 def _area_metadata_score(metadata: dict) -> int:
     """Measure how much writable HVAC information metadata contains."""
@@ -654,12 +675,29 @@ class MessageHandler:
                 )
             case "re2020ControlBoiler":
                 if data is None or data.get("area_id") is None:
+                    metadata = device_metadata.get(uid)
+                    if not _is_physical_tywell_control_endpoint(metadata, data):
+                        LOGGER.debug(
+                            "Ignoring unlinked Tywell thermal endpoint %s (%s)",
+                            uid,
+                            name,
+                        )
+                        return None
                     LOGGER.debug(
-                        "Ignoring unlinked Tywell thermal endpoint %s (%s)",
+                        "Keeping unlinked physical Tywell Control %s (%s) as sensors",
                         uid,
                         name,
                     )
-                    return None
+                    return TydomDevice(
+                        tydom_client,
+                        uid,
+                        device_id,
+                        name,
+                        last_usage,
+                        endpoint,
+                        metadata,
+                        data,
+                    )
                 return TydomBoiler(
                     tydom_client,
                     uid,
@@ -1107,17 +1145,6 @@ class MessageHandler:
                             and passive_climate_uid is None
                         ):
                             data.update(self._area_data[area_id])
-
-                        if (
-                            type_of_id == "re2020ControlBoiler"
-                            and "area_id" not in data
-                        ):
-                            LOGGER.debug(
-                                "Ignoring unlinked Tywell thermal endpoint %s (%s)",
-                                unique_id,
-                                name_of_id,
-                            )
-                            continue
 
                         # Create the device (even without data)
                         device = await MessageHandler.get_device(

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -169,15 +169,19 @@ _TYWELL_CONTROL_SENSOR_ATTRIBUTES = {
 
 
 def _is_physical_tywell_control_endpoint(
-    metadata: dict | None, data: dict | None
+    uid: str, metadata: dict | None, data: dict | None
 ) -> bool:
     """Return whether an unlinked endpoint exposes physical Tywell controls.
 
     Some installations advertise the wall controller itself as
-    ``re2020ControlBoiler`` without linking it to an area. Its controller-only
-    capabilities distinguish it from an orphaned thermal proxy, which must not
-    create a misleading climate entity.
+    ``re2020ControlBoiler`` without linking it to an area. Prefer Delta Dore's
+    explicit tutorial identifier, then fall back to controller-only
+    capabilities when configuration metadata is incomplete. Orphaned thermal
+    proxies must not create misleading climate entities.
     """
+    if str(device_tutorial_id.get(uid, "")).casefold() == "tywell_control":
+        return True
+
     attributes = set(metadata or {}) | set(data or {})
     return bool(attributes & _TYWELL_CONTROL_SENSOR_ATTRIBUTES)
 
@@ -676,7 +680,7 @@ class MessageHandler:
             case "re2020ControlBoiler":
                 if data is None or data.get("area_id") is None:
                     metadata = device_metadata.get(uid)
-                    if not _is_physical_tywell_control_endpoint(metadata, data):
+                    if not _is_physical_tywell_control_endpoint(uid, metadata, data):
                         LOGGER.debug(
                             "Ignoring unlinked Tywell thermal endpoint %s (%s)",
                             uid,

--- a/tests/test_area_thermostats.py
+++ b/tests/test_area_thermostats.py
@@ -85,6 +85,7 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         handler_module.device_type.clear()
         handler_module.device_endpoint.clear()
         handler_module.device_metadata.clear()
+        handler_module.device_tutorial_id.clear()
         handler_module.device_name["10_20"] = "Living room"
         handler_module.device_type["10_20"] = "re2020ControlBoiler"
         handler_module.device_metadata["10_20"] = {}
@@ -215,6 +216,44 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         self.assertEqual(controller.ambientTemperature, 23.97)
         self.assertEqual(controller.hygroIn, 75.0)
         self.assertEqual(controller.battLevel, 2)
+
+    async def test_tywell_tutorial_id_preserves_sparse_physical_controller(
+        self,
+    ) -> None:
+        """The explicit Delta Dore tutorial identifies a physical controller."""
+        handler_module.device_name["10_20"] = "Tywell Control"
+        handler_module.device_tutorial_id["10_20"] = "tywell_control"
+        handler_module.device_metadata["10_20"] = {
+            "ambientTemperature": {"permission": "r", "unit": "degC"}
+        }
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "data": [
+                                {
+                                    "name": "ambientTemperature",
+                                    "value": 21.5,
+                                    "validity": "upToDate",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 1)
+        controller = devices[0]
+        self.assertIsInstance(controller, TydomDevice)
+        self.assertNotIsInstance(controller, TydomBoiler)
+        self.assertEqual(controller.ambientTemperature, 21.5)
 
     async def test_linked_passive_control_keeps_sensor_and_adds_climate(self) -> None:
         """A passive Tywell retains its sensor device and gains a climate device."""

--- a/tests/test_area_thermostats.py
+++ b/tests/test_area_thermostats.py
@@ -66,6 +66,7 @@ handler_spec.loader.exec_module(handler_module)
 
 MessageHandler = handler_module.MessageHandler
 TydomBoiler = devices_module.TydomBoiler
+TydomDevice = devices_module.TydomDevice
 TydomWeather = devices_module.TydomWeather
 
 for name, original in _original_modules.items():
@@ -150,6 +151,70 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(devices, [])
+
+    async def test_unlinked_physical_tywell_control_remains_sensor_only(
+        self,
+    ) -> None:
+        """A physical Tywell controller keeps its sensors without an area link."""
+        handler_module.device_name["10_20"] = "Tywell Control"
+        handler_module.device_metadata["10_20"] = {
+            "synchroRadio": {"permission": "r"},
+            "battLevel": {"permission": "r"},
+            "ambientTemperature": {"permission": "r", "unit": "degC"},
+            "hygroIn": {"permission": "r", "unit": "%"},
+            "isReference": {"permission": "r"},
+            "shutterCmd": {"permission": "r"},
+        }
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "data": [
+                                {
+                                    "name": "synchroRadio",
+                                    "value": True,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "battLevel",
+                                    "value": 2,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "ambientTemperature",
+                                    "value": 23.97,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "hygroIn",
+                                    "value": 75.0,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "isReference",
+                                    "value": True,
+                                    "validity": "upToDate",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 1)
+        controller = devices[0]
+        self.assertIsInstance(controller, TydomDevice)
+        self.assertNotIsInstance(controller, TydomBoiler)
+        self.assertEqual(controller.ambientTemperature, 23.97)
+        self.assertEqual(controller.hygroIn, 75.0)
+        self.assertEqual(controller.battLevel, 2)
 
     async def test_linked_passive_control_keeps_sensor_and_adds_climate(self) -> None:
         """A passive Tywell retains its sensor device and gains a climate device."""


### PR DESCRIPTION
## Summary

Restore the sensors belonging to a physical Tywell Control when TYDOM exposes it as an unlinked `re2020ControlBoiler` endpoint.

## Problem

The area-backed climate support added in #349 deliberately ignores unlinked thermal endpoints so that orphaned protocol endpoints do not create non-functional climate entities.

However, some installations expose the physical Tywell Control itself as an unlinked `re2020ControlBoiler`. The same filtering therefore also removed its legitimate entities, including room temperature, humidity and battery information.

## Changes

- Distinguish a physical Tywell Control from an orphaned thermal endpoint.
- Prefer Delta Dore's explicit `tywell_control` tutorial identifier when it is available.
- Fall back to controller-specific capabilities such as humidity, reference-room and shutter-control attributes when tutorial metadata is incomplete.
- Preserve a recognised physical controller as a sensor-only device when it has no thermal-area association.
- Continue suppressing unlinked thermal proxies so that they do not create misleading climate entities.
- Keep the detection capability-based and independent of a particular heating appliance or receiver model.

## Verification

Automated tests cover:

- an unlinked physical Tywell Control with its normal controller capabilities;
- a sparsely described controller recognised through Delta Dore's explicit tutorial identifier;
- suppression of an ordinary unlinked thermal endpoint;
- linked Tywell Control layouts continuing to provide their existing climate and sensor entities.

All 58 automated tests pass. Ruff linting and formatting checks also pass.

The correction was additionally tested by the reporter of #355. The missing Tywell Control sensors were restored successfully, while the integration continued to load normally.

Follow-up to #349.

Related to #355.