### PR TITLE
Install versioned release archive through HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,7 @@
     "country": "FR",
     "hacs": "2.0.1",
     "homeassistant": "2024.7.0",
-    "render_readme": true
+    "render_readme": true,
+    "zip_release": true,
+    "filename": "deltadore_tydom.zip"
 }


### PR DESCRIPTION
## Summary

Configure HACS to install the versioned archive produced by the existing release workflow.

## Problem

The release workflow already replaces the integration version in `manifest.json` with the GitHub release tag before creating `deltadore_tydom.zip`.

However, `hacs.json` does not currently tell HACS to use that archive. HACS can therefore install the source attached to the tag instead, whose committed manifest may still contain an older version. This occurred with both v0.27 and v0.28: their release archives were generated with the correct version, but Home Assistant continued to display v0.26 after updating through HACS.

## Changes

- enable `zip_release` in `hacs.json`;
- set the release asset filename to `deltadore_tydom.zip`, matching `.github/workflows/release.yml`.

Future releases will therefore follow the intended path:

1. the release tag triggers the workflow;
2. the workflow writes that tag into `manifest.json`;
3. the workflow creates `deltadore_tydom.zip`;
4. HACS installs that generated archive.

This removes the need to update the committed manifest manually for each release and should ensure that Home Assistant reports the installed release version correctly from v0.29 onwards.

## Validation

- `hacs.json` parses successfully as JSON;
- the configured filename matches the release workflow output;
- `git diff --check` passes.