### PR TITLE
Handle nested TYDOM event messages

### DIFF
--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -497,7 +497,8 @@ class MessageHandler:
                 msg_type = partial(no_op, "msg_html")
 
         if msg_type is None:
-            msg_type = MSG_MAPPING.get(uri_origin)
+            mapping_key = "/events" if uri_origin.startswith("/events/") else uri_origin
+            msg_type = MSG_MAPPING.get(mapping_key)
 
             if msg_type is None and uri_origin:
                 area_data = re.fullmatch(r"/areas/([^/]+)/data", uri_origin)

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -136,6 +136,25 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertIsNone(devices)
         client.receive_pong.assert_called_once_with()
 
+    async def test_nested_event_refreshes_devices(self) -> None:
+        """A specialised event URI must use the generic event handler."""
+        logger.reset_mock()
+        client = MagicMock()
+        client.get_devices_data = AsyncMock()
+        handler = MessageHandler(client, b"")
+        body = b'{"mode":"STOP","support":["STOP","HEATING"]}'
+
+        devices = await handler.route_response(
+            b"POST /events/home/hvac HTTP/1.1\r\n"
+            b"Content-Type: application/json\r\n"
+            + f"Content-Length: {len(body)}\r\n\r\n".encode()
+            + body
+        )
+
+        self.assertIsNone(devices)
+        client.get_devices_data.assert_awaited_once_with()
+        logger.warning.assert_not_called()
+
     async def test_light_commands_poll_regular_data_endpoint(self) -> None:
         """Light state refreshes must use the supported data endpoint."""
         client = MagicMock()


### PR DESCRIPTION
## Summary

Handle specialised TYDOM event paths such as `/events/home/hvac` through the existing generic event handler.

These messages were previously reported as unknown and did not trigger the normal device-state refresh.

Fixes #92.

## Problem

The message router looks up incoming paths using exact entries from `MSG_MAPPING`. It contains a handler for `/events`, but TYDOM can publish more specific paths such as:

```text
/events/home/hvac
```

Because that path did not exactly match `/events`, the integration logged:

```text
Unknown message type received /events/home/hvac
```

It also skipped the device refresh normally initiated by the generic event handler.

The original behaviour was reported in #92. The same warning was subsequently observed again during real-device testing for #355 when switching between heating and stop:

```json
{"mode":"HEATING","support":["STOP","HEATING","COOLING"]}
{"mode":"STOP","support":["STOP","HEATING","COOLING"]}
```

In the #355 tests, the HVAC commands themselves operated correctly, confirming that this warning concerns the handling of the resulting event rather than a rejected command.

## Changes

- Route paths beginning with `/events/` through the existing `/events` handler.
- Retain the existing behaviour for the generic `/events` path.
- Trigger the normal device-data refresh after receiving a specialised event.
- Stop reporting recognised nested event paths as unknown messages.
- Leave all unrelated message routing unchanged.

## Testing

Added a regression test which sends:

```text
POST /events/home/hvac
```

with a `STOP` HVAC event and verifies that:

- the generic event handler requests refreshed device data;
- the event is not logged as an unknown message.

Local validation:

- 5 protocol-response tests passed;
- `git diff --check` passed.

The correction was prepared for #92 and has also been added to the combined #355 test branch for confirmation on the installation where the warning was recently reproduced.
### Live installation validation

The correction was subsequently tested by @PATGAR64 on a patched v0.28 installation using the combined #355 test branch.

The tester:

- restarted Home Assistant with debug logging enabled;
- changed HVAC mode from heating to off;
- changed HVAC mode from off back to heating;
- confirmed that both mode changes continued to operate correctly;
- confirmed that `Unknown message type received /events/home/hvac` no longer appeared;
- completed a wider non-regression check across the configured integration devices successfully.

The submitted debug log was reviewed as well as the tester's report. It contained zero occurrences of the former unknown-message warning. The relevant log evidence is reproduced below with device and endpoint identifiers removed; the full raw log and unrelated installation metadata are deliberately not included:

```text
Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=HEATING
POST /events/home/hvac HTTP/1.1
{"mode":"HEATING","support":["STOP","HEATING","COOLING"]}
Message received from /events/home/hvac

Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=STOP
POST /events/home/hvac HTTP/1.1
{"mode":"STOP","support":["STOP","HEATING","COOLING"]}
Message received from /events/home/hvac
```

This confirms on real hardware that both specialised HVAC event paths are accepted by the normal event handler without regressing HVAC mode changes.

## Real-device validation

On 2 August 2026, @PATGAR64 tested this change on real hardware through the combined #355 test branch, based on v0.28. The test covered both the targeted event handling and a broader equipment non-regression pass.

Results:

- heating ? off and off ? heating continued to work correctly;
- the `/events/home/hvac` unknown-message warning disappeared;
- the tester's configured TYDOM equipment passed the non-regression checks.

Privacy-safe aggregate evidence derived from the supplied debug log:

- 4 `/events/home/hvac` messages were received;
- 0 `Unknown message type received /events/home/hvac` warnings were emitted;
- both the STOP and HEATING control paths were exercised;
- 0 Python tracebacks occurred.

The raw log is intentionally not reproduced or linked here because it contains network, device, and location-related identifiers. The tester's confirmation is recorded in #355.

