### PR TITLE
Preserve thermostat setpoints across HVAC mode changes

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -475,6 +475,8 @@ class TydomBoiler(TydomDevice):
     async def set_hvac_mode(self, mode):
         """Set hvac mode (ANTI_FROST/NORMAL/STOP)."""
         LOGGER.debug("setting hvac mode to %s", mode)
+        # Mode changes must not clear or replace the setpoint. TYDOM retains
+        # the user's last setpoint and restores it when heating resumes.
         if hasattr(self, "area_id"):
             area_modes = {
                 "NORMAL": "HEATING",
@@ -508,15 +510,11 @@ class TydomBoiler(TydomDevice):
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "thermicLevel", ""
                 )
-                if self._metadata is not None and "setpoint" in self._metadata:
-                    await self.set_temperature("19.0")
             elif mode in ("NORMAL", "HEATING"):
                 await self._tydom_client.put_home_hvac_mode("HEATING")
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "thermicLevel", ""
                 )
-                if self._metadata is not None and "setpoint" in self._metadata:
-                    await self.set_temperature("19.0")
             elif mode == "ANTI_FROST":
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "thermicLevel", "ANTI_FROST"
@@ -527,9 +525,6 @@ class TydomBoiler(TydomDevice):
 
         if mode == "ANTI_FROST":
             if hasattr(self, "hvacMode"):
-                await self._tydom_client.put_devices_data(
-                    self._id, self._endpoint, "setpoint", None
-                )
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "thermicLevel", "STOP"
                 )
@@ -551,12 +546,6 @@ class TydomBoiler(TydomDevice):
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "hvacMode", "NORMAL"
                 )
-                # Only push a setpoint for devices that actually have one
-                # (real thermostats expose setpoint metadata). Fil-pilote zones
-                # have none; writing one is a phantom value ignored by the
-                # device (upstream #246).
-                if self._metadata is not None and "setpoint" in self._metadata:
-                    await self.set_temperature("19.0")
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "antifrostOn", False
                 )
@@ -587,9 +576,6 @@ class TydomBoiler(TydomDevice):
 
         elif mode == "STOP":
             if hasattr(self, "hvacMode"):
-                await self._tydom_client.put_devices_data(
-                    self._id, self._endpoint, "setpoint", None
-                )
                 await self._tydom_client.put_devices_data(
                     self._id, self._endpoint, "hvacMode", "STOP"
                 )

--- a/tests/test_climate_setpoint_preservation.py
+++ b/tests/test_climate_setpoint_preservation.py
@@ -1,0 +1,164 @@
+"""Tests for preserving thermostat setpoints across HVAC mode changes."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, call
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load protocol devices in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=MagicMock(),
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+module_name = "custom_components.deltadore_tydom.tydom.tydom_devices"
+module_path = (
+    Path(__file__).parents[1]
+    / "custom_components"
+    / "deltadore_tydom"
+    / "tydom"
+    / "tydom_devices.py"
+)
+spec = importlib.util.spec_from_file_location(module_name, module_path)
+assert spec is not None and spec.loader is not None
+devices_module = importlib.util.module_from_spec(spec)
+_original_modules.setdefault(module_name, sys.modules.get(module_name, _MISSING))
+sys.modules[module_name] = devices_module
+spec.loader.exec_module(devices_module)
+
+TydomBoiler = devices_module.TydomBoiler
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+def _boiler(*, metadata, data):
+    """Create a thermostat and its mocked client."""
+    client = MagicMock()
+    client.put_devices_data = AsyncMock()
+    client.put_home_hvac_mode = AsyncMock()
+    device = TydomBoiler(
+        client,
+        "10_20",
+        "20",
+        "Thermostat",
+        "boiler",
+        "10",
+        metadata,
+        data,
+    )
+    return device, client
+
+
+class ClimateSetpointPreservationTests(IsolatedAsyncioTestCase):
+    """Ensure mode-only commands leave the device-owned setpoint untouched."""
+
+    async def test_standard_thermostat_keeps_setpoint_when_toggled(self) -> None:
+        """Off and heat commands must not clear or replace the last setpoint."""
+        device, client = _boiler(
+            metadata={
+                "hvacMode": {"enum_values": ["STOP", "NORMAL"]},
+                "setpoint": {"min": 5, "max": 30, "step": 0.5},
+            },
+            data={"hvacMode": "NORMAL", "setpoint": 21.5},
+        )
+
+        await device.set_hvac_mode("STOP")
+        await device.set_hvac_mode("NORMAL")
+
+        self.assertEqual(
+            client.put_devices_data.await_args_list,
+            [
+                call("20", "10", "hvacMode", "STOP"),
+                call("20", "10", "antifrostOn", True),
+                call("20", "10", "hvacMode", "NORMAL"),
+                call("20", "10", "antifrostOn", False),
+            ],
+        )
+        self.assertEqual(device.setpoint, 21.5)
+
+    async def test_zone_thermostat_keeps_heating_and_cooling_setpoints(self) -> None:
+        """Changing a zone direction must not inject a synthetic temperature."""
+        device, client = _boiler(
+            metadata={
+                "authorization": {"enum_values": ["STOP", "HEATING", "COOLING"]},
+                "setpoint": {"min": 5, "max": 30, "step": 0.5},
+            },
+            data={
+                "authorization": "STOP",
+                "thermicLevel": "STOP",
+                "setpoint": 22.5,
+            },
+        )
+
+        await device.set_hvac_mode("NORMAL")
+        await device.set_hvac_mode("COOLING")
+
+        self.assertEqual(
+            client.put_home_hvac_mode.await_args_list,
+            [call("HEATING"), call("COOLING")],
+        )
+        self.assertEqual(
+            client.put_devices_data.await_args_list,
+            [
+                call("20", "10", "thermicLevel", ""),
+                call("20", "10", "thermicLevel", ""),
+            ],
+        )
+        self.assertEqual(device.setpoint, 22.5)
+
+    async def test_antifrost_does_not_clear_standard_setpoint(self) -> None:
+        """Frost-protection mode must preserve the user's heating target."""
+        device, client = _boiler(
+            metadata={
+                "hvacMode": {"enum_values": ["STOP", "NORMAL", "ANTI_FROST"]},
+                "setpoint": {"min": 5, "max": 30, "step": 0.5},
+            },
+            data={"hvacMode": "NORMAL", "setpoint": 20},
+        )
+
+        await device.set_hvac_mode("ANTI_FROST")
+
+        self.assertEqual(
+            client.put_devices_data.await_args_list,
+            [
+                call("20", "10", "thermicLevel", "STOP"),
+                call("20", "10", "hvacMode", "ANTI_FROST"),
+                call("20", "10", "antifrostOn", True),
+            ],
+        )
+        self.assertEqual(device.setpoint, 20)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

Preserve a thermostat’s existing target temperature when changing its HVAC mode.

The integration currently clears the setpoint when some thermostats are switched off and writes a hard-coded `19°C` target when heating resumes. This PR makes HVAC mode changes mode-only operations and leaves the thermostat or TYDOM responsible for retaining its previous target.

Fixes #246.

## Problem

The TYBOX 137+/RF6000+ reported in #246 returns to `19°C` whenever heating is switched off and then back on from Home Assistant.

Several paths in `TydomBoiler.set_hvac_mode()` currently modify the target temperature as a side effect of changing the mode:

- standard `hvacMode` thermostats receive `setpoint=None` when switched off;
- the same thermostats receive `setpoint=19.0` when heating resumes;
- fallback zone thermostats receive `setpoint=19.0` when heating or cooling resumes;
- anti-frost mode can also clear the previous setpoint.

These writes replace the user’s existing target even though only the HVAC mode was requested.

## Changes

- Stop writing `setpoint=None` when switching a standard thermostat off.
- Stop writing `setpoint=19.0` when switching it back to normal heating.
- Stop injecting `19.0` when fallback zone controllers resume heating or cooling.
- Preserve the target temperature when entering anti-frost mode.
- Continue sending the existing mode, thermal-level and anti-frost commands unchanged.

The integration does not cache or invent a replacement temperature. It simply avoids overwriting the target already retained by TYDOM or the thermostat.

## Compatibility with recent climate changes

This branch has been rebased onto the current `main`, including the metadata-driven climate commands from PR #358.

The existing command priority remains unchanged:

1. Area-backed thermostats continue using their dedicated `/areas` command path.
2. Controllers advertising writable `comfortMode` continue using that register and return immediately.
3. Zone controllers without writable `comfortMode` retain their existing fallback route, without an additional synthetic setpoint write.
4. Standard `hvacMode` thermostats retain their existing mode commands, without clearing or replacing their setpoint.

PR #328 previously prevented a phantom `19°C` write for pilot-wire heaters which do not expose a real setpoint. It deliberately left ordinary thermostats unchanged, so it did not fully resolve #246.

PR #358 removed the unwanted side effect for controllers using its new writable `comfortMode` path. This PR completes the correction for the remaining fallback and standard thermostat layouts.

## Testing

Added three regression tests covering:

- switching a standard thermostat off and back to heating while retaining a `21.5°C` target;
- changing heating and cooling modes on a fallback zone thermostat without injecting a synthetic temperature;
- entering anti-frost mode without clearing the existing target.

The existing metadata-driven climate tests also confirm that area-backed and writable `comfortMode` command selection remains unchanged.

Local validation:

- all 70 repository tests passed;
- all 9 TYXIA 1137 capability tests passed;
- all 3 setpoint-preservation tests passed;
- Ruff checks passed;
- Ruff formatting passed;
- `git diff --check` passed.

## Real-device validation

### TYXIA 1137 supporting test

Testing performed for #355 provided supporting evidence for the intended behaviour: a TYXIA 1137 retained its 20°C target after switching off and back to heating in Home Assistant, on the physical thermostat and in the Tydom application.

That controller uses the writable `comfortMode` path introduced by PR #358, however, so it does not exercise this PR's remaining standard and fallback paths.

### Reported TYBOX 137+/RF6000+ installation

The reporter of #246 subsequently tested this branch on the installation which originally exhibited the unwanted `19°C` reset. They confirmed that after selecting a target other than `19°C`, switching heating off and back on restored the previously selected target instead of replacing it with `19°C`.

The submitted debug log was reviewed as well as the reporter's confirmation. It shows a `21°C` target, followed by mode-only `STOP` and `HEATING` commands. There were no outgoing `setpoint=None` commands and no outgoing synthetic `setpoint=19.0` commands. TYDOM reported the setpoint as unavailable while stopped and restored it to `21°C` when heating resumed.

The relevant evidence is reproduced below with device and endpoint identifiers removed. The raw attachment and unrelated installation information are deliberately not included:

```text
Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=setpoint, value=21.0
Device data: setpoint=21.000

Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=STOP
Device data: authorization=STOP
Device data: setpoint=null

Sending command: device_id=<redacted>, endpoint_id=<redacted>, name=comfortMode, value=HEATING
Device data: authorization=HEATING
Device data: setpoint=21.000
```

This confirms that the user-visible #246 behaviour is corrected on the reporter's installation and that the integration no longer overwrites the retained target during the tested Off → Heat transition.

The log also shows that this installation now selects the capability-driven writable `comfortMode` route merged in PR #358. The successful real-device result therefore validates the complete rebased branch and the issue outcome, but it does not directly exercise the standard `hvacMode` or fallback zone-controller changes unique to this PR. Those remaining paths are covered by the dedicated automated regression tests described above.