### PR TITLE
Fix sensor registration leaking between devices

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -126,7 +126,7 @@ class HAEntity:
     units: dict[str, Any] = {}
     filtered_attrs: list[str] = []
     _device: Any = None
-    _registered_sensors: list[str] = []
+    _registered_sensors: list[str]
     hass: Any = None
 
     def _get_hub(self):
@@ -230,12 +230,16 @@ class HAEntity:
     def get_sensors(self):
         """Get available sensors for this entity."""
         sensors = []
+        # Some lightweight entity wrappers do not have their own sensor list.
+        # Keep registration state on the instance so one device cannot suppress
+        # an attribute already discovered on another device of the same type.
+        registered_sensors = self.__dict__.setdefault("_registered_sensors", [])
 
         for attribute, value in self._device.__dict__.items():
             if (
                 attribute[:1] != "_"
                 and value is not None
-                and attribute not in self._registered_sensors
+                and attribute not in registered_sensors
             ):
                 alt_name = attribute.split("_")[0]
                 if attribute in self.filtered_attrs or alt_name in self.filtered_attrs:
@@ -275,7 +279,7 @@ class HAEntity:
                             unit,
                         )
                     )
-                self._registered_sensors.append(attribute)
+                registered_sensors.append(attribute)
                 LOGGER.debug(
                     "Nouveau capteur créé: %s.%s (type: %s, valeur: %s)",
                     self._device.device_id,

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -230,10 +230,11 @@ class HAEntity:
     def get_sensors(self):
         """Get available sensors for this entity."""
         sensors = []
-        # Some lightweight entity wrappers do not have their own sensor list.
-        # Keep registration state on the instance so one device cannot suppress
-        # an attribute already discovered on another device of the same type.
-        registered_sensors = self.__dict__.setdefault("_registered_sensors", [])
+        # Generic sensor discovery is opt-in. Entity wrappers such as scenes,
+        # groups and events must not expose their internal data as sensors.
+        registered_sensors = self.__dict__.get("_registered_sensors")
+        if registered_sensors is None:
+            return sensors
 
         for attribute, value in self._device.__dict__.items():
             if (
@@ -5133,6 +5134,7 @@ class HASwitch(SwitchEntity, HAEntity):
         """Initialize HASwitch."""
         self.hass = hass
         self._device = device
+        self._registered_sensors = []
         self._device._ha_device = self
         self._attr_unique_id = f"{self._device.device_id}_switch"
         self._attr_name = None  # primary entity inherits device name
@@ -5635,6 +5637,7 @@ class HAButton(ButtonEntity, HAEntity):
         """Initialize HAButton."""
         self.hass = hass
         self._device = device
+        self._registered_sensors = []
         self._device._ha_device = self
         self._action_name = action_name
         self._action_method = action_method

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -61,7 +61,7 @@ class EntitySensorRegistrationTests(TestCase):
     """Ensure generic sensor discovery is isolated between entity instances."""
 
     @staticmethod
-    def _entity(device_id: str):
+    def _entity(device_id: str, *, supports_generic_sensors: bool = True):
         class Device:
             def __init__(self) -> None:
                 self._device_id = device_id
@@ -73,6 +73,8 @@ class EntitySensorRegistrationTests(TestCase):
 
         entity = HAEntity()
         entity._device = Device()
+        if supports_generic_sensors:
+            entity._registered_sensors = []
         return entity
 
     def test_same_attribute_is_registered_for_each_device(self) -> None:
@@ -99,6 +101,13 @@ class EntitySensorRegistrationTests(TestCase):
         second.get_sensors()
 
         self.assertIsNot(first._registered_sensors, second._registered_sensors)
+
+    def test_non_sensor_entity_does_not_expose_internal_data(self) -> None:
+        """Scenes, groups and events must not gain generic sensors on updates."""
+        entity = self._entity("scene_1", supports_generic_sensors=False)
+
+        self.assertEqual(entity.get_sensors(), [])
+        self.assertNotIn("_registered_sensors", entity.__dict__)
 
 
 if __name__ == "__main__":

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -1,0 +1,107 @@
+"""Regression tests for per-device generic sensor registration."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+
+def _load_ha_entity_class():
+    """Load HAEntity alone without requiring Home Assistant test dependencies."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "HAEntity"
+    )
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            class_node,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class GenericBinarySensor:
+        def __init__(self, *_args) -> None:
+            pass
+
+    class GenericSensor:
+        def __init__(self, *_args) -> None:
+            pass
+
+    namespace = {
+        "Any": object,
+        "DOMAIN": "deltadore_tydom",
+        "LOGGER": MagicMock(),
+        "GenericBinarySensor": GenericBinarySensor,
+        "GenericSensor": GenericSensor,
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["HAEntity"]
+
+
+HAEntity = _load_ha_entity_class()
+
+
+class EntitySensorRegistrationTests(TestCase):
+    """Ensure generic sensor discovery is isolated between entity instances."""
+
+    @staticmethod
+    def _entity(device_id: str):
+        class Device:
+            def __init__(self) -> None:
+                self._device_id = device_id
+                self.thermicDefect = False
+
+            @property
+            def device_id(self) -> str:
+                return self._device_id
+
+        entity = HAEntity()
+        entity._device = Device()
+        return entity
+
+    def test_same_attribute_is_registered_for_each_device(self) -> None:
+        """One device must not suppress a matching sensor on another device."""
+        first = self._entity("gate_1")
+        second = self._entity("gate_2")
+
+        self.assertEqual(len(first.get_sensors()), 1)
+        self.assertEqual(len(second.get_sensors()), 1)
+
+    def test_attribute_is_not_registered_twice_on_one_device(self) -> None:
+        """Repeated discovery for one device must not duplicate its sensor."""
+        entity = self._entity("gate_1")
+
+        self.assertEqual(len(entity.get_sensors()), 1)
+        self.assertEqual(entity.get_sensors(), [])
+
+    def test_registration_lists_are_not_shared(self) -> None:
+        """Every entity wrapper owns its registration state."""
+        first = self._entity("switch_1")
+        second = self._entity("switch_2")
+
+        first.get_sensors()
+        second.get_sensors()
+
+        self.assertIsNot(first._registered_sensors, second._registered_sensors)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix generic diagnostic sensors becoming unavailable or being reported as "no longer provided by the integration" when several devices expose the same attribute.

For example, two TYXIA 4620 devices can both report `thermicDefect`, but only the first device discovered by the integration currently retains its sensor.

## Cause

The generic sensor registration list was defined at class level and was therefore shared by entity wrappers that did not initialise their own list.

Once one device registered an attribute such as `thermicDefect`, another device using the same wrapper could incorrectly consider that attribute already registered and skip creating its own sensor.

The entity remained in Home Assistant's registry but was marked unavailable because the integration no longer supplied it.

## Changes

- Keep generic sensor registration state on each individual entity instance.
- Prevent one device from suppressing sensors exposed by another device.
- Preserve duplicate protection when sensor discovery runs repeatedly for the same device.
- Apply the correction in the shared entity layer, covering:
  - toggle-only gate and garage buttons;
  - switches and plugs;
  - other current or future entity wrappers using generic sensor discovery.
- Add regression tests covering multiple devices exposing the same diagnostic attribute.

Remote-control event entities are unaffected because they deliberately do not use generic sensor discovery. Their battery diagnostic also remains managed once per physical remote control.

## Testing

- Confirmed two separate entity instances can both register `thermicDefect`.
- Confirmed repeated discovery on one entity does not create duplicate sensors.
- Confirmed registration lists are not shared between devices.
- Tested successfully on a live Home Assistant installation containing two TYXIA 4620 devices exposing the same `thermicDefect` diagnostic.
- Full test suite: **70 passed**.
- Ruff lint and formatting checks passed.

After updating and reloading the integration, existing registry entities previously marked as "no longer provided" become available again under their original entity IDs.
