### PR TITLE
Expose genuine TYDOM control groups as native Home Assistant entities

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5252,8 +5252,12 @@ class HAGroupEntity(HAEntity):
     def _remove_member_callbacks(self) -> None:
         """Remove every member callback registered by this entity."""
         for member in self._member_callbacks.values():
-            member.remove_callback(self.async_write_ha_state)
+            member.remove_callback(self._handle_member_update)
         self._member_callbacks.clear()
+
+    def _handle_member_update(self) -> None:
+        """Refresh the native group after a member update."""
+        self.async_write_ha_state()
 
     def get_sensors(self) -> list:
         """Do not expose internal group membership as sensors."""
@@ -5295,7 +5299,7 @@ class HAGroupEntity(HAEntity):
             member_identity = id(member)
             if member_identity in self._member_callbacks:
                 continue
-            member.register_callback(self.async_write_ha_state)
+            member.register_callback(self._handle_member_update)
             self._member_callbacks[member_identity] = member
 
     @property
@@ -5329,7 +5333,7 @@ class HAGroupEntity(HAEntity):
 
         return attrs
 
-    async def _control_group_devices(self, action: str, **kwargs: Any) -> None:
+    async def _control_group_devices(self, action: str, **kwargs: Any) -> bool:
         """Control all devices in the group with a specific action.
 
         Args:
@@ -5344,7 +5348,7 @@ class HAGroupEntity(HAEntity):
             LOGGER.warning(
                 "Cannot control group %s: hub not available", self._device.device_name
             )
-            return
+            return False
 
         members = self._member_devices()
         LOGGER.info(
@@ -5465,8 +5469,10 @@ class HAGroupEntity(HAEntity):
         # Execute all commands concurrently
         if tasks:
             results = await asyncio.gather(*tasks, return_exceptions=True)
+            successful = len(tasks) == len(members)
             for result in results:
                 if isinstance(result, Exception):
+                    successful = False
                     LOGGER.warning(
                         "Group %s action %s failed for a member: %s",
                         self._device.device_name,
@@ -5476,12 +5482,14 @@ class HAGroupEntity(HAEntity):
             LOGGER.debug(
                 "Group %s action %s completed", self._device.device_name, action
             )
+            return successful
         else:
             LOGGER.warning(
                 "No devices could be controlled for group %s with action %s",
                 self._device.device_name,
                 action,
             )
+            return False
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on all devices in the group (for lights/plugs)."""
@@ -5521,6 +5529,7 @@ class HAGroupEntity(HAEntity):
 class HALightGroup(LightEntity, HAGroupEntity):
     """A non-empty TYDOM light group represented as a native light."""
 
+    _ASSUMED_STATE_TIMEOUT = 30
     _attr_should_poll = False
     _attr_has_entity_name = True
     _attr_icon = "mdi:lightbulb-group"
@@ -5531,6 +5540,8 @@ class HALightGroup(LightEntity, HAGroupEntity):
         """Initialise the light group."""
         HAGroupEntity.__init__(self, device, hass)
         self._attr_unique_id = f"{device.device_id}_light_group"
+        self._assumed_is_on: bool | None = None
+        self._assumed_state_task: asyncio.Task | None = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to member light updates."""
@@ -5539,6 +5550,7 @@ class HALightGroup(LightEntity, HAGroupEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks registered on member lights."""
+        self._clear_assumed_state()
         self._remove_member_callbacks()
         if self._device._ha_device is self:
             self._device._ha_device = None
@@ -5557,21 +5569,68 @@ class HALightGroup(LightEntity, HAGroupEntity):
     @property
     def is_on(self) -> bool | None:
         """Report on when any member light is on."""
+        if self._assumed_is_on is not None:
+            return self._assumed_is_on
+
+        states = self._reported_member_states()
+        return any(states) if states else None
+
+    def _reported_member_states(self) -> list[bool]:
+        """Return the currently reported on/off state of each known member."""
         states: list[bool] = []
         for member in self._member_devices():
             level = getattr(member, "level", None)
             if level is not None:
                 with suppress(TypeError, ValueError):
                     states.append(float(level) != 0)
-        return any(states) if states else None
+        return states
+
+    def _handle_member_update(self) -> None:
+        """Reconcile an assumed group state with reported member states."""
+        if self._assumed_is_on is not None:
+            members = self._member_devices()
+            states = self._reported_member_states()
+            if len(states) == len(members) and all(
+                state is self._assumed_is_on for state in states
+            ):
+                self._clear_assumed_state()
+        self.async_write_ha_state()
+
+    def _set_assumed_state(self, is_on: bool) -> None:
+        """Publish an immediate state while TYDOM refreshes every member."""
+        self._clear_assumed_state()
+        self._assumed_is_on = is_on
+        create_task = getattr(self.hass, "async_create_task", asyncio.create_task)
+        self._assumed_state_task = create_task(self._expire_assumed_state())
+        self.async_write_ha_state()
+
+    def _clear_assumed_state(self) -> None:
+        """Clear an optimistic state and cancel its expiry task."""
+        task = self._assumed_state_task
+        self._assumed_state_task = None
+        self._assumed_is_on = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _expire_assumed_state(self) -> None:
+        """Fall back to reported member state if refreshes do not converge."""
+        try:
+            await asyncio.sleep(self._ASSUMED_STATE_TIMEOUT)
+        except asyncio.CancelledError:
+            return
+        self._assumed_state_task = None
+        self._assumed_is_on = None
+        self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on every member light."""
-        await self._control_group_devices("turn_on", **kwargs)
+        if await self._control_group_devices("turn_on", **kwargs):
+            self._set_assumed_state(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off every member light."""
-        await self._control_group_devices("turn_off", **kwargs)
+        if await self._control_group_devices("turn_off", **kwargs):
+            self._set_assumed_state(False)
 
 
 class HACoverGroup(CoverEntity, HAGroupEntity):

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 import asyncio
+from contextlib import suppress
 import inspect
 import math
 from datetime import datetime
@@ -80,7 +81,7 @@ from homeassistant.components.weather import (
 )
 from homeassistant.components.scene import Scene
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.components.button import ButtonEntity
 from homeassistant.components.number import NumberEntity
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.event import EventDeviceClass, EventEntity
@@ -5222,213 +5223,111 @@ class HASwitch(SwitchEntity, HAEntity):
                 )
 
 
-class HAGroup(ButtonEntity, HAEntity):
-    """Representation of a Tydom Group."""
+class HAGroupEntity(HAEntity):
+    """Shared behaviour for native Home Assistant group entities."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
 
     def __init__(self, device: TydomGroup, hass) -> None:
-        """Initialize HAGroup."""
+        """Initialise common group entity state."""
         self.hass = hass
         self._device = device
         self._device._ha_device = self
-        self._attr_unique_id = f"{self._device.device_id}_group"
-
-        # Get usage for translation key and icon
-        group_usage = getattr(self._device, "group_usage", None) or ""
-
-        # Set icon based on usage
-        usage_icons = {
-            "light": "mdi:lightbulb-group",
-            "shutter": "mdi:window-shutter",
-            "awning": "mdi:window-shutter-open",
-            "plug": "mdi:power-socket-eu",
-            "heating": "mdi:radiator",
-            "alarm": "mdi:shield-home",
-        }
-        self._attr_icon = usage_icons.get(group_usage, "mdi:group")
-
-        # Create entity description with translation key
-        translation_key = f"group_{group_usage}" if group_usage else None
-        entity_description = ButtonEntityDescription(
-            key=f"group_{self._device.device_id}",
-            name=self._device.device_name,
-            translation_key=translation_key,
-        )
-        self.entity_description = entity_description
-        self._attr_name = None  # primary entity inherits device name
+        self._member_callbacks: dict[int, TydomDevice] = {}
+        self._attr_name = None
 
     async def async_added_to_hass(self) -> None:
-        """Refresh on every device push (see HACover for the MRO rationale)."""
+        """Subscribe to state updates from every current group member."""
         await super().async_added_to_hass()
-        self._device.register_callback(self.async_write_ha_state)
-        self._device._ha_device = self
+        self._register_member_callbacks()
 
     async def async_will_remove_from_hass(self) -> None:
-        """Remove the push callback registered in async_added_to_hass."""
-        self._device.remove_callback(self.async_write_ha_state)
+        """Remove callbacks registered on member devices."""
+        self._remove_member_callbacks()
         if hasattr(self._device, "_ha_device") and self._device._ha_device is self:
             self._device._ha_device = None
         await super().async_will_remove_from_hass()
 
+    def _remove_member_callbacks(self) -> None:
+        """Remove every member callback registered by this entity."""
+        for member in self._member_callbacks.values():
+            member.remove_callback(self.async_write_ha_state)
+        self._member_callbacks.clear()
+
+    def get_sensors(self) -> list:
+        """Do not expose internal group membership as sensors."""
+        return []
+
+    def _member_devices(self) -> list[TydomDevice]:
+        """Resolve and de-duplicate the protocol devices in this group."""
+        hub = self._get_hub()
+        if hub is None or not hasattr(hub, "devices"):
+            return []
+
+        members: list[TydomDevice] = []
+        seen: set[int] = set()
+        for member_id in self._device.device_ids:
+            member = hub.devices.get(member_id)
+            if member is None:
+                member = next(
+                    (
+                        candidate
+                        for stored_id, candidate in hub.devices.items()
+                        if stored_id == member_id
+                        or str(getattr(candidate, "device_id", "")) == member_id
+                        or str(getattr(candidate, "_id", "")) == member_id
+                    ),
+                    None,
+                )
+            if member is None or isinstance(member, TydomGroup):
+                continue
+            member_identity = id(member)
+            if member_identity in seen:
+                continue
+            seen.add(member_identity)
+            members.append(member)
+        return members
+
+    def _register_member_callbacks(self) -> None:
+        """Refresh aggregate state whenever any member publishes an update."""
+        for member in self._member_devices():
+            member_identity = id(member)
+            if member_identity in self._member_callbacks:
+                continue
+            member.register_callback(self.async_write_ha_state)
+            self._member_callbacks[member_identity] = member
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return information to link this entity with the gateway device."""
-        return {
+        info: DeviceInfo = {
             "identifiers": {(DOMAIN, self._device.device_id)},
             "name": self._device.device_name,
             "manufacturer": "Delta Dore",
-            "model": "Tydom Group",
-            "via_device": (DOMAIN, self._get_tydom_gateway_device_id() or ""),
+            "model": f"Tydom {self._device.group_usage.title()} Group",
         }
+        gateway_device_id = self._get_tydom_gateway_device_id()
+        if gateway_device_id is not None:
+            info["via_device"] = (DOMAIN, gateway_device_id)
+        return info
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return additional state attributes for the group."""
+        members = self._member_devices()
         attrs: dict[str, Any] = {
             "group_id": self._device.group_id,
             "group_usage": getattr(self._device, "group_usage", None),
-            "device_count": len(self._device.device_ids),
+            "device_count": len(members),
         }
 
-        # Add device IDs
-        if self._device.device_ids:
-            attrs["device_ids"] = self._device.device_ids
-
-            # Try to get device names and types
-            hub_instance = self._get_hub()
-            if hub_instance and hasattr(hub_instance, "devices"):
-                device_names = []
-                device_types = []
-
-                for device_id in self._device.device_ids:
-                    # Try to find device by various ID formats
-                    found_device = None
-                    for _id, device in hub_instance.devices.items():
-                        if (
-                            _id == device_id
-                            or str(getattr(device, "device_id", "")) == device_id
-                            or str(getattr(device, "_id", "")) == device_id
-                        ):
-                            found_device = device
-                            break
-
-                    if found_device:
-                        # Get device name
-                        device_name = getattr(found_device, "device_name", None)
-                        if not device_name and hasattr(found_device, "productName"):
-                            device_name = getattr(found_device, "productName", None)
-                        if device_name:
-                            device_names.append(str(device_name))
-                        else:
-                            device_names.append(f"Device {device_id}")
-
-                        # Get device type
-                        device_type = getattr(found_device, "device_type", None)
-                        if device_type:
-                            device_types.append(str(device_type))
-                        else:
-                            device_types.append("unknown")
-
-                if device_names:
-                    attrs["device_names"] = device_names
-                if device_types:
-                    attrs["device_types"] = device_types
+        if members:
+            attrs["device_ids"] = [member.device_id for member in members]
+            attrs["device_names"] = [member.device_name for member in members]
+            attrs["device_types"] = [member.device_type for member in members]
 
         return attrs
-
-    async def async_press(self) -> None:
-        """Handle the button press.
-
-        Performs an action on all devices in the group based on the group usage:
-        - shutter/awning: Open all covers
-        - light: Turn on all lights
-        - plug: Turn on all plugs
-        - heating: Not implemented (would need specific commands)
-        - alarm: Not implemented (would need specific commands)
-        """
-        group_usage = getattr(self._device, "group_usage", None) or ""
-        hub_instance = self._get_hub()
-
-        if not hub_instance or not hasattr(hub_instance, "devices"):
-            LOGGER.warning(
-                "Cannot control group %s: hub not available", self._device.device_name
-            )
-            return
-
-        LOGGER.info(
-            "Group %s (%s) button pressed - controlling %d device(s)",
-            self._device.device_name,
-            group_usage,
-            len(self._device.device_ids),
-        )
-
-        # Control all devices in the group based on usage
-        tasks = []
-        for device_id in self._device.device_ids:
-            device = hub_instance.devices.get(device_id)
-            if not device:
-                continue
-
-            try:
-                if group_usage in ("shutter", "awning"):
-                    # Open all covers
-                    if hasattr(device, "up"):
-                        tasks.append(device.up())
-                    elif hasattr(device, "open"):
-                        tasks.append(device.open())
-                elif group_usage == "light":
-                    # Turn on all lights
-                    if hasattr(device, "turn_on"):
-                        tasks.append(
-                            device.turn_on(None)
-                        )  # None = toggle or default brightness
-                    elif (
-                        hasattr(device, "_tydom_client")
-                        and hasattr(device, "_id")
-                        and hasattr(device, "_endpoint")
-                    ):
-                        # Generic light control
-                        tasks.append(
-                            device._tydom_client.put_devices_data(
-                                device._id, device._endpoint, "levelCmd", "ON"
-                            )
-                        )
-                elif group_usage == "plug":
-                    # Turn on all plugs
-                    # Note: Some plug devices might be TydomLight instances which require brightness parameter
-                    if hasattr(device, "turn_on"):
-                        # Pass None as brightness to handle both TydomLight (requires brightness)
-                        # and other devices (brightness is optional)
-                        tasks.append(device.turn_on(None))
-                    elif (
-                        hasattr(device, "_tydom_client")
-                        and hasattr(device, "_id")
-                        and hasattr(device, "_endpoint")
-                    ):
-                        # Generic plug control
-                        tasks.append(
-                            device._tydom_client.put_devices_data(
-                                device._id, device._endpoint, "levelCmd", "ON"
-                            )
-                        )
-            except Exception as e:
-                LOGGER.warning(
-                    "Error controlling device %s in group %s: %s",
-                    device_id,
-                    self._device.device_name,
-                    e,
-                )
-
-        # Execute all commands concurrently
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
-            LOGGER.debug("Group %s control completed", self._device.device_name)
-        else:
-            LOGGER.warning(
-                "No devices could be controlled for group %s", self._device.device_name
-            )
 
     async def _control_group_devices(self, action: str, **kwargs: Any) -> None:
         """Control all devices in the group with a specific action.
@@ -5447,20 +5346,17 @@ class HAGroup(ButtonEntity, HAEntity):
             )
             return
 
+        members = self._member_devices()
         LOGGER.info(
             "Group %s (%s) action %s - controlling %d device(s)",
             self._device.device_name,
             group_usage,
             action,
-            len(self._device.device_ids),
+            len(members),
         )
 
         tasks = []
-        for device_id in self._device.device_ids:
-            device = hub_instance.devices.get(device_id)
-            if not device:
-                continue
-
+        for device in members:
             try:
                 if group_usage in ("shutter", "awning"):
                     # Cover control
@@ -5530,8 +5426,10 @@ class HAGroup(ButtonEntity, HAEntity):
                     if action == "turn_on":
                         if hasattr(device, "turn_on"):
                             # For lights, try to get brightness from kwargs or use None
-                            brightness = kwargs.get("brightness")
-                            tasks.append(device.turn_on(brightness))
+                            if group_usage == "light":
+                                tasks.append(device.turn_on(kwargs.get("brightness")))
+                            else:
+                                tasks.append(device.turn_on())
                         elif (
                             hasattr(device, "_tydom_client")
                             and hasattr(device, "_id")
@@ -5558,7 +5456,7 @@ class HAGroup(ButtonEntity, HAEntity):
             except Exception as e:
                 LOGGER.warning(
                     "Error controlling device %s in group %s with action %s: %s",
-                    device_id,
+                    device.device_id,
                     self._device.device_name,
                     action,
                     e,
@@ -5566,7 +5464,15 @@ class HAGroup(ButtonEntity, HAEntity):
 
         # Execute all commands concurrently
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception):
+                    LOGGER.warning(
+                        "Group %s action %s failed for a member: %s",
+                        self._device.device_name,
+                        action,
+                        result,
+                    )
             LOGGER.debug(
                 "Group %s action %s completed", self._device.device_name, action
             )
@@ -5610,6 +5516,190 @@ class HAGroup(ButtonEntity, HAEntity):
     async def async_activate_scenario(self, scenario_id: str) -> None:
         """Activate a scenario on this group."""
         await self._device.activate_scenario(scenario_id)
+
+
+class HALightGroup(LightEntity, HAGroupEntity):
+    """A non-empty TYDOM light group represented as a native light."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:lightbulb-group"
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+
+    def __init__(self, device: TydomGroup, hass) -> None:
+        """Initialise the light group."""
+        HAGroupEntity.__init__(self, device, hass)
+        self._attr_unique_id = f"{device.device_id}_light_group"
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to member light updates."""
+        await super().async_added_to_hass()
+        self._register_member_callbacks()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks registered on member lights."""
+        self._remove_member_callbacks()
+        if self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the shared TYDOM group device information."""
+        return HAGroupEntity.device_info.fget(self)  # type: ignore[union-attr]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return group membership details."""
+        return HAGroupEntity.extra_state_attributes.fget(self)  # type: ignore[union-attr]
+
+    @property
+    def is_on(self) -> bool | None:
+        """Report on when any member light is on."""
+        states: list[bool] = []
+        for member in self._member_devices():
+            level = getattr(member, "level", None)
+            if level is not None:
+                with suppress(TypeError, ValueError):
+                    states.append(float(level) != 0)
+        return any(states) if states else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on every member light."""
+        await self._control_group_devices("turn_on", **kwargs)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off every member light."""
+        await self._control_group_devices("turn_off", **kwargs)
+
+
+class HACoverGroup(CoverEntity, HAGroupEntity):
+    """A non-empty TYDOM shutter or awning group represented as a cover."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
+
+    def __init__(self, device: TydomGroup, hass) -> None:
+        """Initialise the cover group."""
+        HAGroupEntity.__init__(self, device, hass)
+        self._attr_unique_id = f"{device.device_id}_cover_group"
+        if device.group_usage == "awning":
+            self._attr_device_class = CoverDeviceClass.AWNING
+            self._attr_icon = "mdi:awning-outline"
+        else:
+            self._attr_device_class = CoverDeviceClass.SHUTTER
+            self._attr_icon = "mdi:window-shutter"
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to member cover updates."""
+        await super().async_added_to_hass()
+        self._register_member_callbacks()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks registered on member covers."""
+        self._remove_member_callbacks()
+        if self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the shared TYDOM group device information."""
+        return HAGroupEntity.device_info.fget(self)  # type: ignore[union-attr]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return group membership details."""
+        return HAGroupEntity.extra_state_attributes.fget(self)  # type: ignore[union-attr]
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Report closed only when every member has closed-position feedback."""
+        members = self._member_devices()
+        if not members:
+            return None
+
+        positions: list[float] = []
+        for member in members:
+            position = getattr(member, "position", None)
+            if position is None:
+                return None
+            try:
+                positions.append(float(position))
+            except (TypeError, ValueError):
+                return None
+        return all(position == 0 for position in positions)
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open every member cover."""
+        await self._control_group_devices("open", **kwargs)
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close every member cover."""
+        await self._control_group_devices("close", **kwargs)
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop every member cover."""
+        await self._control_group_devices("stop", **kwargs)
+
+
+class HASwitchGroup(SwitchEntity, HAGroupEntity):
+    """A non-empty TYDOM plug group represented as a native switch."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:power-socket-eu"
+
+    def __init__(self, device: TydomGroup, hass) -> None:
+        """Initialise the switch group."""
+        HAGroupEntity.__init__(self, device, hass)
+        self._attr_unique_id = f"{device.device_id}_switch_group"
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to member switch updates."""
+        await super().async_added_to_hass()
+        self._register_member_callbacks()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks registered on member switches."""
+        self._remove_member_callbacks()
+        if self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the shared TYDOM group device information."""
+        return HAGroupEntity.device_info.fget(self)  # type: ignore[union-attr]
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return group membership details."""
+        return HAGroupEntity.extra_state_attributes.fget(self)  # type: ignore[union-attr]
+
+    @property
+    def is_on(self) -> bool | None:
+        """Report on when any member switch is on."""
+        states: list[bool] = []
+        for member in self._member_devices():
+            if hasattr(member, "on"):
+                states.append(bool(member.on))
+            elif hasattr(member, "level"):
+                with suppress(TypeError, ValueError):
+                    states.append(float(member.level) != 0)
+        return any(states) if states else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on every member switch."""
+        await self._control_group_devices("turn_on", **kwargs)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off every member switch."""
+        await self._control_group_devices("turn_off", **kwargs)
 
 
 class HAButton(ButtonEntity, HAEntity):

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5636,6 +5636,7 @@ class HALightGroup(LightEntity, HAGroupEntity):
 class HACoverGroup(CoverEntity, HAGroupEntity):
     """A non-empty TYDOM shutter or awning group represented as a cover."""
 
+    _ASSUMED_STATE_TIMEOUT = 30
     _attr_should_poll = False
     _attr_has_entity_name = True
     _attr_supported_features = (
@@ -5652,6 +5653,8 @@ class HACoverGroup(CoverEntity, HAGroupEntity):
         else:
             self._attr_device_class = CoverDeviceClass.SHUTTER
             self._attr_icon = "mdi:window-shutter"
+        self._assumed_is_closed: bool | None = None
+        self._assumed_state_task: asyncio.Task | None = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to member cover updates."""
@@ -5660,6 +5663,7 @@ class HACoverGroup(CoverEntity, HAGroupEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove callbacks registered on member covers."""
+        self._clear_assumed_state()
         self._remove_member_callbacks()
         if self._device._ha_device is self:
             self._device._ha_device = None
@@ -5678,28 +5682,78 @@ class HACoverGroup(CoverEntity, HAGroupEntity):
     @property
     def is_closed(self) -> bool | None:
         """Report closed only when every member has closed-position feedback."""
+        if self._assumed_is_closed is not None:
+            return self._assumed_is_closed
+
+        members = self._member_devices()
+        states = self._reported_member_closed_states()
+        if not members or len(states) != len(members):
+            return None
+        return all(states)
+
+    def _reported_member_closed_states(self) -> list[bool]:
+        """Return the reported closed state of each member with feedback."""
         members = self._member_devices()
         if not members:
-            return None
+            return []
 
-        positions: list[float] = []
+        states: list[bool] = []
         for member in members:
             position = getattr(member, "position", None)
             if position is None:
-                return None
+                continue
             try:
-                positions.append(float(position))
+                states.append(float(position) == 0)
             except (TypeError, ValueError):
-                return None
-        return all(position == 0 for position in positions)
+                continue
+        return states
+
+    def _handle_member_update(self) -> None:
+        """Reconcile an assumed group state with reported member positions."""
+        if self._assumed_is_closed is not None:
+            members = self._member_devices()
+            states = self._reported_member_closed_states()
+            if len(states) == len(members) and all(
+                state is self._assumed_is_closed for state in states
+            ):
+                self._clear_assumed_state()
+        self.async_write_ha_state()
+
+    def _set_assumed_state(self, is_closed: bool) -> None:
+        """Publish an immediate state while TYDOM refreshes every member."""
+        self._clear_assumed_state()
+        self._assumed_is_closed = is_closed
+        create_task = getattr(self.hass, "async_create_task", asyncio.create_task)
+        self._assumed_state_task = create_task(self._expire_assumed_state())
+        self.async_write_ha_state()
+
+    def _clear_assumed_state(self) -> None:
+        """Clear an optimistic state and cancel its expiry task."""
+        task = self._assumed_state_task
+        self._assumed_state_task = None
+        self._assumed_is_closed = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _expire_assumed_state(self) -> None:
+        """Fall back to member positions if refreshes do not converge."""
+        try:
+            await asyncio.sleep(self._ASSUMED_STATE_TIMEOUT)
+        except asyncio.CancelledError:
+            return
+        self._assumed_state_task = None
+        self._assumed_is_closed = None
+        self.async_write_ha_state()
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open every member cover."""
-        await self._control_group_devices("open", **kwargs)
+        if await self._control_group_devices("open", **kwargs):
+            self._set_assumed_state(False)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close every member cover."""
-        await self._control_group_devices("close", **kwargs)
+        if await self._control_group_devices("close", **kwargs):
+            self._set_assumed_state(True)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop every member cover."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5302,6 +5302,12 @@ class HAGroupEntity(HAEntity):
             member.register_callback(self._handle_member_update)
             self._member_callbacks[member_identity] = member
 
+    def refresh_members(self) -> None:
+        """Attach members discovered after the group and refresh its HA state."""
+        self._register_member_callbacks()
+        if getattr(self, "entity_id", None) is not None:
+            self._handle_member_update()
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return information to link this entity with the gateway device."""

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -57,7 +57,9 @@ from .ha_entities import (
     HASwitch,
     HAButton,
     HAReloadButton,
-    HAGroup,
+    HACoverGroup,
+    HALightGroup,
+    HASwitchGroup,
     HAMoment,
     HARemoteBattery,
     HARemoteEvent,
@@ -598,12 +600,28 @@ class Hub:
             self.add_scene_callback([ha_device])
 
     async def _create_group_device(self, device: TydomGroup) -> None:
-        """Create group device."""
-        LOGGER.debug("Create group %s", device.device_id)
-        ha_device = HAGroup(device, self._hass)
+        """Create a native Home Assistant entity for a controllable group."""
+        LOGGER.debug("Create %s group %s", device.group_usage, device.device_id)
+        if device.group_usage == "light":
+            ha_device = HALightGroup(device, self._hass)
+            callback = self.add_light_callback
+        elif device.group_usage in {"awning", "shutter"}:
+            ha_device = HACoverGroup(device, self._hass)
+            callback = self.add_cover_callback
+        elif device.group_usage == "plug":
+            ha_device = HASwitchGroup(device, self._hass)
+            callback = self.add_switch_callback
+        else:
+            LOGGER.debug(
+                "Ignore unsupported group %s (%s)",
+                device.device_id,
+                device.group_usage,
+            )
+            return
+
         self.ha_devices[device.device_id] = ha_device
-        if self.add_button_callback is not None:
-            self.add_button_callback([ha_device])
+        if callback is not None:
+            callback([ha_device])
 
     async def _create_moment_device(self, device: TydomMoment) -> None:
         """Create moment device."""
@@ -911,22 +929,16 @@ class Hub:
                 # Check grpAct
                 grp_act = getattr(device, "grpAct", None)
                 if grp_act and isinstance(grp_act, list):
+                    from .tydom.MessageHandler import groups_data
+
                     for grp_action in grp_act:
                         if isinstance(grp_action, dict):
                             grp_id = grp_action.get("id")
                             if grp_id:
                                 grp_id_str = str(grp_id)
-                                # Check if group exists
-                                group_found = False
-                                for _id, _device in self.devices.items():
-                                    if (
-                                        isinstance(_device, TydomGroup)
-                                        and _device.group_id == grp_id_str
-                                    ):
-                                        group_found = True
-                                        break
-
-                                if not group_found:
+                                # All groups remain in protocol metadata even
+                                # when no Home Assistant control is appropriate.
+                                if grp_id_str not in groups_data:
                                     issues.append(
                                         f"Scene {device.device_name} ({device_id}) references non-existent group: {grp_id_str}"
                                     )

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -330,6 +330,16 @@ class Hub:
                         await self.update_ha_device(
                             self.devices[device.device_id], device
                         )
+                self._refresh_group_members()
+
+    def _refresh_group_members(self) -> None:
+        """Resolve group members again after each protocol message batch."""
+        for device in self.devices.values():
+            if not isinstance(device, TydomGroup):
+                continue
+            ha_device = getattr(device, "_ha_device", None)
+            if ha_device is not None and hasattr(ha_device, "refresh_members"):
+                ha_device.refresh_members()
 
     async def create_ha_device(self, device: TydomDevice) -> None:
         """Create a new HA device using factory pattern.

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -22,6 +22,7 @@ from .tydom_devices import (
     TydomEnergy,
     TydomGarage,
     TydomGate,
+    TydomGroup,
     TydomLight,
     TydomSwitch,
     TydomPlug,
@@ -91,6 +92,14 @@ groups_metadata = {}  # Store group metadata from /configs/file: {group_id: {"us
 groups_data = {}  # Store groups data: {group_id: {"devices": [device_ids], "name": group_name}}
 endpoint_config = {}  # Store endpoint-specific configuration from /configs/file
 remote_control_info = {}  # Store physical remote and button details by endpoint UID
+
+SUPPORTED_CONTROL_GROUP_USAGES = {"awning", "light", "plug", "shutter"}
+TOTAL_GROUP_NAMES = {
+    "awning": "All awnings",
+    "light": "All lights",
+    "plug": "All plugs",
+    "shutter": "All shutters",
+}
 
 _REMOTE_CONTROL_MODELS = {
     "tl2000": "TL 2000 TYXAL+",
@@ -918,6 +927,8 @@ class MessageHandler:
                     groups_metadata[group_id_str] = {
                         "usage": group.get("usage", ""),
                         "name": group.get("name", f"Group {group_id}"),
+                        "group_all": bool(group.get("group_all", False)),
+                        "is_group_user": bool(group.get("is_group_user", False)),
                         "tutorial_id": (group.get("widget_behavior") or {}).get(
                             "tutorial_id", ""
                         ),
@@ -1537,16 +1548,15 @@ class MessageHandler:
                         group_usage = group_meta.get("usage", "")
                         config_name = group_meta.get("name", "")
 
-                        # Use config name if available and not default, otherwise use generic name
-                        # The actual display name will come from translation_key in HAGroup
                         if (
-                            config_name
-                            and config_name != f"Group {group_id}"
-                            and config_name != "TOTAL"
+                            config_name == "TOTAL"
+                            and group_meta.get("group_all", False)
+                            and group_usage in TOTAL_GROUP_NAMES
                         ):
+                            group_name = TOTAL_GROUP_NAMES[group_usage]
+                        elif config_name and config_name != f"Group {group_id}":
                             group_name = config_name
                         else:
-                            # Use generic name - translation will be handled by translation_key
                             group_name = f"Group {group_id}"
 
                         # Store group data
@@ -1556,16 +1566,21 @@ class MessageHandler:
                             "usage": group_usage,
                         }
 
-                        if group_usage == "remoteControl":
+                        if not device_ids:
                             LOGGER.debug(
-                                "Skipping non-controllable remote-control group %s",
+                                "Skipping empty %s group %s",
+                                group_usage or "unknown",
                                 group_id_str,
                             )
                             continue
 
-                        # Create TydomGroup device
-                        # Import here to avoid circular import
-                        from .tydom_devices import TydomGroup
+                        if group_usage not in SUPPORTED_CONTROL_GROUP_USAGES:
+                            LOGGER.debug(
+                                "Skipping unsupported %s group %s",
+                                group_usage or "unknown",
+                                group_id_str,
+                            )
+                            continue
 
                         group_device = TydomGroup(
                             self.tydom_client,

--- a/tests/test_native_group_entities.py
+++ b/tests/test_native_group_entities.py
@@ -1,0 +1,229 @@
+"""Regression tests for native Home Assistant TYDOM group entities."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from contextlib import suppress
+from enum import IntFlag
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _load_group_entity_classes():
+    """Load only the group classes without Home Assistant dependencies."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    class_names = {
+        "HAGroupEntity",
+        "HALightGroup",
+        "HACoverGroup",
+        "HASwitchGroup",
+    }
+    class_nodes = [
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name in class_names
+    ]
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            *class_nodes,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class Entity:
+        async def async_added_to_hass(self) -> None:
+            pass
+
+        async def async_will_remove_from_hass(self) -> None:
+            pass
+
+        def async_write_ha_state(self) -> None:
+            pass
+
+    class LightEntity(Entity):
+        pass
+
+    class CoverEntity(Entity):
+        pass
+
+    class SwitchEntity(Entity):
+        pass
+
+    class HAEntity:
+        def _get_hub(self):
+            return self.hass.hub
+
+        def _get_tydom_gateway_device_id(self):
+            return "gateway"
+
+    class CoverEntityFeature(IntFlag):
+        OPEN = 1
+        CLOSE = 2
+        STOP = 4
+
+    class CoverDeviceClass:
+        AWNING = "awning"
+        SHUTTER = "shutter"
+
+    class ColorMode:
+        ONOFF = "onoff"
+
+    class TydomGroup:
+        pass
+
+    namespace = {
+        "Any": object,
+        "asyncio": asyncio,
+        "ColorMode": ColorMode,
+        "CoverDeviceClass": CoverDeviceClass,
+        "CoverEntity": CoverEntity,
+        "CoverEntityFeature": CoverEntityFeature,
+        "DeviceInfo": dict,
+        "DOMAIN": "deltadore_tydom",
+        "HAEntity": HAEntity,
+        "LightEntity": LightEntity,
+        "LOGGER": MagicMock(),
+        "suppress": suppress,
+        "SwitchEntity": SwitchEntity,
+        "TydomGroup": TydomGroup,
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace
+
+
+GROUP_CLASSES = _load_group_entity_classes()
+HALightGroup = GROUP_CLASSES["HALightGroup"]
+HACoverGroup = GROUP_CLASSES["HACoverGroup"]
+HASwitchGroup = GROUP_CLASSES["HASwitchGroup"]
+TydomGroup = GROUP_CLASSES["TydomGroup"]
+
+
+class GroupDevice(TydomGroup):
+    """Minimal protocol group used by the isolated entity tests."""
+
+    def __init__(self, usage: str, member_ids: list[str]) -> None:
+        """Initialise group identity, usage and membership."""
+        self.device_id = "group_1"
+        self.device_name = f"All {usage}s"
+        self.device_ids = member_ids
+        self.group_id = self.device_id
+        self.group_usage = usage
+        self._ha_device = None
+
+
+class MemberDevice:
+    """Minimal controllable member with update callback support."""
+
+    def __init__(
+        self,
+        device_id: str,
+        *,
+        level: int | None = None,
+        position: int | None = None,
+        on: bool | None = None,
+    ) -> None:
+        """Initialise state and mockable member operations."""
+        self.device_id = f"{device_id}_{device_id}"
+        self._id = device_id
+        self.device_name = f"Device {device_id}"
+        self.device_type = "test"
+        if level is not None:
+            self.level = level
+        if position is not None:
+            self.position = position
+        if on is not None:
+            self.on = on
+        self.turn_on = AsyncMock()
+        self.turn_off = AsyncMock()
+        self.up = AsyncMock()
+        self.down = AsyncMock()
+        self.stop = AsyncMock()
+        self.register_callback = MagicMock()
+        self.remove_callback = MagicMock()
+
+
+class NativeGroupEntityTests(IsolatedAsyncioTestCase):
+    """Exercise aggregate state and command fan-out."""
+
+    @staticmethod
+    def _entity(entity_class, usage: str, members: list[MemberDevice]):
+        member_ids = []
+        stored_devices = {}
+        for member in members:
+            member_ids.extend([member._id, member.device_id])
+            stored_devices[member.device_id] = member
+        group = GroupDevice(usage, member_ids)
+        hass = SimpleNamespace(hub=SimpleNamespace(devices=stored_devices))
+        return entity_class(group, hass)
+
+    async def test_light_group_aggregates_state_and_deduplicates_commands(self) -> None:
+        """Report any light on and command each physical member only once."""
+        first = MemberDevice("1", level=0)
+        second = MemberDevice("2", level=50)
+        entity = self._entity(HALightGroup, "light", [first, second])
+
+        self.assertTrue(entity.is_on)
+        self.assertEqual(entity.extra_state_attributes["device_count"], 2)
+
+        await entity.async_turn_off()
+
+        first.turn_off.assert_awaited_once_with()
+        second.turn_off.assert_awaited_once_with()
+
+    async def test_cover_group_requires_all_members_to_be_closed(self) -> None:
+        """Aggregate closed state and fan out native cover commands."""
+        first = MemberDevice("1", position=0)
+        second = MemberDevice("2", position=0)
+        entity = self._entity(HACoverGroup, "shutter", [first, second])
+
+        self.assertTrue(entity.is_closed)
+        second.position = 25
+        self.assertFalse(entity.is_closed)
+
+        await entity.async_open_cover()
+        await entity.async_stop_cover()
+
+        first.up.assert_awaited_once_with()
+        second.up.assert_awaited_once_with()
+        first.stop.assert_awaited_once_with()
+        second.stop.assert_awaited_once_with()
+
+    async def test_switch_group_reports_any_member_on(self) -> None:
+        """Represent plug groups as switches with aggregate state."""
+        first = MemberDevice("1", on=False)
+        second = MemberDevice("2", on=True)
+        entity = self._entity(HASwitchGroup, "plug", [first, second])
+
+        self.assertTrue(entity.is_on)
+
+        await entity.async_turn_on()
+
+        first.turn_on.assert_awaited_once_with()
+        second.turn_on.assert_awaited_once_with()
+
+    def test_groups_never_create_generic_diagnostic_sensors(self) -> None:
+        """Keep membership fields out of the sensor platform."""
+        entity = self._entity(HALightGroup, "light", [MemberDevice("1", level=0)])
+
+        self.assertEqual(entity.get_sensors(), [])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/test_native_group_entities.py
+++ b/tests/test_native_group_entities.py
@@ -184,6 +184,41 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
 
         first.turn_off.assert_awaited_once_with()
         second.turn_off.assert_awaited_once_with()
+        self.assertFalse(entity.is_on)
+        entity._clear_assumed_state()
+
+    async def test_light_group_keeps_requested_state_until_members_converge(self) -> None:
+        """Avoid presenting a stale light state while TYDOM polls each member."""
+        first = MemberDevice("1", level=100)
+        second = MemberDevice("2", level=100)
+        entity = self._entity(HALightGroup, "light", [first, second])
+
+        await entity.async_turn_off()
+
+        self.assertFalse(entity.is_on)
+        first.level = 0
+        entity._handle_member_update()
+        self.assertFalse(entity.is_on)
+        self.assertIsNotNone(entity._assumed_is_on)
+
+        second.level = 0
+        entity._handle_member_update()
+        self.assertFalse(entity.is_on)
+        self.assertIsNone(entity._assumed_is_on)
+
+    async def test_light_group_assumed_state_expires(self) -> None:
+        """Fall back to member reports when they do not reach the requested state."""
+        member = MemberDevice("1", level=100)
+        entity = self._entity(HALightGroup, "light", [member])
+        entity._ASSUMED_STATE_TIMEOUT = 0
+
+        await entity.async_turn_off()
+        self.assertFalse(entity.is_on)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        self.assertTrue(entity.is_on)
+        self.assertIsNone(entity._assumed_is_on)
 
     async def test_cover_group_requires_all_members_to_be_closed(self) -> None:
         """Aggregate closed state and fan out native cover commands."""

--- a/tests/test_native_group_entities.py
+++ b/tests/test_native_group_entities.py
@@ -237,6 +237,26 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
         second.up.assert_awaited_once_with()
         first.stop.assert_awaited_once_with()
         second.stop.assert_awaited_once_with()
+        entity._clear_assumed_state()
+
+    async def test_cover_group_enables_close_while_positions_catch_up(self) -> None:
+        """Do not leave Close disabled while TYDOM still reports old positions."""
+        first = MemberDevice("1", position=0)
+        second = MemberDevice("2", position=0)
+        entity = self._entity(HACoverGroup, "shutter", [first, second])
+
+        await entity.async_open_cover()
+
+        self.assertFalse(entity.is_closed)
+        first.position = 50
+        entity._handle_member_update()
+        self.assertFalse(entity.is_closed)
+        self.assertIsNotNone(entity._assumed_is_closed)
+
+        second.position = 25
+        entity._handle_member_update()
+        self.assertFalse(entity.is_closed)
+        self.assertIsNone(entity._assumed_is_closed)
 
     async def test_switch_group_reports_any_member_on(self) -> None:
         """Represent plug groups as switches with aggregate state."""

--- a/tests/test_native_group_entities.py
+++ b/tests/test_native_group_entities.py
@@ -277,6 +277,24 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
 
         self.assertEqual(entity.get_sensors(), [])
 
+    def test_group_registers_members_discovered_after_entity_creation(self) -> None:
+        """Recover when TYDOM sends the group before its physical members."""
+        group = GroupDevice("light", ["1", "2"])
+        hass = SimpleNamespace(hub=SimpleNamespace(devices={}))
+        entity = HALightGroup(group, hass)
+        entity.entity_id = "light.all_lights"
+        entity.async_write_ha_state = MagicMock()
+        first = MemberDevice("1", level=0)
+        second = MemberDevice("2", level=0)
+        hass.hub.devices = {first.device_id: first, second.device_id: second}
+
+        entity.refresh_members()
+
+        first.register_callback.assert_called_once_with(entity._handle_member_update)
+        second.register_callback.assert_called_once_with(entity._handle_member_update)
+        entity.async_write_ha_state.assert_called_once_with()
+        self.assertFalse(entity.is_on)
+
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_tydom_groups.py
+++ b/tests/test_tydom_groups.py
@@ -1,0 +1,223 @@
+"""Tests for native TYDOM group discovery."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module required to load protocol code in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    DOMAIN="deltadore_tydom",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+root = Path(__file__).parents[1]
+devices_name = "custom_components.deltadore_tydom.tydom.tydom_devices"
+devices_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "tydom_devices.py"
+)
+devices_spec = importlib.util.spec_from_file_location(devices_name, devices_path)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(devices_name, sys.modules.get(devices_name, _MISSING))
+sys.modules[devices_name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_name = "custom_components.deltadore_tydom.tydom.MessageHandler"
+handler_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "MessageHandler.py"
+)
+handler_spec = importlib.util.spec_from_file_location(handler_name, handler_path)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(handler_name, sys.modules.get(handler_name, _MISSING))
+sys.modules[handler_name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+TydomGroup = devices_module.TydomGroup
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class TydomGroupDiscoveryTests(IsolatedAsyncioTestCase):
+    """Exercise membership filtering and names derived from TYDOM metadata."""
+
+    def setUp(self) -> None:
+        """Reset global protocol metadata."""
+        handler_module.groups_metadata.clear()
+        handler_module.groups_data.clear()
+        handler_module.endpoint_config.clear()
+        handler_module.remote_control_info.clear()
+        self.handler = MessageHandler(MagicMock(), b"")
+
+    async def test_only_non_empty_supported_total_groups_are_created(self) -> None:
+        """Ignore advertised global groups that have no installed members."""
+        await self.handler.parse_config_data(
+            {
+                "endpoints": [],
+                "groups": [
+                    {
+                        "id": 1,
+                        "name": "TOTAL",
+                        "usage": "awning",
+                        "group_all": True,
+                    },
+                    {
+                        "id": 2,
+                        "name": "TOTAL",
+                        "usage": "light",
+                        "group_all": True,
+                    },
+                    {
+                        "id": 3,
+                        "name": "TOTAL",
+                        "usage": "plug",
+                        "group_all": True,
+                    },
+                    {
+                        "id": 4,
+                        "name": "TOTAL",
+                        "usage": "shutter",
+                        "group_all": True,
+                    },
+                ],
+            },
+            None,
+        )
+
+        groups = await self.handler.parse_groups_file(
+            {
+                "groups": [
+                    {"id": 1, "devices": [], "areas": []},
+                    {
+                        "id": 2,
+                        "devices": [{"id": 20, "endpoints": [{"id": 21}]}],
+                        "areas": [],
+                    },
+                    {"id": 3, "devices": [], "areas": []},
+                    {
+                        "id": 4,
+                        "devices": [{"id": 40, "endpoints": [{"id": 41}]}],
+                        "areas": [],
+                    },
+                ]
+            },
+            None,
+        )
+
+        self.assertTrue(all(isinstance(group, TydomGroup) for group in groups))
+        self.assertEqual(
+            [
+                (group.group_id, group.device_name, group.group_usage)
+                for group in groups
+            ],
+            [
+                ("2", "All lights", "light"),
+                ("4", "All shutters", "shutter"),
+            ],
+        )
+        self.assertEqual(set(handler_module.groups_data), {"1", "2", "3", "4"})
+
+    async def test_user_group_name_is_preserved(self) -> None:
+        """Retain a meaningful name supplied by the user in the Tydom app."""
+        await self.handler.parse_config_data(
+            {
+                "endpoints": [],
+                "groups": [
+                    {
+                        "id": 5,
+                        "name": "Ground floor lights",
+                        "usage": "light",
+                        "group_all": False,
+                        "is_group_user": True,
+                    }
+                ],
+            },
+            None,
+        )
+
+        groups = await self.handler.parse_groups_file(
+            {
+                "groups": [
+                    {
+                        "id": 5,
+                        "devices": [{"id": 50, "endpoints": [{"id": 50}]}],
+                    }
+                ]
+            },
+            None,
+        )
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].device_name, "Ground floor lights")
+
+    async def test_non_controllable_relationship_group_is_not_created(self) -> None:
+        """Keep relationship metadata without creating a meaningless control."""
+        await self.handler.parse_config_data(
+            {
+                "endpoints": [],
+                "groups": [
+                    {
+                        "id": 6,
+                        "name": "Kitchen window",
+                        "usage": "windowFrench",
+                    }
+                ],
+            },
+            None,
+        )
+
+        groups = await self.handler.parse_groups_file(
+            {
+                "groups": [
+                    {
+                        "id": 6,
+                        "devices": [{"id": 60, "endpoints": [{"id": 60}]}],
+                    }
+                ]
+            },
+            None,
+        )
+
+        self.assertEqual(groups, [])
+        self.assertEqual(handler_module.groups_data["6"]["name"], "Kitchen window")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

TYDOM currently exposes several group devices in Home Assistant using their raw numeric identifiers:

| Current device name | TYDOM usage | Members | What it actually represents |
| --- | --- | ---: | --- |
| `Group 118696998` | `awning` | 0 | Global awning group |
| `Group 321700902` | `light` | 22 | Global light group |
| `Group 345443572` | `plug` | 0 | Global plug group |
| `Group 615460523` | `shutter` | 7 | Global shutter group |

In other words:

```text
118696998 -> awning
321700902 -> light
345443572 -> plug
615460523 -> shutter
```

These numbers are not device types or meaningful names. They are stable group identifiers assigned by the TYDOM gateway. The purpose of each group is supplied separately by `/configs/file`, while its physical membership is returned by `/groups/file` under the same identifier.

The integration currently exposes every such record as a generic TYDOM group with a numeric fallback name and a `Press` button. Internal fields such as `deviceIds`, `groupId` and `groupUsage` can also appear as unavailable diagnostic entities.

This PR correlates the group identifier, metadata and membership so that genuine control groups are represented using the appropriate Home Assistant domain:

| TYDOM group ID | Previous representation | New representation |
| --- | --- | --- |
| `118696998` | Numeric group with a Press button | Not created because it has no members |
| `321700902` | Numeric group with a Press button | Light entity named `All lights` |
| `345443572` | Numeric group with a Press button | Not created because it has no members |
| `615460523` | Numeric group with a Press button | Cover entity named `All shutters` |

The numeric identifier remains part of the entity's stable unique ID, but it is no longer used as the user-facing name.

## Why unexpected one-member groups exist

The integration does not create the group records returned by TYDOM. They are created and stored by the Delta Dore gateway/application.

TYDOM uses the same group structure for three different purposes:

1. global control groups, such as all lights or all shutters;
2. control groups deliberately created by the user;
3. internal relationship groups generated automatically by Delta Dore.

Internal relationship groups associate endpoints belonging to a logical product such as a window, remote control or wall switch. They normally have `group_all=false`, `is_group_user=false` and a usage such as `windowFrench`, `remoteControl` or `interrupter`.

The relationship abstraction can contain one or several endpoints. TYDOM still returns the structure when it currently has only one endpoint and may give it the same name as that endpoint. This explains why Home Assistant can show both a physical device and an apparently pointless one-member group with the same name.

For example, the captured metadata contains both a physical `Baie salle à manger` endpoint and automatic relationship group `428051887`, also named `Baie salle à manger`, with `usage=windowFrench` and `is_group_user=false`. The user did not create this duplicate. The integration was mistakenly presenting an internal Delta Dore relationship as a controllable group.

This PR retains relationship metadata internally where it is needed for scene and relationship processing, but does not create another Home Assistant device or entity for it.

## Discovery rules

| TYDOM metadata | Behaviour |
| --- | --- |
| Supported `group_all=true` group with members | Create a native global control |
| Supported `group_all=true` group without members | Do not create an entity |
| Supported `is_group_user=true` group with members | Create a native entity and preserve its name |
| Automatic relationship group | Retain internally without exposing it |
| Unsupported group usage | Retain internally without exposing it |

A genuine user-created group is not discarded merely because it contains one member. The reliable distinction is the metadata supplied by TYDOM, rather than the member count alone.

## Native Home Assistant entities

| TYDOM usage | Home Assistant entity | Controls |
| --- | --- | --- |
| `light` | Light | Turn on and off |
| `shutter` | Cover | Open, close and stop |
| `awning` | Cover | Open, close and stop |
| `plug` | Switch | Turn on and off |

Global `TOTAL` groups receive meaningful names: `All lights`, `All shutters`, `All awnings` and `All plugs`. Names assigned to user-created groups in the TYDOM application are preserved.

The integration resolves and de-duplicates the device, endpoint and composite identifiers that TYDOM can provide for the same receiver, ensuring that a group action sends one command to each physical member.

Group state is derived only from known member states:

- a light or plug group is on when at least one known member is on;
- a cover group is closed only when every resolved member reports a closed position;
- an indeterminate aggregate state remains unknown rather than being invented.

Cover groups expose open, close and stop. They do not advertise a single position because members may have different positions or may not provide reliable positional feedback.

## Existing installations

Previous group buttons and their generic diagnostic entities may remain unavailable in the Home Assistant registry after upgrading.

This PR deliberately avoids deleting registry entries automatically, which could remove user customisations or affect automations. Once the new entities have been verified, old unavailable group devices can be removed manually.

## Testing

Automated coverage includes:

- correlating group metadata and membership by numeric ID;
- filtering empty global groups;
- deriving friendly global group names;
- preserving names assigned to user-created groups;
- retaining genuine one-member user groups;
- filtering automatic relationship groups while retaining their metadata;
- native light, cover and switch state aggregation;
- command fan-out and physical-member de-duplication;
- suppression of generic group diagnostic sensors.

Results:

- feature branch: `74 passed`;
- combined current-development test branch: `82 passed`;
- Ruff, formatting, compilation and diff checks passed.

The live test installation contains 22 lights in group `321700902`, 7 shutters in group `615460523`, and no members in awning group `118696998` or plug group `345443572`.

The combined test branch has been deployed for live validation of:

- `All lights` controlling all 22 lights;
- `All shutters` opening, closing and stopping all 7 shutters;
- aggregate state reacting to individual member updates;
- empty awning and plug groups remaining absent;
- automatic relationship groups no longer producing duplicate devices, generic Press buttons or diagnostic sensors.

### Live discovery validation

The combined `test/current-development` branch was deployed to Home Assistant and restarted successfully. Live registry and protocol inspection confirmed:

- `light.all_lights` registered from group `321700902` as **All lights**, model **Tydom Light Group**;
- `cover.all_shutters` registered from group `615460523` as **All shutters**, model **Tydom Shutter Group**;
- `/groups/file` resolved 22 physical light members and 7 physical shutter members;
- empty awning group `118696998` and plug group `345443572` did not create native entities;
- automatic window, remote-control and interrupter relationship groups did not create new native group entities;
- the previous numeric group buttons remain as unavailable registry entries, as expected, and can be removed manually;
- no Delta Dore TYDOM exception or entity-registration error was recorded after restart.

One missed PONG occurred during startup. The existing reconnect handling recovered on its first attempt and resumed listening successfully; this was unrelated to group discovery. Home Assistant also reported excessive logging while integration debug logging was enabled, with no functional impact.

Live command logs were not used to claim fan-out validation. Command fan-out and physical-member de-duplication are covered by the automated tests above.

### Independent multi-group discovery validation

The same independent installation supplied a screenshot and debug log showing the native group discovery on a different TYDOM gateway:

- **All lights** was created as a Tydom Light Group with 2 resolved members;
- **All shutters** was created as a Tydom Shutter Group with 12 resolved members;
- **All awnings** was created as a Tydom Awning Group with 2 resolved members; and
- the advertised global plug group had no members and was therefore skipped.

This explains why three of the four supported global group categories appeared on that installation: the fourth was deliberately absent under the empty-group rule. The screenshot confirms the three correctly named devices and their native models. This test validates independent discovery and filtering; it does not add a separate claim that group commands were exercised.