### PR TITLE
Add native button events for TYXIA 2600 wall switches

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -106,6 +106,7 @@ from .tydom.tydom_devices import (
     TydomGroup,
     TydomMoment,
     TydomRemoteControl,
+    TydomInterrupter,
 )
 
 from .const import (
@@ -6027,3 +6028,144 @@ class HAEvent(EventEntity, HAEntity):
         if "model" in device_info:
             info["model"] = device_info["model"]
         return self._enrich_device_info(info)
+
+
+class HAInterrupterEvent(EventEntity, HAEntity):
+    """Representation of a physical wall-switch button."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = ["press_end", "long_press_end"]
+    _attr_icon = "mdi:light-switch"
+
+    def __init__(self, device: TydomInterrupter, hass) -> None:
+        """Initialise a wall-switch button event."""
+        self.hass = hass
+        self._device = device
+        self._device._ha_device = self
+        self._last_event_sequence = device.event_sequence
+        self._attr_unique_id = f"{self._device.device_id}_interrupter_event"
+        self._attr_name = (
+            f"Button {device.button}"
+            if device.button is not None
+            else device.device_name
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for fresh actions from this physical button endpoint."""
+        await super().async_added_to_hass()
+        self._device.register_callback(self._handle_device_update)
+        self._device._ha_device = self
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the wall-switch action callback."""
+        self._device.remove_callback(self._handle_device_update)
+        if hasattr(self._device, "_ha_device") and self._device._ha_device is self:
+            self._device._ha_device = None
+        await super().async_will_remove_from_hass()
+
+    def _handle_device_update(self) -> None:
+        """Emit one Home Assistant event for each fresh TYDOM action."""
+        sequence = self._device.event_sequence
+        if sequence <= self._last_event_sequence:
+            return
+
+        self._last_event_sequence = sequence
+        action = str(getattr(self._device, "action", "IDLE"))
+        if action == "IDLE":
+            return
+
+        event_type = "long_press_end" if action.endswith("_LONG") else "press_end"
+        self._trigger_event(
+            event_type,
+            {
+                "action": action,
+                "configured_action": self._device._configured_action,
+            },
+        )
+        self.async_write_ha_state()
+
+    def get_sensors(self) -> list:
+        """Do not expose transient actions as ordinary sensors."""
+        return []
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Group both buttons under the physical wall switch."""
+        return self._enrich_device_info(
+            {
+                "identifiers": {
+                    (DOMAIN, f"interrupter_{self._device.physical_device_id}")
+                },
+                "name": self._device.interrupter_name,
+                "manufacturer": "Delta Dore",
+                "model": self._device.interrupter_model,
+            }
+        )
+
+
+class HAInterrupterBattery(BinarySensorEntity, HAEntity):
+    """Battery-defect diagnostic shared by both wall-switch endpoints."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.BATTERY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Battery fault"
+
+    def __init__(self, device: TydomInterrupter, hass) -> None:
+        """Initialise the physical wall-switch battery diagnostic."""
+        self.hass = hass
+        self._device = device
+        self._devices: dict[str, TydomInterrupter] = {}
+        self._callbacks: dict[str, Any] = {}
+        self._battery_defect: bool | None = None
+        self._attr_unique_id = (
+            f"interrupter_{device.physical_device_id}_battery_defect"
+        )
+        self.add_device(device)
+
+    def add_device(self, device: TydomInterrupter) -> None:
+        """Include another button endpoint in the battery diagnostic."""
+        if device.device_id in self._devices:
+            return
+
+        self._devices[device.device_id] = device
+
+        def handle_update() -> None:
+            value = getattr(device, "battDefect", None)
+            if value is not None:
+                self._battery_defect = bool(value)
+            self.async_write_ha_state()
+
+        self._callbacks[device.device_id] = handle_update
+        device.register_callback(handle_update)
+        initial_value = getattr(device, "battDefect", None)
+        if initial_value is not None:
+            self._battery_defect = bool(initial_value)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks from both physical button endpoints."""
+        for device_id, device in self._devices.items():
+            device.remove_callback(self._callbacks[device_id])
+        await super().async_will_remove_from_hass()
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether TYDOM reports a wall-switch battery defect."""
+        return self._battery_defect
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach the diagnostic to the same physical wall switch."""
+        return self._enrich_device_info(
+            {
+                "identifiers": {
+                    (DOMAIN, f"interrupter_{self._device.physical_device_id}")
+                },
+                "name": self._device.interrupter_name,
+                "manufacturer": "Delta Dore",
+                "model": self._device.interrupter_model,
+            }
+        )

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -6121,9 +6121,7 @@ class HAInterrupterBattery(BinarySensorEntity, HAEntity):
         self._devices: dict[str, TydomInterrupter] = {}
         self._callbacks: dict[str, Any] = {}
         self._battery_defect: bool | None = None
-        self._attr_unique_id = (
-            f"interrupter_{device.physical_device_id}_battery_defect"
-        )
+        self._attr_unique_id = f"interrupter_{device.physical_device_id}_battery_defect"
         self.add_device(device)
 
     def add_device(self, device: TydomInterrupter) -> None:

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -545,9 +545,7 @@ class Hub:
         if self.add_event_callback is not None:
             self.add_event_callback([ha_device])
 
-        battery = self._interrupter_battery_entities.get(
-            device.physical_device_id
-        )
+        battery = self._interrupter_battery_entities.get(device.physical_device_id)
         if battery is None:
             battery = HAInterrupterBattery(device, self._hass)
             self._interrupter_battery_entities[device.physical_device_id] = battery

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -22,6 +22,7 @@ from .tydom.tydom_devices import (
     TydomGarage,
     TydomLight,
     TydomSwitch,
+    TydomInterrupter,
     TydomPlug,
     TydomAlarm,
     TydomWeather,
@@ -47,6 +48,8 @@ from .ha_entities import (
     HaGate,
     HaGarage,
     HaLight,
+    HAInterrupterBattery,
+    HAInterrupterEvent,
     HaAlarm,
     HaWeather,
     HaMoisture,
@@ -136,6 +139,7 @@ class Hub:
         self.online = True
         self._reload_button_created = False
         self._remote_battery_entities: dict[str, HARemoteBattery] = {}
+        self._interrupter_battery_entities: dict[str, HAInterrupterBattery] = {}
         self._shutting_down = False
 
         # Polling cache for optimization
@@ -158,6 +162,7 @@ class Hub:
             TydomGarage: self._create_garage_device,
             TydomLight: self._create_light_device,
             TydomSwitch: self._create_switch_device,
+            TydomInterrupter: self._create_interrupter_device,
             TydomPlug: self._create_switch_device,
             TydomAlarm: self._create_alarm_device,
             TydomWeather: self._create_weather_device,
@@ -532,6 +537,25 @@ class Hub:
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(ha_device.get_sensors())
 
+    async def _create_interrupter_device(self, device: TydomInterrupter) -> None:
+        """Create a wall-switch event entity and one battery diagnostic."""
+        LOGGER.debug("Create wall-switch button %s", device.device_id)
+        ha_device = HAInterrupterEvent(device, self._hass)
+        self.ha_devices[device.device_id] = ha_device
+        if self.add_event_callback is not None:
+            self.add_event_callback([ha_device])
+
+        battery = self._interrupter_battery_entities.get(
+            device.physical_device_id
+        )
+        if battery is None:
+            battery = HAInterrupterBattery(device, self._hass)
+            self._interrupter_battery_entities[device.physical_device_id] = battery
+            if self.add_binary_sensor_callback is not None:
+                self.add_binary_sensor_callback([battery])
+        else:
+            battery.add_device(device)
+
     async def _create_switch_device(self, device: TydomPlug | TydomSwitch) -> None:
         """Create a switch device for a controllable binary output."""
         LOGGER.debug("Create switch %s", device.device_id)
@@ -829,6 +853,7 @@ class Hub:
         self.devices.clear()
         self.ha_devices.clear()
         self._remote_battery_entities.clear()
+        self._interrupter_battery_entities.clear()
         # Réinitialiser le flag pour recréer le bouton après le rechargement
         self._reload_button_created = False
 

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -22,6 +22,7 @@ from .tydom_devices import (
     TydomEnergy,
     TydomGarage,
     TydomGate,
+    TydomInterrupter,
     TydomLight,
     TydomSwitch,
     TydomPlug,
@@ -86,6 +87,8 @@ device_endpoint = {}
 device_type = {}
 device_metadata = {}
 device_tutorial_id = {}
+interrupter_endpoint_config = {}
+interrupter_info = {}
 scenario_metadata = {}  # Store scenario metadata from /configs/file
 groups_metadata = {}  # Store group metadata from /configs/file: {group_id: {"usage": "light", "name": "TOTAL"}}
 groups_data = {}  # Store groups data: {group_id: {"devices": [device_ids], "name": group_name}}
@@ -227,6 +230,49 @@ class Reply(TypedDict):
     """Raw reply events."""
     done: bool
     """Whether all reply events have been received or not."""
+
+
+def _interrupter_model(tutorial_id: str) -> str:
+    """Return a friendly wall-switch model from its tutorial identifier."""
+    if tutorial_id.startswith("switch_tyxia2600"):
+        return "TYXIA 2600"
+    return "Delta Dore wall switch"
+
+
+def _refresh_interrupter_info() -> None:
+    """Combine button endpoint configuration with its physical device group."""
+    interrupter_info.clear()
+
+    for unique_id, config in interrupter_endpoint_config.items():
+        physical_device_id = str(config["device_id"])
+        group_id = None
+        group_name = f"Wall switch {physical_device_id}"
+        group_tutorial_id = ""
+
+        for candidate_id, group in groups_data.items():
+            group_metadata = groups_metadata.get(candidate_id, {})
+            group_usage = group.get("usage") or group_metadata.get("usage")
+            if group_usage != "interrupter":
+                continue
+            if physical_device_id in group.get("devices", []):
+                group_id = candidate_id
+                group_name = (
+                    group_metadata.get("name") or group.get("name") or group_name
+                )
+                group_tutorial_id = str(group_metadata.get("tutorial_id", ""))
+                break
+
+        endpoint_tutorial_id = str(config.get("tutorial_id", ""))
+        interrupter_info[unique_id] = {
+            "physical_device_id": physical_device_id,
+            "group_id": group_id,
+            "name": group_name,
+            "model": _interrupter_model(
+                group_tutorial_id or endpoint_tutorial_id
+            ),
+            "button": config.get("button"),
+            "configured_action": config.get("configured_action", "TOGGLE"),
+        }
 
 
 class MessageHandler:
@@ -723,6 +769,18 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
+            case "interrupter":
+                return TydomInterrupter(
+                    tydom_client,
+                    uid,
+                    device_id,
+                    name,
+                    last_usage,
+                    endpoint,
+                    device_metadata.get(uid),
+                    data,
+                    interrupter_info.get(uid),
+                )
             case "boiler" | "sh_hvac" | "electric" | "aeraulic":
                 return TydomBoiler(
                     tydom_client,
@@ -889,6 +947,23 @@ class MessageHandler:
             if i.get("last_usage") == "remoteControl" and button_match is not None:
                 device_name[device_unique_id] = f"Button {button_match.group(1)}"
 
+            if i.get("last_usage") == "interrupter":
+                widget_behavior = i.get("widget_behavior") or {}
+                tutorial_id = str(widget_behavior.get("tutorial_id", ""))
+                button_match = re.search(
+                    r"BUTTON([A-Z0-9]+)", str(i.get("name", ""))
+                ) or re.search(r"_btn_([a-z0-9]+)$", tutorial_id)
+                button = button_match.group(1).upper() if button_match else None
+                interrupter_endpoint_config[device_unique_id] = {
+                    "device_id": i["id_device"],
+                    "endpoint_id": i["id_endpoint"],
+                    "tutorial_id": tutorial_id,
+                    "configured_action": widget_behavior.get("action", "TOGGLE"),
+                    "button": button,
+                }
+                if button is not None:
+                    device_name[device_unique_id] = f"Button {button}"
+
             if i["last_usage"] == "alarm":
                 device_name[device_unique_id] = "Tyxal Alarm"
 
@@ -930,6 +1005,7 @@ class MessageHandler:
                     )
 
         _refresh_remote_control_info()
+        _refresh_interrupter_info()
         LOGGER.debug("Configuration updated")
         return []
 
@@ -1556,9 +1632,9 @@ class MessageHandler:
                             "usage": group_usage,
                         }
 
-                        if group_usage == "remoteControl":
+                        if group_usage in {"remoteControl", "interrupter"}:
                             LOGGER.debug(
-                                "Skipping non-controllable remote-control group %s",
+                                "Skipping non-controllable input group %s",
                                 group_id_str,
                             )
                             continue
@@ -1587,6 +1663,7 @@ class MessageHandler:
                     len(groups) if isinstance(groups, list) else 0,
                 )
                 _refresh_remote_control_info()
+                _refresh_interrupter_info()
         return devices
 
     async def parse_moments_file(self, parsed, transaction_id):

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -267,9 +267,7 @@ def _refresh_interrupter_info() -> None:
             "physical_device_id": physical_device_id,
             "group_id": group_id,
             "name": group_name,
-            "model": _interrupter_model(
-                group_tutorial_id or endpoint_tutorial_id
-            ),
+            "model": _interrupter_model(group_tutorial_id or endpoint_tutorial_id),
             "button": config.get("button"),
             "configured_action": config.get("configured_action", "TOGGLE"),
         }

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -239,14 +239,44 @@ def _interrupter_model(tutorial_id: str) -> str:
     return "Delta Dore wall switch"
 
 
+def _is_ungrouped_tyxia_2600(endpoint_configs: list[dict]) -> bool:
+    """Recognise a TYXIA 2600 whose two outputs were paired separately."""
+    if len(endpoint_configs) != 2:
+        return False
+
+    names = [str(config.get("name", "")) for config in endpoint_configs]
+    return any(
+        re.fullmatch(r"Interrupteur\s+\d+", name, flags=re.IGNORECASE) for name in names
+    ) and any(
+        re.fullmatch(r"CG_DD_COMMON_BUTTON[AB]", name, flags=re.IGNORECASE)
+        for name in names
+    )
+
+
 def _refresh_interrupter_info() -> None:
     """Combine button endpoint configuration with its physical device group."""
     interrupter_info.clear()
 
+    configs_by_device: dict[str, list[tuple[str, dict]]] = {}
     for unique_id, config in interrupter_endpoint_config.items():
-        physical_device_id = str(config["device_id"])
+        configs_by_device.setdefault(str(config["device_id"]), []).append(
+            (unique_id, config)
+        )
+
+    for physical_device_id, endpoint_items in configs_by_device.items():
+        endpoint_configs = [config for _, config in endpoint_items]
         group_id = None
-        group_name = f"Wall switch {physical_device_id}"
+        friendly_names = [
+            str(config.get("name", ""))
+            for config in endpoint_configs
+            if config.get("name")
+            and not re.fullmatch(
+                r"CG_DD_COMMON_BUTTON[A-Z0-9]+",
+                str(config["name"]),
+                flags=re.IGNORECASE,
+            )
+        ]
+        group_name = friendly_names[0] if friendly_names else "Wall switch"
         group_tutorial_id = ""
 
         for candidate_id, group in groups_data.items():
@@ -262,15 +292,38 @@ def _refresh_interrupter_info() -> None:
                 group_tutorial_id = str(group_metadata.get("tutorial_id", ""))
                 break
 
-        endpoint_tutorial_id = str(config.get("tutorial_id", ""))
-        interrupter_info[unique_id] = {
-            "physical_device_id": physical_device_id,
-            "group_id": group_id,
-            "name": group_name,
-            "model": _interrupter_model(group_tutorial_id or endpoint_tutorial_id),
-            "button": config.get("button"),
-            "configured_action": config.get("configured_action", "TOGGLE"),
+        if not group_tutorial_id and _is_ungrouped_tyxia_2600(endpoint_configs):
+            group_tutorial_id = "switch_tyxia2600"
+
+        assigned_buttons = {
+            str(config["button"])
+            for config in endpoint_configs
+            if config.get("button") in {"A", "B"}
         }
+        missing_buttons = {"A", "B"} - assigned_buttons
+        missing_configs = [
+            config for config in endpoint_configs if config.get("button") is None
+        ]
+        if (
+            len(endpoint_configs) == 2
+            and len(missing_configs) == 1
+            and len(missing_buttons) == 1
+        ):
+            missing_configs[0]["button"] = missing_buttons.pop()
+
+        for unique_id, config in endpoint_items:
+            endpoint_tutorial_id = str(config.get("tutorial_id", ""))
+            button = config.get("button")
+            if button is not None:
+                device_name[unique_id] = f"Button {button}"
+            interrupter_info[unique_id] = {
+                "physical_device_id": physical_device_id,
+                "group_id": group_id,
+                "name": group_name,
+                "model": _interrupter_model(group_tutorial_id or endpoint_tutorial_id),
+                "button": button,
+                "configured_action": config.get("configured_action", "TOGGLE"),
+            }
 
 
 class MessageHandler:
@@ -955,6 +1008,7 @@ class MessageHandler:
                 interrupter_endpoint_config[device_unique_id] = {
                     "device_id": i["id_device"],
                     "endpoint_id": i["id_endpoint"],
+                    "name": i.get("name", ""),
                     "tutorial_id": tutorial_id,
                     "configured_action": widget_behavior.get("action", "TOGGLE"),
                     "button": button,

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -708,9 +708,7 @@ class TydomInterrupter(TydomDevice):
         self._interrupter_name = str(
             info.get("name", f"Wall switch {self._physical_device_id}")
         )
-        self._interrupter_model = str(
-            info.get("model", "Delta Dore wall switch")
-        )
+        self._interrupter_model = str(info.get("model", "Delta Dore wall switch"))
         self._button = info.get("button")
         self._configured_action = str(info.get("configured_action", "TOGGLE"))
         self._event_sequence = 0

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -677,6 +677,77 @@ class TydomWindow(TydomDevice):
     """represents a window."""
 
 
+class TydomInterrupter(TydomDevice):
+    """Represent one button endpoint of a physical wall switch."""
+
+    def __init__(
+        self,
+        tydom_client: TydomClient,
+        uid: str,
+        device_id: str,
+        name: str,
+        device_type: str,
+        endpoint: str | None,
+        metadata: dict | None,
+        data: dict | None,
+        interrupter_info: dict | None = None,
+    ) -> None:
+        """Initialise a wall-switch button endpoint."""
+        super().__init__(
+            tydom_client,
+            uid,
+            device_id,
+            name,
+            device_type,
+            endpoint,
+            metadata,
+            data,
+        )
+        info = interrupter_info or {}
+        self._physical_device_id = str(info.get("physical_device_id", device_id))
+        self._interrupter_name = str(
+            info.get("name", f"Wall switch {self._physical_device_id}")
+        )
+        self._interrupter_model = str(
+            info.get("model", "Delta Dore wall switch")
+        )
+        self._button = info.get("button")
+        self._configured_action = str(info.get("configured_action", "TOGGLE"))
+        self._event_sequence = 0
+
+    @property
+    def physical_device_id(self) -> str:
+        """Return the identifier shared by both wall-switch buttons."""
+        return self._physical_device_id
+
+    @property
+    def interrupter_name(self) -> str:
+        """Return the configured name of the physical wall switch."""
+        return self._interrupter_name
+
+    @property
+    def interrupter_model(self) -> str:
+        """Return the wall-switch model inferred from TYDOM configuration."""
+        return self._interrupter_model
+
+    @property
+    def button(self) -> str | None:
+        """Return the physical button represented by this endpoint."""
+        return self._button
+
+    @property
+    def event_sequence(self) -> int:
+        """Return a monotonically increasing sequence for fresh button actions."""
+        return self._event_sequence
+
+    async def update_device(self, device) -> None:
+        """Record fresh switch actions before publishing the endpoint update."""
+        action = getattr(device, "action", None)
+        if action is not None and action != "IDLE":
+            self._event_sequence += 1
+        await super().update_device(device)
+
+
 class TydomDoor(TydomDevice):
     """represents a door."""
 

--- a/tests/test_interrupter.py
+++ b/tests/test_interrupter.py
@@ -138,8 +138,7 @@ class TestInterrupter(IsolatedAsyncioTestCase):
                             {
                                 "id": device_id,
                                 "endpoints": [
-                                    {"id": endpoint_id}
-                                    for endpoint_id in endpoint_ids
+                                    {"id": endpoint_id} for endpoint_id in endpoint_ids
                                 ],
                             }
                         ],
@@ -238,11 +237,53 @@ class TestInterrupter(IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(
-            {
-                info["name"]
-                for info in handler_module.interrupter_info.values()
-            },
+            {info["name"] for info in handler_module.interrupter_info.values()},
             {"Portillon/Portail", "S à Manger/Esc Haut", "Cuisine / Esc Bas"},
+        )
+
+    async def test_separately_paired_outputs_rebuild_tyxia_2600_identity(
+        self,
+    ) -> None:
+        """A separately paired A output is combined with its raw B endpoint."""
+        device_id = 1759744899
+        endpoint_ids = [1759744899, 1759745026]
+
+        await self.handler.parse_config_data(
+            {
+                "endpoints": [
+                    {
+                        "id_device": device_id,
+                        "id_endpoint": endpoint_ids[0],
+                        "name": "Interrupteur 1",
+                        "first_usage": "interrupter",
+                        "last_usage": "interrupter",
+                    },
+                    {
+                        "id_device": device_id,
+                        "id_endpoint": endpoint_ids[1],
+                        "name": "CG_DD_COMMON_BUTTONB",
+                        "first_usage": "interrupter",
+                        "last_usage": "interrupter",
+                    },
+                ],
+                "groups": [],
+            },
+            None,
+        )
+
+        infos = [
+            handler_module.interrupter_info[f"{endpoint_id}_{device_id}"]
+            for endpoint_id in endpoint_ids
+        ]
+        self.assertEqual([info["button"] for info in infos], ["A", "B"])
+        self.assertEqual({info["name"] for info in infos}, {"Interrupteur 1"})
+        self.assertEqual({info["model"] for info in infos}, {"TYXIA 2600"})
+        self.assertEqual(
+            [
+                handler_module.device_name[f"{endpoint_id}_{device_id}"]
+                for endpoint_id in endpoint_ids
+            ],
+            ["Button A", "Button B"],
         )
 
     async def test_expired_action_does_not_repeat_last_press(self) -> None:

--- a/tests/test_interrupter.py
+++ b/tests/test_interrupter.py
@@ -1,0 +1,301 @@
+"""Tests for dedicated TYDOM wall-switch support."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module required to load the protocol code."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+root = Path(__file__).parents[1]
+devices_name = "custom_components.deltadore_tydom.tydom.tydom_devices"
+devices_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "tydom_devices.py"
+)
+devices_spec = importlib.util.spec_from_file_location(devices_name, devices_path)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(devices_name, sys.modules.get(devices_name, _MISSING))
+sys.modules[devices_name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_name = "custom_components.deltadore_tydom.tydom.MessageHandler"
+handler_path = (
+    root / "custom_components" / "deltadore_tydom" / "tydom" / "MessageHandler.py"
+)
+handler_spec = importlib.util.spec_from_file_location(handler_name, handler_path)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(handler_name, sys.modules.get(handler_name, _MISSING))
+sys.modules[handler_name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+TydomInterrupter = devices_module.TydomInterrupter
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class TestInterrupter(IsolatedAsyncioTestCase):
+    """Exercise physical wall-switch and button discovery."""
+
+    def setUp(self) -> None:
+        """Reset global protocol metadata."""
+        for mapping_name in (
+            "device_name",
+            "device_type",
+            "device_metadata",
+            "groups_metadata",
+            "groups_data",
+            "interrupter_endpoint_config",
+            "interrupter_info",
+        ):
+            getattr(handler_module, mapping_name).clear()
+        logger.reset_mock()
+        self.handler = MessageHandler(MagicMock(), b"")
+
+    async def _configure_switch(
+        self,
+        *,
+        device_id: int,
+        endpoint_ids: list[int],
+        endpoint_buttons: list[str],
+        group_id: int,
+        group_name: str,
+    ) -> None:
+        """Apply configuration matching a captured TYXIA 2600."""
+        await self.handler.parse_config_data(
+            {
+                "endpoints": [
+                    {
+                        "id_device": device_id,
+                        "id_endpoint": endpoint_id,
+                        "name": f"CG_DD_COMMON_BUTTON{button}",
+                        "first_usage": "interrupter",
+                        "last_usage": "interrupter",
+                        "widget_behavior": {
+                            "action": "TOGGLE",
+                            "tutorial_id": f"switch_tyxia2600_btn_{button.lower()}",
+                        },
+                    }
+                    for endpoint_id, button in zip(
+                        endpoint_ids, endpoint_buttons, strict=True
+                    )
+                ],
+                "groups": [
+                    {
+                        "id": group_id,
+                        "name": group_name,
+                        "usage": "interrupter",
+                        "type": "relatedendpoints",
+                        "widget_behavior": {"tutorial_id": "switch_tyxia2600"},
+                    }
+                ],
+            },
+            None,
+        )
+
+        groups = await self.handler.parse_groups_file(
+            {
+                "groups": [
+                    {
+                        "id": group_id,
+                        "devices": [
+                            {
+                                "id": device_id,
+                                "endpoints": [
+                                    {"id": endpoint_id}
+                                    for endpoint_id in endpoint_ids
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            },
+            None,
+        )
+        self.assertEqual(groups, [])
+
+    async def test_tyxia_2600_buttons_share_named_physical_device(self) -> None:
+        """Both endpoints are grouped and retain their A/B button identity."""
+        device_id = 1759742040
+        endpoint_ids = [1759742040, 1759742338]
+        await self._configure_switch(
+            device_id=device_id,
+            endpoint_ids=endpoint_ids,
+            endpoint_buttons=["B", "A"],
+            group_id=845782971,
+            group_name="Portillon/Portail",
+        )
+
+        for endpoint_id in endpoint_ids:
+            unique_id = f"{endpoint_id}_{device_id}"
+            handler_module.device_metadata[unique_id] = {
+                "battDefect": {"type": "boolean"},
+                "action": {"type": "string"},
+            }
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": device_id,
+                    "endpoints": [
+                        {
+                            "id": endpoint_id,
+                            "error": 0,
+                            "data": [
+                                {
+                                    "name": "battDefect",
+                                    "validity": "upToDate",
+                                    "value": False,
+                                },
+                                {
+                                    "name": "action",
+                                    "validity": "upToDate",
+                                    "value": "IDLE",
+                                },
+                            ],
+                        }
+                        for endpoint_id in endpoint_ids
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 2)
+        self.assertTrue(all(isinstance(device, TydomInterrupter) for device in devices))
+        self.assertEqual([device.button for device in devices], ["B", "A"])
+        self.assertEqual(
+            {device.physical_device_id for device in devices}, {str(device_id)}
+        )
+        self.assertEqual(
+            {device.interrupter_name for device in devices}, {"Portillon/Portail"}
+        )
+        self.assertEqual(
+            {device.interrupter_model for device in devices}, {"TYXIA 2600"}
+        )
+
+    async def test_all_three_captured_switch_names_are_retained(self) -> None:
+        """The group names configured in the Delta Dore app remain available."""
+        captures = (
+            (1759742040, [1759742040, 1759742338], 845782971, "Portillon/Portail"),
+            (
+                1759742530,
+                [1759742530, 1759742560],
+                1886000055,
+                "S à Manger/Esc Haut",
+            ),
+            (
+                1759743287,
+                [1759743287, 1759743998],
+                1896078259,
+                "Cuisine / Esc Bas",
+            ),
+        )
+
+        for device_id, endpoints, group_id, name in captures:
+            await self._configure_switch(
+                device_id=device_id,
+                endpoint_ids=endpoints,
+                endpoint_buttons=["A", "B"],
+                group_id=group_id,
+                group_name=name,
+            )
+
+        self.assertEqual(
+            {
+                info["name"]
+                for info in handler_module.interrupter_info.values()
+            },
+            {"Portillon/Portail", "S à Manger/Esc Haut", "Cuisine / Esc Bas"},
+        )
+
+    async def test_expired_action_does_not_repeat_last_press(self) -> None:
+        """Polling without a fresh action must not emit the previous press again."""
+        device = TydomInterrupter(
+            MagicMock(),
+            "endpoint_device",
+            "device",
+            "Button A",
+            "interrupter",
+            "endpoint",
+            None,
+            {"action": "IDLE"},
+            {"physical_device_id": "device", "button": "A"},
+        )
+        callback = MagicMock()
+        device.register_callback(callback)
+
+        pressed = TydomInterrupter(
+            MagicMock(),
+            "endpoint_device",
+            "device",
+            "Button A",
+            "interrupter",
+            "endpoint",
+            None,
+            {"action": "TOGGLE"},
+            {"physical_device_id": "device", "button": "A"},
+        )
+        await device.update_device(pressed)
+
+        self.assertEqual(device.event_sequence, 1)
+        callback.assert_called_once_with()
+
+        callback.reset_mock()
+        expired = TydomInterrupter(
+            MagicMock(),
+            "endpoint_device",
+            "device",
+            "Button A",
+            "interrupter",
+            "endpoint",
+            None,
+            None,
+            {"physical_device_id": "device", "button": "A"},
+        )
+        await device.update_device(expired)
+
+        self.assertEqual(device.event_sequence, 1)
+        callback.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

Add native Home Assistant event support for Delta Dore wall switches exposed by TYDOM with the `interrupter` usage.

TYXIA 2600 endpoints currently appear in the protocol data, but their physical button actions are not exposed to Home Assistant. This prevents the switches from being used as automation triggers independently of their configured TYDOM actions.

Buttons A and B are input-only physical controls, not controllable switches. Exposing them as switch entities would be misleading and would provide no useful command. This feature instead exposes their presses as Home Assistant event entities so a short or long press can trigger any action chosen by the user in an automation.

## Changes

- Recognise `interrupter` endpoints as physical wall-switch buttons.
- Identify TYXIA 2600 devices from their explicit Delta Dore tutorial identifier.
- Expose each button endpoint as a Home Assistant button event entity.
- Keep these input-only endpoints out of the switch platform: they report physical presses and do not represent controllable outputs.
- Emit `press_end` for a normal completed press and `long_press_end` for a completed long press.
- Include the raw Delta Dore action and configured action in the event data.
- Group buttons A and B under one physical TYXIA 2600 device.
- Expose one shared battery-fault diagnostic per physical switch.
- Prevent an expired or `IDLE` update from repeating the previous button event.
- Avoid creating a separate, non-controllable entity for the internal TYDOM `interrupter` relationship group.

## Separately paired TYXIA 2600 outputs

TYDOM does not always expose the two outputs consistently.

When both buttons are paired together, the configuration includes the normal `switch_tyxia2600` relationship group and the integration can directly recover the physical device name and model.

When the outputs have been paired separately, TYDOM may instead expose:

- one endpoint named `Interrupteur <number>`;
- one endpoint named `CG_DD_COMMON_BUTTONA` or `CG_DD_COMMON_BUTTONB`;
- no normal relationship group.

The integration recognises this two-endpoint signature, rebuilds the shared physical TYXIA 2600 identity and assigns the missing A/B button designation without hard-coding a particular installation or endpoint identifier.

Unknown `interrupter` devices remain supported with the generic model name `Delta Dore wall switch`.

## Home Assistant entities

A two-button TYXIA 2600 produces:

- `event.button_a`;
- `event.button_b`;
- one shared `binary_sensor.battery_fault`.

Example event data:

```yaml
event_type: press_end
data:
  action: TOGGLE
  configured_action: TOGGLE
```

These are deliberately event entities rather than switches. A press does not ask Home Assistant to turn the TYXIA 2600 itself on or off; it supplies an automation trigger. Users can therefore assign any Home Assistant action to a physical input, for example:

- a short press on button A turns a light on or off;
- a long press on button A starts a scene;
- a short press on button B opens a gate;
- a long press on button B runs a different script.

Automations can distinguish `press_end` from `long_press_end` and can also inspect the raw and configured Delta Dore action data. The existing action configured in TYDOM remains independent of the Home Assistant automation.

## Testing

Added focused regression coverage for:

- grouping both button endpoints under one named physical TYXIA 2600;
- retaining the captured names of multiple wall switches;
- rebuilding the TYXIA 2600 identity when its outputs were paired separately;
- assigning the missing A/B button designation;
- exposing a single shared battery diagnostic;
- emitting fresh button actions only once;
- ignoring expired updates so the previous press is not repeated.

Final automated checks:

- Ruff: passed;
- full test suite: 71 passed.

### Live installation testing

Tested on three physical TYXIA 2600 wall switches:

- `Portillon/Portail`;
- `S à Manger/Esc Haut`;
- `Cuisine/Esc Bas`.

Both A and B buttons were pressed on each device. Sanitised debug-log review confirmed that:

- every endpoint was classified as `interrupter`;
- the physical devices and A/B endpoints were mapped correctly;
- each short press produced a fresh `TOGGLE` action;
- each action returned to `IDLE`;
- the `IDLE` updates did not repeat the previous event;
- the shared battery diagnostics reported no fault.

### Independent live validation

A second installation was tested by @PATGAR64 after pairing a TYXIA 2600 with the TYDOM gateway. Before applying this branch, Home Assistant exposed the raw button and diagnostic registers as several generic button and sensor entities.

After applying the branch, restarting Home Assistant and removing the obsolete registry entries, the same physical transmitter was represented as:

- one TYXIA 2600 device;
- a Button A event entity;
- a Button B event entity; and
- one shared battery-fault diagnostic, reported as normal.

The supplied screenshots show two separate physical Button A presses recorded as `press_end`. The sanitised debug-log review also confirmed the explicit Delta Dore button A/B tutorial identifiers, both endpoints grouped under the same physical device, and their initial `IDLE` and no-battery-fault states.

This independently validates discovery, physical-device grouping, entity creation and repeated short-press delivery on another gateway. Button B discovery was confirmed, but a physical Button B press and long presses were not claimed as part of this particular test.