### PR TITLE
Fix TYWATT cdata energy readings

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -1588,6 +1588,8 @@ class HAEnergy(SensorEntity, HAEntity):
         "energyIndexECSWatt": SensorDeviceClass.ENERGY,
         "energyIndexHeatGas": SensorDeviceClass.ENERGY,
         "energyIndex": SensorDeviceClass.ENERGY,
+        "energyDistrib": SensorDeviceClass.ENERGY,
+        "energyInstant_ELEC_A": SensorDeviceClass.CURRENT,
         "outTemperature": SensorDeviceClass.TEMPERATURE,
     }
 
@@ -1599,7 +1601,9 @@ class HAEnergy(SensorEntity, HAEntity):
         "energyIndexHeatWatt": SensorStateClass.TOTAL_INCREASING,
         "energyIndexHeatGas": SensorStateClass.TOTAL_INCREASING,
         "energyIndex": SensorStateClass.TOTAL_INCREASING,
+        "energyDistrib": SensorStateClass.TOTAL_INCREASING,
         # Measurement for instant values
+        "energyInstant_ELEC_A": SensorStateClass.MEASUREMENT,
         "energyInstantTotElec": SensorStateClass.MEASUREMENT,
         "energyInstantTotElecP": SensorStateClass.MEASUREMENT,
         "energyInstantTi1P": SensorStateClass.MEASUREMENT,
@@ -1648,6 +1652,8 @@ class HAEnergy(SensorEntity, HAEntity):
         "energyIndexECSWatt": UnitOfEnergy.WATT_HOUR,
         "energyIndexHeatGas": UnitOfEnergy.WATT_HOUR,
         "energyIndex": UnitOfEnergy.WATT_HOUR,
+        "energyDistrib": UnitOfEnergy.WATT_HOUR,
+        "energyInstant_ELEC_A": UnitOfElectricCurrent.AMPERE,
         "outTemperature": UnitOfTemperature.CELSIUS,
     }
 

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -53,6 +53,59 @@ Some firmwares never send an EOR flag; they mark the end of the enumeration
 with a last element carrying index 255 and invalid event data instead.
 """
 
+_ENERGY_INSTANT_DIVISORS = {
+    "ELEC_A": 100,
+}
+"""Divisors used by TYDOM for instantaneous energy measurements."""
+
+
+def _parse_energy_cdata_element(element: Any) -> dict[str, int | float]:
+    """Extract sensor values from one successful energy cdata element."""
+    if not isinstance(element, dict) or element.get("status", "OK") != "OK":
+        return {}
+
+    name = element.get("name")
+    parameters = element.get("parameters")
+    values = element.get("values")
+    if not isinstance(parameters, dict) or not isinstance(values, dict):
+        return {}
+
+    if name == "energyIndex":
+        destination = parameters.get("dest")
+        counter = values.get("counter")
+        if (
+            not isinstance(destination, str)
+            or destination.startswith("TEMP_")
+            or not isinstance(counter, (int, float))
+            or isinstance(counter, bool)
+        ):
+            return {}
+        return {f"{name}_{destination}": counter}
+
+    if name == "energyInstant":
+        unit = parameters.get("unit")
+        measure = values.get("measure")
+        if (
+            not isinstance(unit, str)
+            or unit not in _ENERGY_INSTANT_DIVISORS
+            or not isinstance(measure, (int, float))
+            or isinstance(measure, bool)
+        ):
+            return {}
+        return {f"{name}_{unit}": measure / _ENERGY_INSTANT_DIVISORS[unit]}
+
+    if name == "energyDistrib":
+        return {
+            f"{name}_{key}": value
+            for key, value in values.items()
+            if isinstance(key, str)
+            and key.isupper()
+            and isinstance(value, (int, float))
+            and not isinstance(value, bool)
+        }
+
+    return {}
+
 
 def _is_tyxia_4910_other(uid: str) -> bool:
     """Identify a binary TYXIA 4910 configured under the TYDOM 'others' usage."""
@@ -1466,45 +1519,7 @@ class MessageHandler:
 
                         for elem in endpoint["cdata"]:
                             if type_of_id == "conso":
-                                element_name = None
-                                if "parameters" in elem and elem["parameters"].get(
-                                    "dest"
-                                ):
-                                    element_name = (
-                                        elem["name"] + "_" + elem["parameters"]["dest"]
-                                    )
-                                    element_value = elem["values"]["counter"]
-                                    data[element_name] = element_value
-                                elif "parameters" in elem and elem["parameters"].get(
-                                    "period"
-                                ):
-                                    for key in elem["values"]:
-                                        if key.isupper():
-                                            element_name = elem["name"] + "_" + key
-                                            data[element_name] = elem["values"][key]
-                                else:
-                                    continue
-
-                                # Create the device
-                                device = await MessageHandler.get_device(
-                                    self.tydom_client,
-                                    type_of_id,
-                                    unique_id,
-                                    device_id,
-                                    name_of_id,
-                                    endpoint_id,
-                                    data,
-                                )
-
-                                if device is not None:
-                                    devices.append(device)
-                                    LOGGER.debug(
-                                        "Device update (id=%s, endpoint=%s, name=%s, type=%s)",
-                                        device_id,
-                                        endpoint_id,
-                                        name_of_id,
-                                        type_of_id,
-                                    )
+                                data.update(_parse_energy_cdata_element(elem))
 
                             elif type_of_id == "alarm" and transaction_id is not None:
                                 reply = None
@@ -1555,6 +1570,27 @@ class MessageHandler:
                             else:
                                 LOGGER.debug(
                                     "Ignore cdata message targetting '%s' (%s).",
+                                    name_of_id,
+                                    type_of_id,
+                                )
+
+                        if type_of_id == "conso" and data:
+                            device = await MessageHandler.get_device(
+                                self.tydom_client,
+                                type_of_id,
+                                unique_id,
+                                device_id,
+                                name_of_id,
+                                endpoint_id,
+                                data,
+                            )
+
+                            if device is not None:
+                                devices.append(device)
+                                LOGGER.debug(
+                                    "Device update (id=%s, endpoint=%s, name=%s, type=%s)",
+                                    device_id,
+                                    endpoint_id,
                                     name_of_id,
                                     type_of_id,
                                 )

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -66,6 +66,7 @@ handler_spec.loader.exec_module(handler_module)
 
 MessageHandler = handler_module.MessageHandler
 TydomLight = devices_module.TydomLight
+TydomEnergy = devices_module.TydomEnergy
 
 for name, original in _original_modules.items():
     if original is _MISSING:
@@ -76,6 +77,11 @@ for name, original in _original_modules.items():
 
 class ProtocolResponseTests(IsolatedAsyncioTestCase):
     """Exercise response acknowledgements and light refresh polling."""
+
+    def setUp(self) -> None:
+        """Reset protocol state shared between tests."""
+        handler_module.device_name.clear()
+        handler_module.device_type.clear()
 
     def test_light_brightness_requires_intermediate_levels(self) -> None:
         """Binary level metadata must not advertise variable brightness."""
@@ -190,6 +196,103 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
                 call("/devices/20/endpoints/10/data"),
             ],
         )
+
+    async def test_energy_cdata_exposes_index_distribution_and_current(self) -> None:
+        """Captured TYWATT cdata shapes must become one energy device update."""
+        handler_module.device_name["20_10"] = "TYWATT"
+        handler_module.device_type["20_10"] = "conso"
+        handler = MessageHandler(MagicMock(), b"")
+
+        devices = await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 10,
+                    "endpoints": [
+                        {
+                            "id": 20,
+                            "error": 0,
+                            "cdata": [
+                                {
+                                    "name": "energyIndex",
+                                    "status": "OK",
+                                    "parameters": {"dest": "ELEC_TOTAL"},
+                                    "values": {"counter": 66268504},
+                                },
+                                {
+                                    "name": "energyInstant",
+                                    "status": "OK",
+                                    "parameters": {"unit": "ELEC_A"},
+                                    "values": {"measure": 500},
+                                },
+                                {
+                                    "name": "energyDistrib",
+                                    "status": "OK",
+                                    "parameters": {
+                                        "src": "ELEC",
+                                        "period": "YEAR",
+                                        "periodOffset": 0,
+                                    },
+                                    "values": {
+                                        "date": "2095-10-07",
+                                        "ELEC_HEATING": 14484,
+                                        "ELEC_HOTWATER": 201117,
+                                        "ELEC_OUTLET": 25638,
+                                        "ELEC_OTHER": 176376,
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(len(devices), 1)
+        device = devices[0]
+        self.assertIsInstance(device, TydomEnergy)
+        self.assertEqual(device.energyIndex_ELEC_TOTAL, 66268504)
+        self.assertEqual(device.energyInstant_ELEC_A, 5)
+        self.assertEqual(device.energyDistrib_ELEC_HEATING, 14484)
+        self.assertEqual(device.energyDistrib_ELEC_HOTWATER, 201117)
+        self.assertEqual(device.energyDistrib_ELEC_OUTLET, 25638)
+        self.assertEqual(device.energyDistrib_ELEC_OTHER, 176376)
+
+    async def test_energy_cdata_ignores_failed_and_malformed_values(self) -> None:
+        """Unsupported cdata replies must not create misleading sensors."""
+        handler_module.device_name["20_10"] = "TYWATT"
+        handler_module.device_type["20_10"] = "conso"
+        handler = MessageHandler(MagicMock(), b"")
+
+        devices = await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 10,
+                    "endpoints": [
+                        {
+                            "id": 20,
+                            "error": 0,
+                            "cdata": [
+                                {"name": "energyIndex", "status": "destNOK"},
+                                {
+                                    "name": "energyIndex",
+                                    "status": "OK",
+                                    "parameters": {"dest": "TEMP_OUTDOOR"},
+                                    "values": {"counter": 18},
+                                },
+                                {
+                                    "name": "energyInstant",
+                                    "status": "OK",
+                                    "parameters": {"unit": "UNKNOWN"},
+                                    "values": {"measure": 500},
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        )
+
+        self.assertEqual(devices, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR restores TYWATT electrical consumption readings returned through the TYDOM `cdata` protocol.

It exposes:

- instantaneous electrical current;
- total electricity consumption;
- heating consumption;
- hot-water consumption;
- socket consumption;
- other electrical consumption.

## Problem

The integration already requests the appropriate TYWATT values, but the responses use several different structures.

An energy index is returned through:

```json
{
  name: energyIndex,
  status: OK,
  parameters: {
    dest: ELEC_TOTAL
  },
  values: {
    counter: 66268504
  }
}
```

Instantaneous current uses `unit` and `measure` instead:

```json
{
  name: energyInstant,
  status: OK,
  parameters: {
    unit: ELEC_A
  },
  values: {
    measure: 500
  }
}
```

Distribution values are returned together:

```json
{
  name: energyDistrib,
  status: OK,
  parameters: {
    src: ELEC,
    period: YEAR,
    periodOffset: 0
  },
  values: {
    ELEC_HEATING: 14484,
    ELEC_HOTWATER: 201117,
    ELEC_OUTLET: 25638,
    ELEC_OTHER: 176376
  }
}
```

The existing parser handles some destination counters and distribution values, but ignores the `energyInstant` structure. It also creates a separate partial device update while processing each response element.

As a result, requests are visible in the logs but several corresponding Home Assistant sensors are never populated.

## Resolution

The `cdata` parser now:

- handles `energyIndex`, `energyInstant` and `energyDistrib` independently;
- converts the raw `ELEC_A` value using the scale observed in the supplied protocol data, for example `500` becomes `5 A`;
- validates response status and numeric values before exposing them;
- ignores failed, malformed and unsupported replies;
- combines all values from one endpoint response into a single TYWATT device update;
- avoids creating partial duplicate updates while processing individual elements.

The generated sensor attributes inherit the appropriate Home Assistant metadata:

- electrical current: amperes with `measurement`;
- consumption counters: watt-hours with `total_increasing`.

The implementation is based on response capabilities and protocol fields rather than a specific device identifier.

## Temperature destinations

`TEMP_INDOOR` and `TEMP_OUTDOOR` are deliberately not exposed by this change.

The supplied logs show those requests being rejected with `destNOK` or `srcNOK`. The returned counter therefore cannot safely be interpreted as a temperature without a successful response confirming its meaning and scale.

## Testing

Automated coverage confirms that:

- total consumption is parsed from `energyIndex`;
- raw instantaneous current is correctly scaled;
- heating, hot-water, socket and other consumption are parsed from `energyDistrib`;
- all readings are combined into one device update;
- failed responses are ignored;
- temperature destinations rejected by the gateway do not create misleading sensors;
- malformed and unsupported values do not create entities.

Local validation:

```text
Ruff: passed
Focused protocol and sensor-registration tests: 11 passed
Full maintained test suite: 92 passed
git diff --check: passed
```

A dedicated branch is available for live TYWATT testing:

https://github.com/Sleinous/hass-deltadore-tydom-component/tree/fix/issue-191-tywatt-cdata

Live confirmation from the reporter is still pending.

Fixes #191