### PR TITLE
Add TYXAL+ remote product and zone management

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ describes how to probe available API resources and HTTP methods.
 The alarm control panel provides services for the TYXAL+ functions that are
 useful in Home Assistant:
 
+- `deltadore_tydom.get_events` returns alarm history filtered as all,
+  alarm events, activation/deactivation events or unacknowledged events;
+- `deltadore_tydom.acknowledge_events` acknowledges pending alarm events;
 - `deltadore_tydom.get_alarm_products` lists configured products and zones;
 - `deltadore_tydom.enter_alarm_maintenance` opens a locked remote
   configuration session and puts a disarmed CS8000 into maintenance mode;
@@ -139,6 +142,9 @@ reading or changing product configuration, and always exit maintenance when
 finished. The installer code is used only for the request and is redacted from
 logs. Product deletion, access codes, telephone settings and siren
 configuration are not exposed.
+
+The TYXAL alarm device also provides an **Acknowledge events** button for the
+same operation when an action call or automation is not required.
 
 ## Contributions are welcome!
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ useful in Home Assistant:
   state and zone assignment;
 - `deltadore_tydom.configure_alarm_product` enables or disables a product and
   can assign it to another zone;
-- `deltadore_tydom.rename_alarm_zone` changes a zone's custom name;
+- `deltadore_tydom.rename_alarm_zone` changes a zone's custom name, or clears
+  its label when supplied with an empty name;
 - `deltadore_tydom.exit_alarm_maintenance` returns the CS8000 to its normal
   disarmed state and unlocks the remote configuration session.
 

--- a/README.md
+++ b/README.md
@@ -122,17 +122,23 @@ The alarm control panel provides services for the TYXAL+ functions that are
 useful in Home Assistant:
 
 - `deltadore_tydom.get_alarm_products` lists configured products and zones;
+- `deltadore_tydom.enter_alarm_maintenance` opens a locked remote
+  configuration session and puts a disarmed CS8000 into maintenance mode;
 - `deltadore_tydom.get_alarm_product_configuration` reads a product's active
   state and zone assignment;
 - `deltadore_tydom.configure_alarm_product` enables or disables a product and
   can assign it to another zone;
-- `deltadore_tydom.rename_alarm_zone` changes a zone's custom name.
+- `deltadore_tydom.rename_alarm_zone` changes a zone's custom name;
+- `deltadore_tydom.exit_alarm_maintenance` returns the CS8000 to its normal
+  disarmed state and unlocks the remote configuration session.
 
 Use the first service to obtain the product and zone IDs required by the other
-services. Configuration changes require the alarm PIN supplied in the service
-call. The PIN is used only for that request and is redacted from logs. Product
-deletion, access codes, telephone settings and siren configuration are not
-exposed.
+services. Product configuration requires the CS8000 to be disarmed and the
+TYXAL installer code supplied in each service call. Enter maintenance before
+reading or changing product configuration, and always exit maintenance when
+finished. The installer code is used only for the request and is redacted from
+logs. Product deletion, access codes, telephone settings and siren
+configuration are not exposed.
 
 ## Contributions are welcome!
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ connection examples, output analysis, parser validation and security guidance.
 The separate [endpoint discovery guide](tools/README_discover_endpoints.md)
 describes how to probe available API resources and HTTP methods.
 
+## TYXAL+ remote management
+
+The alarm control panel provides services for the TYXAL+ functions that are
+useful in Home Assistant:
+
+- `deltadore_tydom.get_alarm_products` lists configured products and zones;
+- `deltadore_tydom.get_alarm_product_configuration` reads a product's active
+  state and zone assignment;
+- `deltadore_tydom.configure_alarm_product` enables or disables a product and
+  can assign it to another zone;
+- `deltadore_tydom.rename_alarm_zone` changes a zone's custom name.
+
+Use the first service to obtain the product and zone IDs required by the other
+services. Configuration changes require the alarm PIN supplied in the service
+call. The PIN is used only for that request and is redacted from logs. Product
+deletion, access codes, telephone settings and siren configuration are not
+exposed.
+
 ## Contributions are welcome!
 
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)

--- a/custom_components/deltadore_tydom/alarm_control_panel.py
+++ b/custom_components/deltadore_tydom/alarm_control_panel.py
@@ -15,6 +15,14 @@ from .const import DOMAIN
 
 SERVICE_ACKNOWLEDGE_EVENTS = "acknowledge_events"
 SERVICE_GET_EVENTS = "get_events"
+SERVICE_GET_ALARM_PRODUCTS = "get_alarm_products"
+SERVICE_GET_ALARM_PRODUCT_CONFIGURATION = "get_alarm_product_configuration"
+SERVICE_CONFIGURE_ALARM_PRODUCT = "configure_alarm_product"
+SERVICE_RENAME_ALARM_ZONE = "rename_alarm_zone"
+
+ALARM_CODE_SCHEMA = vol.All(cv.string, vol.Length(min=1))
+PRODUCT_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0))
+ZONE_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=1, max=8))
 
 
 async def async_setup_entry(
@@ -47,4 +55,44 @@ async def async_setup_entry(
         },
         "async_get_events",
         supports_response=SupportsResponse.ONLY,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_GET_ALARM_PRODUCTS,
+        {},
+        "async_get_alarm_products",
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_GET_ALARM_PRODUCT_CONFIGURATION,
+        {
+            vol.Required("code"): ALARM_CODE_SCHEMA,
+            vol.Required("product_id"): PRODUCT_ID_SCHEMA,
+        },
+        "async_get_alarm_product_configuration",
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_CONFIGURE_ALARM_PRODUCT,
+        {
+            vol.Required("code"): ALARM_CODE_SCHEMA,
+            vol.Required("product_id"): PRODUCT_ID_SCHEMA,
+            vol.Optional("active"): cv.boolean,
+            vol.Optional("zone"): ZONE_ID_SCHEMA,
+        },
+        "async_configure_alarm_product",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_RENAME_ALARM_ZONE,
+        {
+            vol.Required("code"): ALARM_CODE_SCHEMA,
+            vol.Required("zone_id"): ZONE_ID_SCHEMA,
+            vol.Required("name"): vol.All(
+                cv.string, str.strip, vol.Length(min=1, max=64)
+            ),
+        },
+        "async_rename_alarm_zone",
     )

--- a/custom_components/deltadore_tydom/alarm_control_panel.py
+++ b/custom_components/deltadore_tydom/alarm_control_panel.py
@@ -110,9 +110,7 @@ async def async_setup_entry(
         {
             vol.Required("code"): ALARM_CODE_SCHEMA,
             vol.Required("zone_id"): ZONE_ID_SCHEMA,
-            vol.Required("name"): vol.All(
-                cv.string, str.strip, vol.Length(min=1, max=64)
-            ),
+            vol.Required("name"): vol.All(cv.string, str.strip, vol.Length(max=64)),
         },
         "async_rename_alarm_zone",
     )

--- a/custom_components/deltadore_tydom/alarm_control_panel.py
+++ b/custom_components/deltadore_tydom/alarm_control_panel.py
@@ -19,6 +19,8 @@ SERVICE_GET_ALARM_PRODUCTS = "get_alarm_products"
 SERVICE_GET_ALARM_PRODUCT_CONFIGURATION = "get_alarm_product_configuration"
 SERVICE_CONFIGURE_ALARM_PRODUCT = "configure_alarm_product"
 SERVICE_RENAME_ALARM_ZONE = "rename_alarm_zone"
+SERVICE_ENTER_ALARM_MAINTENANCE = "enter_alarm_maintenance"
+SERVICE_EXIT_ALARM_MAINTENANCE = "exit_alarm_maintenance"
 
 ALARM_CODE_SCHEMA = vol.All(
     cv.string,
@@ -78,6 +80,18 @@ async def async_setup_entry(
         },
         "async_get_alarm_product_configuration",
         supports_response=SupportsResponse.ONLY,
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ENTER_ALARM_MAINTENANCE,
+        {vol.Required("code"): ALARM_CODE_SCHEMA},
+        "async_enter_alarm_maintenance",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_EXIT_ALARM_MAINTENANCE,
+        {vol.Required("code"): ALARM_CODE_SCHEMA},
+        "async_exit_alarm_maintenance",
     )
 
     platform.async_register_entity_service(

--- a/custom_components/deltadore_tydom/alarm_control_panel.py
+++ b/custom_components/deltadore_tydom/alarm_control_panel.py
@@ -20,7 +20,13 @@ SERVICE_GET_ALARM_PRODUCT_CONFIGURATION = "get_alarm_product_configuration"
 SERVICE_CONFIGURE_ALARM_PRODUCT = "configure_alarm_product"
 SERVICE_RENAME_ALARM_ZONE = "rename_alarm_zone"
 
-ALARM_CODE_SCHEMA = vol.All(cv.string, vol.Length(min=1))
+ALARM_CODE_SCHEMA = vol.All(
+    cv.string,
+    vol.Match(
+        r"^[0-9A-Fa-f]{6}$",
+        msg="The TYXAL access code must contain 6 hexadecimal characters",
+    ),
+)
 PRODUCT_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0))
 ZONE_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=7))
 

--- a/custom_components/deltadore_tydom/alarm_control_panel.py
+++ b/custom_components/deltadore_tydom/alarm_control_panel.py
@@ -22,7 +22,7 @@ SERVICE_RENAME_ALARM_ZONE = "rename_alarm_zone"
 
 ALARM_CODE_SCHEMA = vol.All(cv.string, vol.Length(min=1))
 PRODUCT_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0))
-ZONE_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=1, max=8))
+ZONE_ID_SCHEMA = vol.All(vol.Coerce(int), vol.Range(min=0, max=7))
 
 
 async def async_setup_entry(

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5997,6 +5997,103 @@ class HAAlarmAcknowledgeButton(ButtonEntity, HAEntity):
         await self._device.acknowledge_events()
 
 
+class HAAlarmPendingEventsSensor(SensorEntity, HAEntity):
+    """Dashboard-friendly view of unacknowledged TYXAL alarm events."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_translation_key = "pending_alarm_events"
+    _attr_icon = "mdi:shield-alert-outline"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, device: TydomAlarm, hass) -> None:
+        """Initialise the pending-events sensor."""
+        self.hass = hass
+        self._device = device
+        self._attr_unique_id = f"{device.device_id}_pending_alarm_events"
+        self._last_unacked_state = bool(getattr(device, "unackedEvent", False))
+        self._refresh_task = None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the number of cached unacknowledged events."""
+        events = self._device.pending_events
+        return None if events is None else len(events)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the bounded TYXAL event list for dashboards and automations."""
+        events = self._device.pending_events
+        if events is None:
+            return {}
+        return {
+            "events": events,
+            "latest_event": events[0] if events else None,
+        }
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link the sensor to the existing TYXAL alarm device."""
+        device_info = self._get_device_info()
+        info: DeviceInfo = {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": device_info["manufacturer"],
+        }
+        if "model" in device_info:
+            info["model"] = device_info["model"]
+        return self._enrich_device_info(info)
+
+    async def async_added_to_hass(self) -> None:
+        """Fetch pending events initially and react to alarm supervision pushes."""
+        await super().async_added_to_hass()
+        self._device.register_callback(self._handle_alarm_update)
+        if self._last_unacked_state:
+            self._schedule_refresh()
+        else:
+            self._device.clear_pending_events()
+            self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the alarm-state callback and cancel an outstanding refresh."""
+        self._device.remove_callback(self._handle_alarm_update)
+        if self._refresh_task is not None:
+            self._refresh_task.cancel()
+        await super().async_will_remove_from_hass()
+
+    def _handle_alarm_update(self) -> None:
+        """Refresh history when TYXAL reports a new unacknowledged condition."""
+        unacked = bool(getattr(self._device, "unackedEvent", False))
+        should_refresh = unacked and (
+            not self._last_unacked_state or self._device.pending_events is None
+        )
+        self._last_unacked_state = unacked
+
+        if not unacked:
+            self._device.clear_pending_events()
+        elif should_refresh:
+            self._schedule_refresh()
+        self.async_write_ha_state()
+
+    def _schedule_refresh(self) -> None:
+        """Schedule one history request without delaying entity setup."""
+        if self._refresh_task is None or self._refresh_task.done():
+            self._refresh_task = self.hass.async_create_task(
+                self._async_refresh_events(),
+                "Refresh TYXAL unacknowledged events",
+            )
+
+    async def _async_refresh_events(self) -> None:
+        """Fetch the bounded list advertised by the TYXAL history endpoint."""
+        try:
+            await self._device.get_events("UNACKED_EVENTS")
+        except Exception:
+            LOGGER.exception(
+                "Unable to refresh unacknowledged events for %s",
+                self._device.device_id,
+            )
+
+
 class HAReloadButton(ButtonEntity):
     """Button entity for reloading all devices."""
 

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     PERCENTAGE,
 )
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -3397,6 +3398,34 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
     async def async_get_events(self, event_type=None) -> list:
         """Get alarm events."""
         return await self._device.get_events(event_type or "UNACKED_EVENTS")
+
+    async def async_get_alarm_products(self) -> dict[str, list[dict[str, Any]]]:
+        """Return the products and zones configured on the alarm."""
+        return await self._device.get_alarm_products()
+
+    async def async_get_alarm_product_configuration(
+        self, code: str, product_id: int
+    ) -> dict[str, Any]:
+        """Return the common configuration of one alarm product."""
+        return await self._device.get_alarm_product_configuration(code, product_id)
+
+    async def async_configure_alarm_product(
+        self,
+        code: str,
+        product_id: int,
+        active: bool | None = None,
+        zone: int | None = None,
+    ) -> None:
+        """Enable, disable or reassign one alarm product."""
+        if active is None and zone is None:
+            raise HomeAssistantError("At least one of active or zone must be supplied")
+        await self._device.configure_alarm_product(
+            code, product_id, active=active, zone=zone
+        )
+
+    async def async_rename_alarm_zone(self, code: str, zone_id: int, name: str) -> None:
+        """Rename one alarm zone."""
+        await self._device.rename_alarm_zone(code, zone_id, name)
 
 
 class HaWeather(WeatherEntity, HAEntity):

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5965,6 +5965,38 @@ class HAButton(ButtonEntity, HAEntity):
             )
 
 
+class HAAlarmAcknowledgeButton(ButtonEntity, HAEntity):
+    """Button which acknowledges pending TYXAL alarm events."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_translation_key = "acknowledge_events"
+    _attr_icon = "mdi:notification-clear-all"
+
+    def __init__(self, device: TydomAlarm, hass) -> None:
+        """Initialise the alarm acknowledgement button."""
+        self.hass = hass
+        self._device = device
+        self._attr_unique_id = f"{device.device_id}_acknowledge_events"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link the button to the existing TYXAL alarm device."""
+        device_info = self._get_device_info()
+        info: DeviceInfo = {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": device_info["manufacturer"],
+        }
+        if "model" in device_info:
+            info["model"] = device_info["model"]
+        return self._enrich_device_info(info)
+
+    async def async_press(self) -> None:
+        """Acknowledge every pending alarm event."""
+        await self._device.acknowledge_events()
+
+
 class HAReloadButton(ButtonEntity):
     """Button entity for reloading all devices."""
 

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3407,7 +3407,32 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         self, code: str, product_id: int
     ) -> dict[str, Any]:
         """Return the common configuration of one alarm product."""
-        return await self._device.get_alarm_product_configuration(code, product_id)
+        try:
+            return await self._device.get_alarm_product_configuration(code, product_id)
+        except Exception as err:
+            raise HomeAssistantError(
+                "The TYXAL rejected the configuration request. Ensure the CS8000 "
+                "is in maintenance mode and use its installer code."
+            ) from err
+
+    async def async_enter_alarm_maintenance(self, code: str) -> None:
+        """Put the TYXAL central unit into maintenance mode."""
+        try:
+            await self._device.enter_alarm_maintenance(code)
+        except Exception as err:
+            raise HomeAssistantError(
+                "The TYXAL could not enter maintenance mode. Check the installer code "
+                "and ensure the alarm is disarmed."
+            ) from err
+
+    async def async_exit_alarm_maintenance(self, code: str) -> None:
+        """Take the TYXAL central unit out of maintenance mode."""
+        try:
+            await self._device.exit_alarm_maintenance(code)
+        except Exception as err:
+            raise HomeAssistantError(
+                "The TYXAL could not leave maintenance mode. Check the installer code."
+            ) from err
 
     async def async_configure_alarm_product(
         self,
@@ -3419,13 +3444,25 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         """Enable, disable or reassign one alarm product."""
         if active is None and zone is None:
             raise HomeAssistantError("At least one of active or zone must be supplied")
-        await self._device.configure_alarm_product(
-            code, product_id, active=active, zone=zone
-        )
+        try:
+            await self._device.configure_alarm_product(
+                code, product_id, active=active, zone=zone
+            )
+        except Exception as err:
+            raise HomeAssistantError(
+                "The TYXAL rejected the product change. Ensure the CS8000 is in "
+                "maintenance mode and use its installer code."
+            ) from err
 
     async def async_rename_alarm_zone(self, code: str, zone_id: int, name: str) -> None:
         """Rename one alarm zone."""
-        await self._device.rename_alarm_zone(code, zone_id, name)
+        try:
+            await self._device.rename_alarm_zone(code, zone_id, name)
+        except Exception as err:
+            raise HomeAssistantError(
+                "The TYXAL rejected the zone change. Ensure the CS8000 is in "
+                "maintenance mode and use its installer code."
+            ) from err
 
 
 class HaWeather(WeatherEntity, HAEntity):

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3411,8 +3411,8 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
             return await self._device.get_alarm_product_configuration(code, product_id)
         except Exception as err:
             raise HomeAssistantError(
-                "The TYXAL rejected the configuration request. Ensure the CS8000 "
-                "is in maintenance mode and use its installer code."
+                "The CS8000 rejected the configuration request. Ensure it is in "
+                "maintenance mode and use its installer code."
             ) from err
 
     async def async_enter_alarm_maintenance(self, code: str) -> None:
@@ -3421,7 +3421,7 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
             await self._device.enter_alarm_maintenance(code)
         except Exception as err:
             raise HomeAssistantError(
-                "The TYXAL could not enter maintenance mode. Check the installer code "
+                "The CS8000 could not enter maintenance mode. Check the installer code "
                 "and ensure the alarm is disarmed."
             ) from err
 
@@ -3431,7 +3431,7 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
             await self._device.exit_alarm_maintenance(code)
         except Exception as err:
             raise HomeAssistantError(
-                "The TYXAL could not leave maintenance mode. Check the installer code."
+                "The CS8000 could not leave maintenance mode. Check the installer code."
             ) from err
 
     async def async_configure_alarm_product(
@@ -3450,7 +3450,7 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
             )
         except Exception as err:
             raise HomeAssistantError(
-                "The TYXAL rejected the product change. Ensure the CS8000 is in "
+                "The CS8000 rejected the product change. Ensure it is in "
                 "maintenance mode and use its installer code."
             ) from err
 
@@ -3460,7 +3460,7 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
             await self._device.rename_alarm_zone(code, zone_id, name)
         except Exception as err:
             raise HomeAssistantError(
-                "The TYXAL rejected the zone change. Ensure the CS8000 is in "
+                "The CS8000 rejected the zone change. Ensure it is in "
                 "maintenance mode and use its installer code."
             ) from err
 

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -59,6 +59,7 @@ from .ha_entities import (
     HAScene,
     HASwitch,
     HAButton,
+    HAAlarmAcknowledgeButton,
     HAReloadButton,
     HACoverGroup,
     HALightGroup,
@@ -583,6 +584,8 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_alarm_callback is not None:
             self.add_alarm_callback([ha_device])
+        if self.add_button_callback is not None:
+            self.add_button_callback([HAAlarmAcknowledgeButton(device, self._hass)])
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(ha_device.get_sensors())
 

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -589,7 +589,10 @@ class Hub:
             self.add_button_callback([HAAlarmAcknowledgeButton(device, self._hass)])
         if self.add_sensor_callback is not None:
             self.add_sensor_callback(
-                [HAAlarmPendingEventsSensor(device, self._hass), *ha_device.get_sensors()]
+                [
+                    HAAlarmPendingEventsSensor(device, self._hass),
+                    *ha_device.get_sensors(),
+                ]
             )
 
     async def _create_weather_device(self, device: TydomWeather) -> None:

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -60,6 +60,7 @@ from .ha_entities import (
     HASwitch,
     HAButton,
     HAAlarmAcknowledgeButton,
+    HAAlarmPendingEventsSensor,
     HAReloadButton,
     HACoverGroup,
     HALightGroup,
@@ -587,7 +588,9 @@ class Hub:
         if self.add_button_callback is not None:
             self.add_button_callback([HAAlarmAcknowledgeButton(device, self._hass)])
         if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+            self.add_sensor_callback(
+                [HAAlarmPendingEventsSensor(device, self._hass), *ha_device.get_sensors()]
+            )
 
     async def _create_weather_device(self, device: TydomWeather) -> None:
         """Create weather device."""

--- a/custom_components/deltadore_tydom/services.yaml
+++ b/custom_components/deltadore_tydom/services.yaml
@@ -38,15 +38,15 @@ get_alarm_products:
       domain: alarm_control_panel
 get_alarm_product_configuration:
   name: Get alarm product configuration
-  description: Retrieve the active state and zone assignment of a TYXAL alarm product.
+  description: Retrieve the active state and zone assignment of a TYXAL alarm product while the CS8000 is in maintenance mode.
   target:
     entity:
       integration: deltadore_tydom
       domain: alarm_control_panel
   fields:
     code:
-      name: Alarm PIN
-      description: PIN used to access the alarm configuration.
+      name: TYXAL installer code
+      description: Installer code used while the CS8000 is in maintenance mode.
       required: true
       selector:
         text:
@@ -59,6 +59,36 @@ get_alarm_product_configuration:
         number:
           min: 0
           mode: box
+enter_alarm_maintenance:
+  name: Enter alarm maintenance mode
+  description: Put a disarmed TYXAL CS8000 into maintenance mode before reading or changing its configuration.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+  fields:
+    code:
+      name: TYXAL installer code
+      description: Installer code for the CS8000. Do not use an ordinary user alarm code.
+      required: true
+      selector:
+        text:
+          type: password
+exit_alarm_maintenance:
+  name: Exit alarm maintenance mode
+  description: Return a TYXAL CS8000 from maintenance mode to its normal disarmed state.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+  fields:
+    code:
+      name: TYXAL installer code
+      description: Installer code for the CS8000.
+      required: true
+      selector:
+        text:
+          type: password
 configure_alarm_product:
   name: Configure alarm product
   description: Enable or disable a TYXAL product, assign it to a zone, or perform both changes together.
@@ -68,8 +98,8 @@ configure_alarm_product:
       domain: alarm_control_panel
   fields:
     code:
-      name: Alarm PIN
-      description: PIN used to change the alarm configuration.
+      name: TYXAL installer code
+      description: Installer code used while the CS8000 is in maintenance mode.
       required: true
       selector:
         text:
@@ -106,8 +136,8 @@ rename_alarm_zone:
       domain: alarm_control_panel
   fields:
     code:
-      name: Alarm PIN
-      description: PIN used to change the alarm configuration.
+      name: TYXAL installer code
+      description: Installer code used while the CS8000 is in maintenance mode.
       required: true
       selector:
         text:

--- a/custom_components/deltadore_tydom/services.yaml
+++ b/custom_components/deltadore_tydom/services.yaml
@@ -94,8 +94,8 @@ configure_alarm_product:
       required: false
       selector:
         number:
-          min: 1
-          max: 8
+          min: 0
+          max: 7
           mode: box
 rename_alarm_zone:
   name: Rename alarm zone
@@ -118,8 +118,8 @@ rename_alarm_zone:
       required: true
       selector:
         number:
-          min: 1
-          max: 8
+          min: 0
+          max: 7
           mode: box
     name:
       name: Zone name

--- a/custom_components/deltadore_tydom/services.yaml
+++ b/custom_components/deltadore_tydom/services.yaml
@@ -129,7 +129,7 @@ configure_alarm_product:
           mode: box
 rename_alarm_zone:
   name: Rename alarm zone
-  description: Change the custom name of one TYXAL alarm zone.
+  description: Change the custom name of one TYXAL alarm zone, or clear it by supplying an empty name.
   target:
     entity:
       integration: deltadore_tydom
@@ -153,7 +153,7 @@ rename_alarm_zone:
           mode: box
     name:
       name: Zone name
-      description: New custom name for the zone.
+      description: New custom name for the zone. Supply an empty string to clear its custom or standard label.
       required: true
       selector:
         text:

--- a/custom_components/deltadore_tydom/services.yaml
+++ b/custom_components/deltadore_tydom/services.yaml
@@ -29,6 +29,104 @@ get_events:
               value: ON_OFF
             - label: All alarm events
               value: EVENTS
+get_alarm_products:
+  name: Get alarm products and zones
+  description: Retrieve the products and zones configured on a TYXAL alarm. This service does not require the alarm PIN.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+get_alarm_product_configuration:
+  name: Get alarm product configuration
+  description: Retrieve the active state and zone assignment of a TYXAL alarm product.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+  fields:
+    code:
+      name: Alarm PIN
+      description: PIN used to access the alarm configuration.
+      required: true
+      selector:
+        text:
+          type: password
+    product_id:
+      name: Product ID
+      description: Product identifier returned by Get alarm products and zones.
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
+configure_alarm_product:
+  name: Configure alarm product
+  description: Enable or disable a TYXAL product, assign it to a zone, or perform both changes together.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+  fields:
+    code:
+      name: Alarm PIN
+      description: PIN used to change the alarm configuration.
+      required: true
+      selector:
+        text:
+          type: password
+    product_id:
+      name: Product ID
+      description: Product identifier returned by Get alarm products and zones.
+      required: true
+      selector:
+        number:
+          min: 0
+          mode: box
+    active:
+      name: Active
+      description: Whether the product should participate in the alarm system. Leave empty to keep its current setting.
+      required: false
+      selector:
+        boolean:
+    zone:
+      name: Zone
+      description: Zone to which the product should be assigned. Leave empty to keep its current assignment.
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+rename_alarm_zone:
+  name: Rename alarm zone
+  description: Change the custom name of one TYXAL alarm zone.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+  fields:
+    code:
+      name: Alarm PIN
+      description: PIN used to change the alarm configuration.
+      required: true
+      selector:
+        text:
+          type: password
+    zone_id:
+      name: Zone ID
+      description: Zone identifier returned by Get alarm products and zones.
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 8
+          mode: box
+    name:
+      name: Zone name
+      description: New custom name for the zone.
+      required: true
+      selector:
+        text:
 reload_devices:
   name: Reload devices
   description: Recharger tous les appareils et entités comme au démarrage initial. Cette action supprime toutes les entités existantes et les recrée depuis zéro.

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -173,17 +173,31 @@
         },
         "get_alarm_product_configuration": {
             "name": "Get alarm product configuration",
-            "description": "Retrieve the active state and zone assignment of a TYXAL alarm product.",
+            "description": "Retrieve the active state and zone assignment of a TYXAL alarm product while the CS8000 is in maintenance mode.",
             "fields": {
-                "code": {"name": "Alarm PIN", "description": "PIN used to access the alarm configuration."},
+                "code": {"name": "TYXAL installer code", "description": "Installer code used while the CS8000 is in maintenance mode."},
                 "product_id": {"name": "Product ID", "description": "Identifier returned by Get alarm products and zones."}
+            }
+        },
+        "enter_alarm_maintenance": {
+            "name": "Enter alarm maintenance mode",
+            "description": "Put a disarmed TYXAL CS8000 into maintenance mode before reading or changing its configuration.",
+            "fields": {
+                "code": {"name": "TYXAL installer code", "description": "Installer code for the CS8000. Do not use an ordinary user alarm code."}
+            }
+        },
+        "exit_alarm_maintenance": {
+            "name": "Exit alarm maintenance mode",
+            "description": "Return a TYXAL CS8000 from maintenance mode to its normal disarmed state.",
+            "fields": {
+                "code": {"name": "TYXAL installer code", "description": "Installer code for the CS8000."}
             }
         },
         "configure_alarm_product": {
             "name": "Configure alarm product",
             "description": "Enable or disable a TYXAL product and change its zone assignment.",
             "fields": {
-                "code": {"name": "Alarm PIN", "description": "PIN used to change the alarm configuration."},
+                "code": {"name": "TYXAL installer code", "description": "Installer code used while the CS8000 is in maintenance mode."},
                 "product_id": {"name": "Product ID", "description": "Identifier returned by Get alarm products and zones."},
                 "active": {"name": "Active", "description": "Whether the product should participate in the alarm system."},
                 "zone": {"name": "Zone", "description": "Zone to which the product should be assigned."}
@@ -193,7 +207,7 @@
             "name": "Rename alarm zone",
             "description": "Change the custom name of one TYXAL alarm zone.",
             "fields": {
-                "code": {"name": "Alarm PIN", "description": "PIN used to change the alarm configuration."},
+                "code": {"name": "TYXAL installer code", "description": "Installer code used while the CS8000 is in maintenance mode."},
                 "zone_id": {"name": "Zone ID", "description": "Identifier returned by Get alarm products and zones."},
                 "name": {"name": "Zone name", "description": "New custom name for the zone."}
             }

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -205,11 +205,11 @@
         },
         "rename_alarm_zone": {
             "name": "Rename alarm zone",
-            "description": "Change the custom name of one TYXAL alarm zone.",
+            "description": "Change the custom name of one TYXAL alarm zone, or clear it by supplying an empty name.",
             "fields": {
                 "code": {"name": "TYXAL installer code", "description": "Installer code used while the CS8000 is in maintenance mode."},
                 "zone_id": {"name": "Zone ID", "description": "Identifier returned by Get alarm products and zones."},
-                "name": {"name": "Zone name", "description": "New custom name for the zone."}
+                "name": {"name": "Zone name", "description": "New custom name for the zone. Supply an empty string to clear its custom or standard label."}
             }
         },
         "reload_devices": {

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -231,6 +231,9 @@
         "scene": {},
         "switch": {},
         "button": {
+            "acknowledge_events": {
+                "name": "Acknowledge events"
+            },
             "group_light": {
                 "name": "Light Group"
             },

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -264,6 +264,9 @@
         "weather": {},
         "update": {},
         "sensor": {
+            "pending_alarm_events": {
+                "name": "Pending alarm events"
+            },
             "temperature": {
                 "name": "Temperature"
             },

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -167,6 +167,37 @@
                 }
             }
         },
+        "get_alarm_products": {
+            "name": "Get alarm products and zones",
+            "description": "Retrieve the products and zones configured on a TYXAL alarm."
+        },
+        "get_alarm_product_configuration": {
+            "name": "Get alarm product configuration",
+            "description": "Retrieve the active state and zone assignment of a TYXAL alarm product.",
+            "fields": {
+                "code": {"name": "Alarm PIN", "description": "PIN used to access the alarm configuration."},
+                "product_id": {"name": "Product ID", "description": "Identifier returned by Get alarm products and zones."}
+            }
+        },
+        "configure_alarm_product": {
+            "name": "Configure alarm product",
+            "description": "Enable or disable a TYXAL product and change its zone assignment.",
+            "fields": {
+                "code": {"name": "Alarm PIN", "description": "PIN used to change the alarm configuration."},
+                "product_id": {"name": "Product ID", "description": "Identifier returned by Get alarm products and zones."},
+                "active": {"name": "Active", "description": "Whether the product should participate in the alarm system."},
+                "zone": {"name": "Zone", "description": "Zone to which the product should be assigned."}
+            }
+        },
+        "rename_alarm_zone": {
+            "name": "Rename alarm zone",
+            "description": "Change the custom name of one TYXAL alarm zone.",
+            "fields": {
+                "code": {"name": "Alarm PIN", "description": "PIN used to change the alarm configuration."},
+                "zone_id": {"name": "Zone ID", "description": "Identifier returned by Get alarm products and zones."},
+                "name": {"name": "Zone name", "description": "New custom name for the zone."}
+            }
+        },
         "reload_devices": {
             "name": "Reload devices",
             "description": "Reload all devices and entities as at initial startup. This action removes all existing entities and recreates them from scratch."

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -174,17 +174,31 @@
         },
         "get_alarm_product_configuration": {
             "name": "Obtenir la configuration d'un produit d'alarme",
-            "description": "Récupérer l'état actif et la zone d'un produit d'alarme TYXAL.",
+            "description": "Récupérer l'état actif et la zone d'un produit TYXAL lorsque la CS8000 est en mode maintenance.",
             "fields": {
-                "code": {"name": "Code PIN de l'alarme", "description": "Code PIN permettant d'accéder à la configuration de l'alarme."},
+                "code": {"name": "Code installateur TYXAL", "description": "Code installateur utilisé lorsque la CS8000 est en mode maintenance."},
                 "product_id": {"name": "ID du produit", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."}
+            }
+        },
+        "enter_alarm_maintenance": {
+            "name": "Passer l'alarme en mode maintenance",
+            "description": "Passer une CS8000 désarmée en mode maintenance avant de lire ou modifier sa configuration.",
+            "fields": {
+                "code": {"name": "Code installateur TYXAL", "description": "Code installateur de la CS8000. Ne pas utiliser un code utilisateur ordinaire."}
+            }
+        },
+        "exit_alarm_maintenance": {
+            "name": "Quitter le mode maintenance de l'alarme",
+            "description": "Faire revenir une CS8000 du mode maintenance à son état normal désarmé.",
+            "fields": {
+                "code": {"name": "Code installateur TYXAL", "description": "Code installateur de la CS8000."}
             }
         },
         "configure_alarm_product": {
             "name": "Configurer un produit d'alarme",
             "description": "Activer ou désactiver un produit TYXAL et modifier sa zone.",
             "fields": {
-                "code": {"name": "Code PIN de l'alarme", "description": "Code PIN permettant de modifier la configuration de l'alarme."},
+                "code": {"name": "Code installateur TYXAL", "description": "Code installateur utilisé lorsque la CS8000 est en mode maintenance."},
                 "product_id": {"name": "ID du produit", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."},
                 "active": {"name": "Actif", "description": "Indique si le produit doit participer au système d'alarme."},
                 "zone": {"name": "Zone", "description": "Zone à laquelle le produit doit être affecté."}
@@ -194,7 +208,7 @@
             "name": "Renommer une zone d'alarme",
             "description": "Modifier le nom personnalisé d'une zone d'alarme TYXAL.",
             "fields": {
-                "code": {"name": "Code PIN de l'alarme", "description": "Code PIN permettant de modifier la configuration de l'alarme."},
+                "code": {"name": "Code installateur TYXAL", "description": "Code installateur utilisé lorsque la CS8000 est en mode maintenance."},
                 "zone_id": {"name": "ID de la zone", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."},
                 "name": {"name": "Nom de la zone", "description": "Nouveau nom personnalisé de la zone."}
             }

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -206,11 +206,11 @@
         },
         "rename_alarm_zone": {
             "name": "Renommer une zone d'alarme",
-            "description": "Modifier le nom personnalisé d'une zone d'alarme TYXAL.",
+            "description": "Modifier le nom personnalisé d'une zone d'alarme TYXAL, ou l'effacer en fournissant un nom vide.",
             "fields": {
                 "code": {"name": "Code installateur TYXAL", "description": "Code installateur utilisé lorsque la CS8000 est en mode maintenance."},
                 "zone_id": {"name": "ID de la zone", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."},
-                "name": {"name": "Nom de la zone", "description": "Nouveau nom personnalisé de la zone."}
+                "name": {"name": "Nom de la zone", "description": "Nouveau nom personnalisé de la zone. Fournir une chaîne vide pour effacer son libellé personnalisé ou standard."}
             }
         },
         "reload_devices": {

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -232,6 +232,9 @@
         "scene": {},
         "switch": {},
         "button": {
+            "acknowledge_events": {
+                "name": "Acquitter les évènements"
+            },
             "group_light": {
                 "name": "Groupe Lumières"
             },

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -265,6 +265,9 @@
         "weather": {},
         "update": {},
         "sensor": {
+            "pending_alarm_events": {
+                "name": "Évènements d'alarme en attente"
+            },
             "temperature": {
                 "name": "Température"
             },

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -168,6 +168,37 @@
                 }
             }
         },
+        "get_alarm_products": {
+            "name": "Obtenir les produits et zones d'alarme",
+            "description": "Récupérer les produits et les zones configurés sur une alarme TYXAL."
+        },
+        "get_alarm_product_configuration": {
+            "name": "Obtenir la configuration d'un produit d'alarme",
+            "description": "Récupérer l'état actif et la zone d'un produit d'alarme TYXAL.",
+            "fields": {
+                "code": {"name": "Code PIN de l'alarme", "description": "Code PIN permettant d'accéder à la configuration de l'alarme."},
+                "product_id": {"name": "ID du produit", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."}
+            }
+        },
+        "configure_alarm_product": {
+            "name": "Configurer un produit d'alarme",
+            "description": "Activer ou désactiver un produit TYXAL et modifier sa zone.",
+            "fields": {
+                "code": {"name": "Code PIN de l'alarme", "description": "Code PIN permettant de modifier la configuration de l'alarme."},
+                "product_id": {"name": "ID du produit", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."},
+                "active": {"name": "Actif", "description": "Indique si le produit doit participer au système d'alarme."},
+                "zone": {"name": "Zone", "description": "Zone à laquelle le produit doit être affecté."}
+            }
+        },
+        "rename_alarm_zone": {
+            "name": "Renommer une zone d'alarme",
+            "description": "Modifier le nom personnalisé d'une zone d'alarme TYXAL.",
+            "fields": {
+                "code": {"name": "Code PIN de l'alarme", "description": "Code PIN permettant de modifier la configuration de l'alarme."},
+                "zone_id": {"name": "ID de la zone", "description": "Identifiant renvoyé par le service d'obtention des produits et zones."},
+                "name": {"name": "Nom de la zone", "description": "Nouveau nom personnalisé de la zone."}
+            }
+        },
         "reload_devices": {
             "name": "Recharger les appareils",
             "description": "Recharger tous les appareils et entités comme au démarrage initial. Cette action supprime toutes les entités existantes et les recrée depuis zéro."
@@ -380,4 +411,3 @@
         "moment": {}
     }
 }
-

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -38,6 +38,17 @@ from .tydom_devices import (
     TydomScene,
 )
 
+
+def _sanitize_uri(uri: str) -> str:
+    """Redact credentials carried by legacy TYDOM query parameters."""
+    return re.sub(
+        r"([?&](?:password|pwd|passwd|token|access_token)=)[^&\s]*",
+        r"\1***",
+        uri,
+        flags=re.IGNORECASE,
+    )
+
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -436,7 +447,7 @@ class MessageHandler:
                 LOGGER.warning(
                     "Request '%s' (%s) rejected with HTTP status %s: %s",
                     transaction_id,
-                    uri_origin,
+                    _sanitize_uri(uri_origin),
                     status,
                     (parsed_message.body or b"")[:500],
                 )
@@ -1552,6 +1563,17 @@ class MessageHandler:
                                         transaction_id,
                                     )
                                     reply["events"].append(elem)
+                                    # Configuration reads and writes return one
+                                    # cdata object. Unlike streamed history,
+                                    # they do not require an EOR sentinel.
+                                    if elem.get("name") != "histo":
+                                        reply["done"] = True
+                                        if (
+                                            event := self._end_reply_events.pop(
+                                                transaction_id, None
+                                            )
+                                        ) is not None:
+                                            event.set()
                             else:
                                 LOGGER.debug(
                                     "Ignore cdata message targetting '%s' (%s).",

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1551,13 +1551,13 @@ class MessageHandler:
                                     self._cdata_replies.insert(0, reply)
                                     # Limit the number of tracked replies
                                     if len(self._cdata_replies) > _MAX_REPLIES_SIZE:
-                                        reply = self._cdata_replies.pop()
+                                        forgotten_reply = self._cdata_replies.pop()
                                         LOGGER.warning(
                                             "Forget uncomplete request with transaction ID '%s'.",
-                                            reply["transaction_id"],
+                                            forgotten_reply["transaction_id"],
                                         )
                                         self._end_reply_events.pop(
-                                            reply["transaction_id"], None
+                                            forgotten_reply["transaction_id"], None
                                         )
 
                                 values = elem.get("values") or {}

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -355,6 +355,7 @@ class MessageHandler:
         self.cmd_prefix = cmd_prefix
         self._cdata_replies: list[Reply] = []
         self._end_reply_events: dict[str, asyncio.Event] = {}
+        self._reply_errors: dict[str, str] = {}
         self._area_devices: dict[str, dict[str, AreaDeviceReference]] = {}
         self._area_data: dict[str, dict[str, Any]] = {}
         self._area_metadata: dict[str, dict] = {}
@@ -412,6 +413,10 @@ class MessageHandler:
         self._end_reply_events.pop(transaction_id, None)
         LOGGER.debug("Removed pending reply for transaction_id: %s", transaction_id)
 
+    def get_reply_error(self, transaction_id: str) -> str | None:
+        """Return and forget a protocol error for one pending request."""
+        return self._reply_errors.pop(transaction_id, None)
+
     async def route_response(self, bytes_str: bytes) -> list["TydomDevice"] | None:
         """
         Identify message type and dispatch the result.
@@ -452,6 +457,12 @@ class MessageHandler:
                     (parsed_message.body or b"")[:500],
                 )
                 if transaction_id and transaction_id in self._end_reply_events:
+                    detail = (parsed_message.body or b"").decode(
+                        "utf-8", errors="replace"
+                    )
+                    self._reply_errors[transaction_id] = (
+                        f"HTTP {status}: {re.sub(r'<[^>]+>', ' ', detail).strip()}"
+                    )
                     event = self._end_reply_events.get(transaction_id)
                     self.remove_reply(transaction_id)
                     if event is not None:

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -64,6 +64,9 @@ Some firmwares never send an EOR flag; they mark the end of the enumeration
 with a last element carrying index 255 and invalid event data instead.
 """
 
+_EMPTY_CDATA_EOR_GRACE = 0.1
+"""Seconds to wait for TYXAL data sent just after an early empty EOR."""
+
 
 def _is_tyxia_4910_other(uid: str) -> bool:
     """Identify a binary TYXIA 4910 configured under the TYDOM 'others' usage."""
@@ -416,6 +419,11 @@ class MessageHandler:
     def get_reply_error(self, transaction_id: str) -> str | None:
         """Return and forget a protocol error for one pending request."""
         return self._reply_errors.pop(transaction_id, None)
+
+    def _complete_empty_cdata_reply(self, transaction_id: str) -> None:
+        """Complete an EOR-only reply unless late TYXAL data completed it first."""
+        if event := self._end_reply_events.pop(transaction_id, None):
+            event.set()
 
     async def route_response(self, bytes_str: bytes) -> list["TydomDevice"] | None:
         """
@@ -1561,13 +1569,27 @@ class MessageHandler:
                                         "End of reply for request '%s'.", transaction_id
                                     )
                                     reply["done"] = True
-                                    # Set the end reply event and forget about it
-                                    if (
-                                        event := self._end_reply_events.pop(
-                                            transaction_id, None
+                                    if reply["events"]:
+                                        # A streamed response has already
+                                        # supplied its data, so EOR completes
+                                        # it immediately.
+                                        if (
+                                            event := self._end_reply_events.pop(
+                                                transaction_id, None
+                                            )
+                                        ) is not None:
+                                            event.set()
+                                    elif transaction_id in self._end_reply_events:
+                                        # Some CS8000 firmware emits EOR a few
+                                        # milliseconds before its single cdata
+                                        # object. Give that object a brief
+                                        # chance to arrive before treating the
+                                        # response as genuinely empty.
+                                        asyncio.get_running_loop().call_later(
+                                            _EMPTY_CDATA_EOR_GRACE,
+                                            self._complete_empty_cdata_reply,
+                                            transaction_id,
                                         )
-                                    ) is not None:
-                                        event.set()
                                 else:
                                     LOGGER.debug(
                                         "Catching new reply for request '%s'.",

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -912,6 +912,11 @@ class TydomClient:
                 f"Timeout waiting for reply to {method} {safe_url}"
             )
 
+        if error := self._message_handler.get_reply_error(transaction_id):
+            raise TydomClientApiClientCommunicationError(
+                f"Request {method} {safe_url} failed: {error}"
+            )
+
         reply = self._message_handler.get_reply(transaction_id)
 
         if reply is None:
@@ -1629,7 +1634,14 @@ class TydomClient:
             f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
             f"?name=productConf&pwd={safe_pin}&id={int(product_id)}"
         )
-        messages = await self.get_reply_to_request("GET", url)
+        messages = await self.get_reply_to_request(
+            "GET",
+            url,
+            headers={
+                "Content-Length": "0",
+                "Content-Type": "application/json; charset=UTF-8",
+            },
+        )
         return self._first_cdata_value(messages)
 
     async def put_alarm_product_configuration_cdata(

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1731,7 +1731,7 @@ class TydomClient:
         control: str,
     ) -> None:
         """Lock or unlock the TYXAL remote configuration session."""
-        if control not in {"LOCK", "UNLOCK"}:
+        if control not in {"lock", "unlock"}:
             raise ValueError(f"Unsupported TYXAL remote control action: {control}")
         safe_device_id = quote(str(device_id), safe="")
         safe_endpoint_id = quote(str(endpoint_id), safe="")

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1606,7 +1606,13 @@ class TydomClient:
     async def get_alarm_products_cdata(
         self, device_id: str, endpoint_id: str
     ) -> dict[str, dict | None]:
-        """Get the TYXAL product inventory and its user-facing labels."""
+        """Get the TYXAL product inventory and its user-facing labels.
+
+        The documented ``label`` response contains both products and zones.
+        Some CS8000 firmware rejects the app's optional ``productInfo`` battery
+        enrichment command with HTTP 400, so inventory discovery must not
+        depend on it.
+        """
         safe_device_id = quote(str(device_id), safe="")
         safe_endpoint_id = quote(str(endpoint_id), safe="")
         base_url = f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
@@ -1614,14 +1620,11 @@ class TydomClient:
             "Content-Length": "0",
             "Content-Type": "application/json; charset=UTF-8",
         }
-        product_info = await self.get_reply_to_request(
-            "GET", f"{base_url}?name=productInfo", headers=headers.copy()
-        )
         labels = await self.get_reply_to_request(
             "GET", f"{base_url}?name=label", headers=headers.copy()
         )
         return {
-            "productInfo": self._first_cdata_value(product_info),
+            "productInfo": None,
             "label": self._first_cdata_value(labels),
         }
 

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1777,10 +1777,10 @@ class TydomClient:
                 "id": int(zone_id),
                 # The Delta Dore app constructs nullable standard-name and
                 # number fields, but Gson omits them from the wire payload.
-                # Sending either field explicitly as JSON null is rejected by
-                # the CS8000 as a malformed request.  The app clears all label
-                # fields by serialising their null values as an empty object.
-                "label": {"nameCustom": name} if name else {},
+                # Sending the unused standard-name or number fields explicitly
+                # as JSON null is rejected by the CS8000. The app keeps an
+                # explicitly blank custom name when clearing a label.
+                "label": {"nameCustom": name},
             },
         )
 

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -871,6 +871,10 @@ class TydomClient:
 
         """
         event = asyncio.Event()
+        # Some official TYXAL configuration endpoints carry the alarm PIN in
+        # the query string.  Always redact sensitive query parameters before
+        # the URL reaches a log message or an exception.
+        safe_url = sanitize_log_message(url)
 
         transaction_id, request = self._message_handler.prepare_request(
             method, url, body, headers, reply_event=event
@@ -882,12 +886,12 @@ class TydomClient:
             LOGGER.error(
                 "Failed to send request %s %s: %s",
                 method,
-                url,
+                safe_url,
                 str(e),
                 exc_info=True,
             )
             raise TydomClientApiClientCommunicationError(
-                f"Failed to send request {method} {url}: {str(e)}"
+                f"Failed to send request {method} {safe_url}: {str(e)}"
             ) from e
 
         # Wait for the reply with timeout
@@ -898,14 +902,14 @@ class TydomClient:
             LOGGER.warning(
                 "Timeout waiting for reply to %s %s (transaction_id: %s, timeout: %.1fs)",
                 method,
-                url,
+                safe_url,
                 transaction_id,
                 timeout,
             )
             # Remove the pending reply to avoid memory leak
             self._message_handler.remove_reply(transaction_id)
             raise TydomClientApiClientCommunicationError(
-                f"Timeout waiting for reply to {method} {url}"
+                f"Timeout waiting for reply to {method} {safe_url}"
             )
 
         reply = self._message_handler.get_reply(transaction_id)
@@ -914,7 +918,7 @@ class TydomClient:
             LOGGER.warning(
                 "No reply received for %s %s (transaction_id: %s)",
                 method,
-                url,
+                safe_url,
                 transaction_id,
             )
             return None
@@ -1579,6 +1583,118 @@ class TydomClient:
         # apart), so the reply wait needs the long timeout; the default one
         # (10 s) cuts the stream off after a few events.
         return await self.get_reply_to_request("GET", url, timeout=TIMEOUT_LONG_REQUEST)
+
+    @staticmethod
+    def _first_cdata_value(messages: list[dict] | None) -> dict | None:
+        """Return the first non-sentinel cdata response."""
+        if not messages:
+            return None
+        return next(
+            (
+                message
+                for message in messages
+                if isinstance(message, dict) and not message.get("EOR", False)
+            ),
+            None,
+        )
+
+    async def get_alarm_products_cdata(
+        self, device_id: str, endpoint_id: str
+    ) -> dict[str, dict | None]:
+        """Get the TYXAL product inventory and its user-facing labels."""
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        base_url = f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+        product_info = await self.get_reply_to_request(
+            "GET", f"{base_url}?name=productInfo"
+        )
+        labels = await self.get_reply_to_request("GET", f"{base_url}?name=label")
+        return {
+            "productInfo": self._first_cdata_value(product_info),
+            "label": self._first_cdata_value(labels),
+        }
+
+    async def get_alarm_product_configuration_cdata(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        alarm_pin: str,
+        product_id: int,
+    ) -> dict | None:
+        """Get the common configuration of one TYXAL product."""
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        safe_pin = quote(str(alarm_pin), safe="")
+        url = (
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            f"?name=productConf&pwd={safe_pin}&id={int(product_id)}"
+        )
+        messages = await self.get_reply_to_request("GET", url)
+        return self._first_cdata_value(messages)
+
+    async def put_alarm_product_configuration_cdata(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        alarm_pin: str,
+        product_id: int,
+        *,
+        active: bool | None = None,
+        zone: int | None = None,
+    ) -> None:
+        """Update selected common settings of one TYXAL product."""
+        common: dict[str, bool | int] = {}
+        if active is not None:
+            common["inactive"] = not active
+        if zone is not None:
+            common["zone"] = int(zone)
+        if not common:
+            raise ValueError("At least one product setting must be supplied")
+
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        url = (
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            "?name=productConf"
+        )
+        await self.get_reply_to_request(
+            "PUT",
+            url,
+            body={
+                "pwd": str(alarm_pin),
+                "id": int(product_id),
+                "common": common,
+            },
+        )
+
+    async def put_alarm_zone_label_cdata(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        alarm_pin: str,
+        zone_id: int,
+        name: str,
+    ) -> None:
+        """Rename a TYXAL zone using the official zone label command."""
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        url = (
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            "?name=zoneLabelConf"
+        )
+        await self.get_reply_to_request(
+            "PUT",
+            url,
+            body={
+                "pwd": str(alarm_pin),
+                "id": int(zone_id),
+                "label": {
+                    "nameStd": None,
+                    "number": None,
+                    "nameCustom": name,
+                },
+            },
+        )
 
     async def update_firmware(self):
         """Update Tydom firmware."""

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1766,11 +1766,11 @@ class TydomClient:
             body={
                 "pwd": str(alarm_pin),
                 "id": int(zone_id),
-                "label": {
-                    "nameStd": None,
-                    "number": None,
-                    "nameCustom": name,
-                },
+                # The Delta Dore app constructs nullable standard-name and
+                # number fields, but Gson omits them from the wire payload.
+                # Sending either field explicitly as JSON null is rejected by
+                # the CS8000 as a malformed request.
+                "label": {"nameCustom": name},
             },
         )
 

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1723,6 +1723,28 @@ class TydomClient:
             body={"pwd": str(installer_code), "value": mode},
         )
 
+    async def put_alarm_remote_control_cdata(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        installer_code: str,
+        control: str,
+    ) -> None:
+        """Lock or unlock the TYXAL remote configuration session."""
+        if control not in {"LOCK", "UNLOCK"}:
+            raise ValueError(f"Unsupported TYXAL remote control action: {control}")
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        url = (
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            "?name=remoteCtrl"
+        )
+        await self.get_reply_to_request(
+            "PUT",
+            url,
+            body={"pwd": str(installer_code), "control": control},
+        )
+
     async def put_alarm_zone_label_cdata(
         self,
         device_id: str,

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1651,13 +1651,10 @@ class TydomClient:
         alarm_pin: str,
         product_id: int,
         *,
-        active: bool | None = None,
         zone: int | None = None,
     ) -> None:
         """Update selected common settings of one TYXAL product."""
-        common: dict[str, bool | int] = {}
-        if active is not None:
-            common["inactive"] = not active
+        common: dict[str, int] = {}
         if zone is not None:
             common["zone"] = int(zone)
         if not common:
@@ -1677,6 +1674,53 @@ class TydomClient:
                 "id": int(product_id),
                 "common": common,
             },
+        )
+
+    async def put_alarm_product_active_cdata(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        installer_code: str,
+        product_id: int,
+        active: bool,
+    ) -> None:
+        """Activate or deactivate one TYXAL product."""
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        url = (
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            "?name=activeProductConf"
+        )
+        await self.get_reply_to_request(
+            "PUT",
+            url,
+            body={
+                "pwd": str(installer_code),
+                "id": int(product_id),
+                "activeProduct": bool(active),
+            },
+        )
+
+    async def put_alarm_mode_cdata(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        installer_code: str,
+        mode: str,
+    ) -> None:
+        """Set a global TYXAL mode and await the gateway response."""
+        if mode not in {"MAINTENANCE", "OFF"}:
+            raise ValueError(f"Unsupported TYXAL maintenance mode: {mode}")
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        url = (
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            "?name=alarmCmd"
+        )
+        await self.get_reply_to_request(
+            "PUT",
+            url,
+            body={"pwd": str(installer_code), "value": mode},
         )
 
     async def put_alarm_zone_label_cdata(

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1610,10 +1610,16 @@ class TydomClient:
         safe_device_id = quote(str(device_id), safe="")
         safe_endpoint_id = quote(str(endpoint_id), safe="")
         base_url = f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+        headers = {
+            "Content-Length": "0",
+            "Content-Type": "application/json; charset=UTF-8",
+        }
         product_info = await self.get_reply_to_request(
-            "GET", f"{base_url}?name=productInfo"
+            "GET", f"{base_url}?name=productInfo", headers=headers.copy()
         )
-        labels = await self.get_reply_to_request("GET", f"{base_url}?name=label")
+        labels = await self.get_reply_to_request(
+            "GET", f"{base_url}?name=label", headers=headers.copy()
+        )
         return {
             "productInfo": self._first_cdata_value(product_info),
             "label": self._first_cdata_value(labels),

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1557,16 +1557,34 @@ class TydomClient:
             LOGGER.error("put_alarm_cdata ERROR !", exc_info=True)
 
     async def put_ackevents_cdata(self, device_id, endpoint_id=None, alarm_pin=None):
-        """Acknowledge the alarm events.
+        """Acknowledge alarm events using the command supported by the gateway.
 
-        The box acknowledges through the data channel: /devices/meta declares
-        ackEventCmd as a writable attribute with enum ["ACK"], and no pin is
-        required (alarm_pin is kept for signature compatibility). The cdata
-        form with a pwd body inherited from tydom2mqtt is rejected with an
-        HTTP 500 (verified on a Tyxal+ via Tydom 1.0, right pin or not, pwd
-        in the body or in the query string), while this data write is
-        accepted and clears the unacked events.
+        TYXAL gateways expose two incompatible forms in the field. Some
+        advertise ``ackEventCmd`` as authenticated cdata requiring ``pwd``;
+        others accept the pin-free ``ACK`` value through the regular data
+        endpoint and reject the cdata form. Prefer the authenticated command
+        whenever an alarm code is available, then retain the proven data form
+        as a compatibility fallback.
         """
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        pin = alarm_pin or self._alarm_pin
+
+        if pin:
+            try:
+                await self.get_reply_to_request(
+                    "PUT",
+                    f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+                    "?name=ackEventCmd",
+                    body={"pwd": str(pin)},
+                )
+                return
+            except TydomClientApiClientCommunicationError:
+                LOGGER.debug(
+                    "Authenticated TYXAL acknowledgement was rejected; "
+                    "trying the data-channel form"
+                )
+
         await self.put_devices_data(device_id, endpoint_id, "ackEventCmd", "ACK")
 
     async def get_historic_cdata(

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1762,7 +1762,7 @@ class TydomClient:
         zone_id: int,
         name: str,
     ) -> None:
-        """Rename a TYXAL zone using the official zone label command."""
+        """Rename or clear a TYXAL zone using the official label command."""
         safe_device_id = quote(str(device_id), safe="")
         safe_endpoint_id = quote(str(endpoint_id), safe="")
         url = (
@@ -1778,8 +1778,9 @@ class TydomClient:
                 # The Delta Dore app constructs nullable standard-name and
                 # number fields, but Gson omits them from the wire payload.
                 # Sending either field explicitly as JSON null is rejected by
-                # the CS8000 as a malformed request.
-                "label": {"nameCustom": name},
+                # the CS8000 as a malformed request.  The app clears all label
+                # fields by serialising their null values as an empty object.
+                "label": {"nameCustom": name} if name else {},
             },
         )
 

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1033,7 +1033,7 @@ class TydomAlarm(TydomDevice):
             self._id, self._endpoint, code, "PANIC", None, self.is_legacy_alarm()
         )
 
-    async def acknowledge_events(self, code) -> None:
+    async def acknowledge_events(self, code=None) -> None:
         """Acknowledge alarm events."""
         await self._tydom_client.put_ackevents_cdata(self._id, self._endpoint, code)
 

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -948,6 +948,20 @@ class TydomLight(TydomDevice):
 class TydomAlarm(TydomDevice):
     """represents an alarm."""
 
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialise an alarm and its dashboard event cache."""
+        super().__init__(*args, **kwargs)
+        self._pending_events: list[dict[str, Any]] | None = None
+
+    @property
+    def pending_events(self) -> list[dict[str, Any]] | None:
+        """Return the most recently fetched unacknowledged events."""
+        return self._pending_events
+
+    def clear_pending_events(self) -> None:
+        """Clear the local event cache after acknowledgement or a clear state."""
+        self._pending_events = []
+
     def is_legacy_alarm(self) -> bool:
         """Check if alarm is legacy."""
         if hasattr(self, "part1State"):
@@ -1036,6 +1050,8 @@ class TydomAlarm(TydomDevice):
     async def acknowledge_events(self, code=None) -> None:
         """Acknowledge alarm events."""
         await self._tydom_client.put_ackevents_cdata(self._id, self._endpoint, code)
+        self.clear_pending_events()
+        await self.publish_updates()
 
     _KEPT_KEYS: ClassVar = {
         "": {"name", "date", "zones", "accessCode", "product"},
@@ -1074,11 +1090,15 @@ class TydomAlarm(TydomDevice):
         #   "parameters":{"type":"<event_type>","nbElem":10,"indexStart":0},
         #   "values":{"step":0,"nbElemTot":1,"index":0,"event":{...}}
         # }
-        return [
+        formatted_events = [
             self._format_alarm_event(m["values"]["event"])
             for m in (events or [])
             if m.get("values", {}).get("event") is not None
         ]
+        if event_type == "UNACKED_EVENTS":
+            self._pending_events = formatted_events
+            await self.publish_updates()
+        return formatted_events
 
     def _require_endpoint(self) -> str:
         """Return the alarm endpoint or fail before building a request."""

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1080,6 +1080,109 @@ class TydomAlarm(TydomDevice):
             if m.get("values", {}).get("event") is not None
         ]
 
+    def _require_endpoint(self) -> str:
+        """Return the alarm endpoint or fail before building a request."""
+        if self._endpoint is None:
+            raise ValueError(f"Alarm device {self._id} has no endpoint")
+        return self._endpoint
+
+    async def get_alarm_products(self) -> dict[str, list[dict[str, Any]]]:
+        """Return the TYXAL product inventory and configured zones."""
+        messages = await self._tydom_client.get_alarm_products_cdata(
+            self._id, self._require_endpoint()
+        )
+        label_values = (messages.get("label") or {}).get("values") or {}
+        info_values = (messages.get("productInfo") or {}).get("values") or {}
+
+        technical_products = {
+            product.get("id"): product
+            for product in info_values.get("products", [])
+            if isinstance(product, dict) and product.get("id") is not None
+        }
+        products = []
+        for product in label_values.get("products", []):
+            if not isinstance(product, dict) or product.get("id") is None:
+                continue
+            technical = technical_products.get(product["id"], {})
+            products.append(
+                {
+                    key: value
+                    for key, value in {
+                        "id": product["id"],
+                        "name_custom": product.get("nameCustom"),
+                        "name_standard": product.get("nameStd"),
+                        "number": product.get("number"),
+                        "type_short": product.get("typeShort"),
+                        "type_long": product.get("typeLong"),
+                        "zone": product.get("zone"),
+                        "uuid": technical.get("uuid"),
+                        "battery_level": technical.get("batteryLevel"),
+                    }.items()
+                    if value is not None
+                }
+            )
+
+        zones = [
+            {
+                key: value
+                for key, value in {
+                    "id": zone.get("id"),
+                    "name_custom": zone.get("nameCustom"),
+                    "name_standard": zone.get("nameStd"),
+                    "number": zone.get("number"),
+                }.items()
+                if value is not None
+            }
+            for zone in label_values.get("zones", [])
+            if isinstance(zone, dict) and zone.get("id") is not None
+        ]
+        return {"zones": zones, "products": products}
+
+    async def get_alarm_product_configuration(
+        self, code: str, product_id: int
+    ) -> dict[str, Any]:
+        """Return only the safe, common settings of one TYXAL product."""
+        message = (
+            await self._tydom_client.get_alarm_product_configuration_cdata(
+                self._id, self._require_endpoint(), code, product_id
+            )
+            or {}
+        )
+        values = message.get("values") or {}
+        common = values.get("common") or {}
+        response: dict[str, Any] = {"id": values.get("id", product_id)}
+        if common.get("inactive") is not None:
+            response["active"] = not common["inactive"]
+        if common.get("zone") is not None:
+            response["zone"] = common["zone"]
+        if common.get("autoProtectActive") is not None:
+            response["auto_protect_active"] = common["autoProtectActive"]
+        return response
+
+    async def configure_alarm_product(
+        self,
+        code: str,
+        product_id: int,
+        *,
+        active: bool | None = None,
+        zone: int | None = None,
+    ) -> None:
+        """Enable, disable or reassign one TYXAL product."""
+        await self._tydom_client.put_alarm_product_configuration_cdata(
+            self._id,
+            self._require_endpoint(),
+            code,
+            product_id,
+            active=active,
+            zone=zone,
+        )
+
+    async def rename_alarm_zone(self, code: str, zone_id: int, name: str) -> None:
+        """Rename one TYXAL zone."""
+        await self._tydom_client.put_alarm_zone_label_cdata(
+            self._id, self._require_endpoint(), code, zone_id, name
+        )
+
 
 class TydomWeather(TydomDevice):
     """Represents a weather sensor."""

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1048,10 +1048,9 @@ class TydomAlarm(TydomDevice):
         )
 
     async def acknowledge_events(self, code=None) -> None:
-        """Acknowledge alarm events."""
+        """Acknowledge alarm events and refresh the authoritative event list."""
         await self._tydom_client.put_ackevents_cdata(self._id, self._endpoint, code)
-        self.clear_pending_events()
-        await self.publish_updates()
+        await self.get_events("UNACKED_EVENTS")
 
     _KEPT_KEYS: ClassVar = {
         "": {"name", "date", "zones", "accessCode", "product"},

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1179,15 +1179,31 @@ class TydomAlarm(TydomDevice):
 
     async def enter_alarm_maintenance(self, code: str) -> None:
         """Put the TYXAL central unit into maintenance mode."""
-        await self._tydom_client.put_alarm_mode_cdata(
-            self._id, self._require_endpoint(), code, "MAINTENANCE"
+        endpoint = self._require_endpoint()
+        await self._tydom_client.put_alarm_remote_control_cdata(
+            self._id, endpoint, code, "LOCK"
         )
+        try:
+            await self._tydom_client.put_alarm_mode_cdata(
+                self._id, endpoint, code, "MAINTENANCE"
+            )
+        except Exception:
+            await self._tydom_client.put_alarm_remote_control_cdata(
+                self._id, endpoint, code, "UNLOCK"
+            )
+            raise
 
     async def exit_alarm_maintenance(self, code: str) -> None:
         """Take the TYXAL central unit out of maintenance mode."""
-        await self._tydom_client.put_alarm_mode_cdata(
-            self._id, self._require_endpoint(), code, "OFF"
-        )
+        endpoint = self._require_endpoint()
+        try:
+            await self._tydom_client.put_alarm_mode_cdata(
+                self._id, endpoint, code, "OFF"
+            )
+        finally:
+            await self._tydom_client.put_alarm_remote_control_cdata(
+                self._id, endpoint, code, "UNLOCK"
+            )
 
     async def rename_alarm_zone(self, code: str, zone_id: int, name: str) -> None:
         """Rename one TYXAL zone."""

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1181,7 +1181,7 @@ class TydomAlarm(TydomDevice):
         """Put the TYXAL central unit into maintenance mode."""
         endpoint = self._require_endpoint()
         await self._tydom_client.put_alarm_remote_control_cdata(
-            self._id, endpoint, code, "LOCK"
+            self._id, endpoint, code, "lock"
         )
         try:
             await self._tydom_client.put_alarm_mode_cdata(
@@ -1189,7 +1189,7 @@ class TydomAlarm(TydomDevice):
             )
         except Exception:
             await self._tydom_client.put_alarm_remote_control_cdata(
-                self._id, endpoint, code, "UNLOCK"
+                self._id, endpoint, code, "unlock"
             )
             raise
 
@@ -1202,7 +1202,7 @@ class TydomAlarm(TydomDevice):
             )
         finally:
             await self._tydom_client.put_alarm_remote_control_cdata(
-                self._id, endpoint, code, "UNLOCK"
+                self._id, endpoint, code, "unlock"
             )
 
     async def rename_alarm_zone(self, code: str, zone_id: int, name: str) -> None:

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1142,12 +1142,11 @@ class TydomAlarm(TydomDevice):
         self, code: str, product_id: int
     ) -> dict[str, Any]:
         """Return only the safe, common settings of one TYXAL product."""
-        message = (
-            await self._tydom_client.get_alarm_product_configuration_cdata(
-                self._id, self._require_endpoint(), code, product_id
-            )
-            or {}
+        message = await self._tydom_client.get_alarm_product_configuration_cdata(
+            self._id, self._require_endpoint(), code, product_id
         )
+        if message is None:
+            raise ValueError("The TYXAL alarm returned no product configuration")
         values = message.get("values") or {}
         common = values.get("common") or {}
         response: dict[str, Any] = {"id": values.get("id", product_id)}

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1167,13 +1167,26 @@ class TydomAlarm(TydomDevice):
         zone: int | None = None,
     ) -> None:
         """Enable, disable or reassign one TYXAL product."""
-        await self._tydom_client.put_alarm_product_configuration_cdata(
-            self._id,
-            self._require_endpoint(),
-            code,
-            product_id,
-            active=active,
-            zone=zone,
+        endpoint = self._require_endpoint()
+        if active is not None:
+            await self._tydom_client.put_alarm_product_active_cdata(
+                self._id, endpoint, code, product_id, active
+            )
+        if zone is not None:
+            await self._tydom_client.put_alarm_product_configuration_cdata(
+                self._id, endpoint, code, product_id, zone=zone
+            )
+
+    async def enter_alarm_maintenance(self, code: str) -> None:
+        """Put the TYXAL central unit into maintenance mode."""
+        await self._tydom_client.put_alarm_mode_cdata(
+            self._id, self._require_endpoint(), code, "MAINTENANCE"
+        )
+
+    async def exit_alarm_maintenance(self, code: str) -> None:
+        """Take the TYXAL central unit out of maintenance mode."""
+        await self._tydom_client.put_alarm_mode_cdata(
+            self._id, self._require_endpoint(), code, "OFF"
         )
 
     async def rename_alarm_zone(self, code: str, zone_id: int, name: str) -> None:

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1166,7 +1166,7 @@ class TydomAlarm(TydomDevice):
             self._id, self._require_endpoint(), code, product_id
         )
         if message is None:
-            raise ValueError("The TYXAL alarm returned no product configuration")
+            raise ValueError("The CS8000 returned no product configuration")
         values = message.get("values") or {}
         common = values.get("common") or {}
         response: dict[str, Any] = {"id": values.get("id", product_id)}

--- a/tests/test_alarm_acknowledge_button.py
+++ b/tests/test_alarm_acknowledge_button.py
@@ -1,0 +1,83 @@
+"""Tests for the TYXAL alarm acknowledgement button."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+
+def _load_acknowledgement_button():
+    """Load the button class without importing Home Assistant."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "HAAlarmAcknowledgeButton"
+    )
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            class_node,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class ButtonEntity:
+        pass
+
+    class HAEntity:
+        def _get_device_info(self) -> dict[str, str]:
+            return {"manufacturer": "Delta Dore", "model": "CS 8000"}
+
+        def _enrich_device_info(self, info):
+            return info
+
+    namespace = {
+        "ButtonEntity": ButtonEntity,
+        "DeviceInfo": dict,
+        "DOMAIN": "deltadore_tydom",
+        "HAEntity": HAEntity,
+        "TydomAlarm": object,
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["HAAlarmAcknowledgeButton"]
+
+
+HAAlarmAcknowledgeButton = _load_acknowledgement_button()
+
+
+class AlarmAcknowledgeButtonTests(IsolatedAsyncioTestCase):
+    """Exercise the native acknowledgement button."""
+
+    async def test_press_acknowledges_events_without_requesting_a_pin(self) -> None:
+        """A press must call the existing pin-free acknowledgement command."""
+        device = SimpleNamespace(
+            device_id="alarm_device",
+            device_name="TYXAL Alarm",
+            acknowledge_events=AsyncMock(),
+        )
+        button = HAAlarmAcknowledgeButton(device, SimpleNamespace())
+
+        await button.async_press()
+
+        device.acknowledge_events.assert_awaited_once_with()
+        self.assertEqual(button._attr_unique_id, "alarm_device_acknowledge_events")
+        self.assertEqual(button._attr_translation_key, "acknowledge_events")
+        self.assertEqual(
+            button.device_info["identifiers"],
+            {("deltadore_tydom", "alarm_device")},
+        )

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -342,6 +342,51 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         await asyncio.wait_for(reply_event.wait(), timeout=0.2)
         self.assertEqual(handler.get_reply("request-1")["events"], [])
 
+    async def test_alarm_reply_cache_rollover_keeps_new_reply(self) -> None:
+        """Evicting an old reply must not redirect new data into that reply."""
+        handler = MessageHandler(MagicMock(), b"")
+        handler.get_type_from_id = MagicMock(return_value="alarm")
+        handler.get_name_from_id = MagicMock(return_value="Alarm")
+        for request_id in range(5):
+            handler._cdata_replies.append(
+                {
+                    "transaction_id": f"old-request-{request_id}",
+                    "events": [],
+                    "done": False,
+                }
+            )
+        reply_event = asyncio.Event()
+        handler._end_reply_events["new-request"] = reply_event
+
+        await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "cdata": [
+                                {
+                                    "name": "productConf",
+                                    "values": {
+                                        "id": 2,
+                                        "common": {"inactive": False},
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "new-request",
+        )
+
+        self.assertTrue(reply_event.is_set())
+        reply = handler.get_reply("new-request")
+        self.assertIsNotNone(reply)
+        self.assertEqual(reply["events"][0]["name"], "productConf")
+
     async def test_rejected_alarm_configuration_redacts_pin(self) -> None:
         """An alarm PIN in Uri-Origin must never be written to the log."""
         logger.reset_mock()

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -237,6 +237,8 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         """An alarm PIN in Uri-Origin must never be written to the log."""
         logger.reset_mock()
         handler = MessageHandler(MagicMock(), b"")
+        reply_event = asyncio.Event()
+        handler._end_reply_events["request-1"] = reply_event
 
         await handler.route_response(
             b"HTTP/1.1 403 Forbidden\r\n"
@@ -249,6 +251,10 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         warning = str(logger.warning.call_args)
         self.assertNotIn("123456", warning)
         self.assertIn("pwd=***", warning)
+        self.assertTrue(reply_event.is_set())
+        error = handler.get_reply_error("request-1")
+        self.assertIn("HTTP 403", error)
+        self.assertIn("Denied", error)
 
     async def test_empty_ping_acknowledgement_updates_liveness(self) -> None:
         """The gateway's bodyless ping response must clear a pending ping."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -182,6 +182,68 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         )
         self.assertNotIn("transmitter", result)
 
+    async def test_unacknowledged_alarm_events_are_sanitised_and_cached(self) -> None:
+        """Pending history should provide a bounded dashboard-safe event list."""
+        client = MagicMock()
+        client.get_historic_cdata = AsyncMock(
+            return_value=[
+                {
+                    "values": {
+                        "event": {
+                            "name": "INTRUSION",
+                            "date": "2026-08-02T19:00:00",
+                            "zones": [2],
+                            "product": {
+                                "nameCustom": "Garage detector",
+                                "typeLong": "DMB",
+                                "privateRadioIdentifier": "hidden",
+                            },
+                            "accessCode": {"nameCustom": "Owner", "id": 12},
+                            "privateField": "hidden",
+                        }
+                    }
+                }
+            ]
+        )
+        alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+        callback = MagicMock()
+        alarm.register_callback(callback)
+
+        result = await alarm.get_events("UNACKED_EVENTS")
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    "name": "INTRUSION",
+                    "date": "2026-08-02T19:00:00",
+                    "zones": [2],
+                    "product": {
+                        "nameCustom": "Garage detector",
+                        "typeLong": "DMB",
+                    },
+                    "accessCode": {"nameCustom": "Owner"},
+                }
+            ],
+        )
+        self.assertEqual(alarm.pending_events, result)
+        callback.assert_called_once_with()
+
+    async def test_acknowledgement_clears_cached_alarm_events(self) -> None:
+        """A successful acknowledgement should clear the dashboard immediately."""
+        client = MagicMock()
+        client.put_ackevents_cdata = AsyncMock()
+        alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+        alarm._pending_events = [{"name": "INTRUSION"}]
+        callback = MagicMock()
+        alarm.register_callback(callback)
+
+        await alarm.acknowledge_events()
+
+        client.put_ackevents_cdata.assert_awaited_once_with("20", "10", None)
+        self.assertEqual(alarm.pending_events, [])
+        callback.assert_called_once_with()
+
     async def test_empty_success_response_is_treated_as_acknowledgement(self) -> None:
         """An empty successful response must not be reported as an unknown message."""
         logger.reset_mock()

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -1,5 +1,6 @@
 """Tests for Tydom protocol response handling."""
 
+import asyncio
 import importlib.util
 from pathlib import Path
 import sys
@@ -66,6 +67,7 @@ handler_spec.loader.exec_module(handler_module)
 
 MessageHandler = handler_module.MessageHandler
 TydomLight = devices_module.TydomLight
+TydomAlarm = devices_module.TydomAlarm
 
 for name, original in _original_modules.items():
     if original is _MISSING:
@@ -104,6 +106,82 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertFalse(binary_light.supports_brightness)
         self.assertTrue(dimmable_light.supports_brightness)
 
+    async def test_alarm_inventory_merges_labels_and_technical_data(self) -> None:
+        """Inventory responses should be useful without exposing other labels."""
+        client = MagicMock()
+        client.get_alarm_products_cdata = AsyncMock(
+            return_value={
+                "productInfo": {
+                    "values": {
+                        "products": [
+                            {"id": 4, "uuid": "product-uuid", "batteryLevel": 88}
+                        ]
+                    }
+                },
+                "label": {
+                    "values": {
+                        "products": [
+                            {
+                                "id": 4,
+                                "nameCustom": "Garage detector",
+                                "typeLong": "Movement detector",
+                                "zone": 2,
+                            }
+                        ],
+                        "zones": [{"id": 2, "nameCustom": "Garage"}],
+                        "accessCodes": [{"id": 1, "nameCustom": "Private"}],
+                    }
+                },
+            }
+        )
+        alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+
+        result = await alarm.get_alarm_products()
+
+        self.assertEqual(
+            result,
+            {
+                "zones": [{"id": 2, "name_custom": "Garage"}],
+                "products": [
+                    {
+                        "id": 4,
+                        "name_custom": "Garage detector",
+                        "type_long": "Movement detector",
+                        "zone": 2,
+                        "uuid": "product-uuid",
+                        "battery_level": 88,
+                    }
+                ],
+            },
+        )
+        self.assertNotIn("accessCodes", result)
+
+    async def test_alarm_product_configuration_filters_sensitive_sections(self) -> None:
+        """Only common product settings should reach a service response."""
+        client = MagicMock()
+        client.get_alarm_product_configuration_cdata = AsyncMock(
+            return_value={
+                "values": {
+                    "id": 4,
+                    "common": {
+                        "inactive": False,
+                        "zone": 2,
+                        "autoProtectActive": True,
+                    },
+                    "transmitter": {"codePin": "secret"},
+                }
+            }
+        )
+        alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+
+        result = await alarm.get_alarm_product_configuration("123456", 4)
+
+        self.assertEqual(
+            result,
+            {"id": 4, "active": True, "zone": 2, "auto_protect_active": True},
+        )
+        self.assertNotIn("transmitter", result)
+
     async def test_empty_success_response_is_treated_as_acknowledgement(self) -> None:
         """An empty successful response must not be reported as an unknown message."""
         logger.reset_mock()
@@ -119,6 +197,58 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
 
         self.assertIsNone(devices)
         logger.warning.assert_not_called()
+
+    async def test_single_alarm_configuration_cdata_completes_reply(self) -> None:
+        """Non-history cdata must complete without a streamed EOR sentinel."""
+        client = MagicMock()
+        handler = MessageHandler(client, b"")
+        handler.get_type_from_id = MagicMock(return_value="alarm")
+        handler.get_name_from_id = MagicMock(return_value="Alarm")
+        reply_event = asyncio.Event()
+        handler._end_reply_events["request-1"] = reply_event
+
+        await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "cdata": [
+                                {
+                                    "name": "productConf",
+                                    "values": {"id": 4, "common": {"zone": 2}},
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "request-1",
+        )
+
+        self.assertTrue(reply_event.is_set())
+        self.assertEqual(
+            handler.get_reply("request-1")["events"][0]["name"], "productConf"
+        )
+
+    async def test_rejected_alarm_configuration_redacts_pin(self) -> None:
+        """An alarm PIN in Uri-Origin must never be written to the log."""
+        logger.reset_mock()
+        handler = MessageHandler(MagicMock(), b"")
+
+        await handler.route_response(
+            b"HTTP/1.1 403 Forbidden\r\n"
+            b"Uri-Origin: /devices/20/endpoints/10/cdata?name=productConf&pwd=123456&id=4\r\n"
+            b"Content-Type: text/html\r\n"
+            b"Content-Length: 6\r\n"
+            b"Transac-Id: request-1\r\n\r\nDenied"
+        )
+
+        warning = str(logger.warning.call_args)
+        self.assertNotIn("123456", warning)
+        self.assertIn("pwd=***", warning)
 
     async def test_empty_ping_acknowledgement_updates_liveness(self) -> None:
         """The gateway's bodyless ping response must clear a pending ping."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -229,10 +229,11 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertEqual(alarm.pending_events, result)
         callback.assert_called_once_with()
 
-    async def test_acknowledgement_clears_cached_alarm_events(self) -> None:
-        """A successful acknowledgement should clear the dashboard immediately."""
+    async def test_acknowledgement_refreshes_cached_alarm_events(self) -> None:
+        """Acknowledgement must replace optimistic state with gateway history."""
         client = MagicMock()
         client.put_ackevents_cdata = AsyncMock()
+        client.get_historic_cdata = AsyncMock(return_value=[])
         alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
         alarm._pending_events = [{"name": "INTRUSION"}]
         callback = MagicMock()
@@ -241,8 +242,37 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         await alarm.acknowledge_events()
 
         client.put_ackevents_cdata.assert_awaited_once_with("20", "10", None)
+        client.get_historic_cdata.assert_awaited_once_with(
+            "20", "10", "UNACKED_EVENTS"
+        )
         self.assertEqual(alarm.pending_events, [])
         callback.assert_called_once_with()
+
+    async def test_ignored_acknowledgement_keeps_pending_alarm_events(self) -> None:
+        """A transport acknowledgement must not hide an uncleared gateway event."""
+        client = MagicMock()
+        client.put_ackevents_cdata = AsyncMock()
+        client.get_historic_cdata = AsyncMock(
+            return_value=[
+                {
+                    "values": {
+                        "event": {
+                            "name": "alarmIntrusion",
+                            "date": "2026-08-05T09:59:00",
+                        }
+                    }
+                }
+            ]
+        )
+        alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+        alarm._pending_events = [{"name": "alarmIntrusion"}]
+
+        await alarm.acknowledge_events()
+
+        self.assertEqual(
+            alarm.pending_events,
+            [{"name": "alarmIntrusion", "date": "2026-08-05T09:59:00"}],
+        )
 
     async def test_empty_success_response_is_treated_as_acknowledgement(self) -> None:
         """An empty successful response must not be reported as an unknown message."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -125,10 +125,10 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
                                 "id": 4,
                                 "nameCustom": "Garage detector",
                                 "typeLong": "Movement detector",
-                                "zone": 2,
+                                "zone": 0,
                             }
                         ],
-                        "zones": [{"id": 2, "nameCustom": "Garage"}],
+                        "zones": [{"id": 0, "nameCustom": "Ground floor"}],
                         "accessCodes": [{"id": 1, "nameCustom": "Private"}],
                     }
                 },
@@ -141,13 +141,13 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertEqual(
             result,
             {
-                "zones": [{"id": 2, "name_custom": "Garage"}],
+                "zones": [{"id": 0, "name_custom": "Ground floor"}],
                 "products": [
                     {
                         "id": 4,
                         "name_custom": "Garage detector",
                         "type_long": "Movement detector",
-                        "zone": 2,
+                        "zone": 0,
                         "uuid": "product-uuid",
                         "battery_level": 88,
                     }
@@ -165,7 +165,7 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
                     "id": 4,
                     "common": {
                         "inactive": False,
-                        "zone": 2,
+                        "zone": 0,
                         "autoProtectActive": True,
                     },
                     "transmitter": {"codePin": "secret"},
@@ -178,7 +178,7 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
 
         self.assertEqual(
             result,
-            {"id": 4, "active": True, "zone": 2, "auto_protect_active": True},
+            {"id": 4, "active": True, "zone": 0, "auto_protect_active": True},
         )
         self.assertNotIn("transmitter", result)
 

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -295,6 +295,53 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
             handler.get_reply("request-1")["events"][0]["name"], "productConf"
         )
 
+    async def test_alarm_data_after_early_eor_is_not_lost(self) -> None:
+        """A TYXAL cdata object arriving just after EOR must win the race."""
+        handler = MessageHandler(MagicMock(), b"")
+        handler.get_type_from_id = MagicMock(return_value="alarm")
+        handler.get_name_from_id = MagicMock(return_value="Alarm")
+        reply_event = asyncio.Event()
+        handler._end_reply_events["request-1"] = reply_event
+        envelope = {"id": 20, "endpoints": [{"id": 10, "error": 0, "cdata": []}]}
+
+        envelope["endpoints"][0]["cdata"] = [{"EOR": True}]
+        await handler.parse_devices_cdata([envelope], "request-1")
+        self.assertFalse(reply_event.is_set())
+
+        envelope["endpoints"][0]["cdata"] = [
+            {
+                "name": "productConf",
+                "values": {"id": 2, "common": {"inactive": False}},
+            }
+        ]
+        await handler.parse_devices_cdata([envelope], "request-1")
+
+        self.assertTrue(reply_event.is_set())
+        self.assertEqual(
+            handler.get_reply("request-1")["events"][0]["name"], "productConf"
+        )
+
+    async def test_alarm_eor_only_reply_completes_after_grace_period(self) -> None:
+        """A genuinely empty TYXAL reply must still complete promptly."""
+        handler = MessageHandler(MagicMock(), b"")
+        handler.get_type_from_id = MagicMock(return_value="alarm")
+        handler.get_name_from_id = MagicMock(return_value="Alarm")
+        reply_event = asyncio.Event()
+        handler._end_reply_events["request-1"] = reply_event
+
+        await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [{"id": 10, "error": 0, "cdata": [{"EOR": True}]}],
+                }
+            ],
+            "request-1",
+        )
+
+        await asyncio.wait_for(reply_event.wait(), timeout=0.2)
+        self.assertEqual(handler.get_reply("request-1")["events"], [])
+
     async def test_rejected_alarm_configuration_redacts_pin(self) -> None:
         """An alarm PIN in Uri-Origin must never be written to the log."""
         logger.reset_mock()

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -96,6 +96,7 @@ _original_modules.setdefault(module_name, sys.modules.get(module_name, _MISSING)
 sys.modules[module_name] = client_module
 spec.loader.exec_module(client_module)
 TydomClient = client_module.TydomClient
+sanitize_log_message = client_module.sanitize_log_message
 
 for name, original in _original_modules.items():
     if original is _MISSING:
@@ -166,6 +167,86 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
                 call("20", "10", "123456", "ON", "1", True),
                 call("20", "10", "123456", "ON", "3", True),
             ],
+        )
+
+    async def test_alarm_inventory_reads_product_info_and_labels(self) -> None:
+        """The alarm inventory must combine the two official read commands."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(
+            side_effect=[
+                [{"name": "productInfo", "values": {"products": []}}],
+                [{"name": "label", "values": {"products": [], "zones": []}}],
+            ]
+        )
+
+        result = await client.get_alarm_products_cdata("20", "10")
+
+        self.assertEqual(result["productInfo"]["name"], "productInfo")
+        self.assertEqual(result["label"]["name"], "label")
+        self.assertEqual(
+            client.get_reply_to_request.await_args_list,
+            [
+                call("GET", "/devices/20/endpoints/10/cdata?name=productInfo"),
+                call("GET", "/devices/20/endpoints/10/cdata?name=label"),
+            ],
+        )
+
+    async def test_alarm_product_configuration_uses_encoded_pin(self) -> None:
+        """The read command must follow the official query-string protocol."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(
+            return_value=[{"name": "productConf", "values": {"id": 4}}]
+        )
+
+        result = await client.get_alarm_product_configuration_cdata(
+            "20", "10", "12&34", 4
+        )
+
+        self.assertEqual(result["values"]["id"], 4)
+        client.get_reply_to_request.assert_awaited_once_with(
+            "GET",
+            "/devices/20/endpoints/10/cdata?name=productConf&pwd=12%2634&id=4",
+        )
+        self.assertNotIn("12&34", sanitize_log_message("?pwd=12&34"))
+
+    async def test_alarm_product_update_sends_only_requested_fields(self) -> None:
+        """A partial update must not overwrite unrelated product settings."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+
+        await client.put_alarm_product_configuration_cdata(
+            "20", "10", "123456", 4, active=False, zone=3
+        )
+
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=productConf",
+            body={
+                "pwd": "123456",
+                "id": 4,
+                "common": {"inactive": True, "zone": 3},
+            },
+        )
+
+    async def test_alarm_zone_rename_uses_custom_label_command(self) -> None:
+        """Zone renaming must use the official zoneLabelConf payload."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+
+        await client.put_alarm_zone_label_cdata("20", "10", "123456", 2, "Outbuildings")
+
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=zoneLabelConf",
+            body={
+                "pwd": "123456",
+                "id": 2,
+                "label": {
+                    "nameStd": None,
+                    "number": None,
+                    "nameCustom": "Outbuildings",
+                },
+            },
         )
 
     async def test_failed_initialisation_closes_candidate(self) -> None:

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -335,6 +335,19 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_alarm_zone_empty_name_clears_label(self) -> None:
+        """An empty name must match the app's empty label reset payload."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+
+        await client.put_alarm_zone_label_cdata("20", "10", "123456", 4, "")
+
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=zoneLabelConf",
+            body={"pwd": "123456", "id": 4, "label": {}},
+        )
+
     async def test_failed_initialisation_closes_candidate(self) -> None:
         """A socket that fails initialisation must never remain active."""
         client = self._client()

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -291,6 +291,30 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_alarm_remote_configuration_lock_uses_official_command(self) -> None:
+        """Remote TYXAL configuration must be explicitly locked and unlocked."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+
+        await client.put_alarm_remote_control_cdata("20", "10", "123456", "LOCK")
+        await client.put_alarm_remote_control_cdata("20", "10", "123456", "UNLOCK")
+
+        self.assertEqual(
+            client.get_reply_to_request.await_args_list,
+            [
+                call(
+                    "PUT",
+                    "/devices/20/endpoints/10/cdata?name=remoteCtrl",
+                    body={"pwd": "123456", "control": "LOCK"},
+                ),
+                call(
+                    "PUT",
+                    "/devices/20/endpoints/10/cdata?name=remoteCtrl",
+                    body={"pwd": "123456", "control": "UNLOCK"},
+                ),
+            ],
+        )
+
     async def test_alarm_zone_rename_uses_custom_label_command(self) -> None:
         """Zone renaming must use the official zoneLabelConf payload."""
         client = self._client()

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -96,6 +96,9 @@ _original_modules.setdefault(module_name, sys.modules.get(module_name, _MISSING)
 sys.modules[module_name] = client_module
 spec.loader.exec_module(client_module)
 TydomClient = client_module.TydomClient
+TydomClientApiClientCommunicationError = (
+    client_module.TydomClientApiClientCommunicationError
+)
 sanitize_log_message = client_module.sanitize_log_message
 
 for name, original in _original_modules.items():
@@ -191,6 +194,25 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_rejected_tracked_request_raises_protocol_error(self) -> None:
+        """A gateway rejection must not be returned as an empty success."""
+        client = self._client()
+
+        def prepare_request(_method, _url, _body, _headers, reply_event):
+            reply_event.set()
+            return "request-1", b"request"
+
+        client._message_handler.prepare_request = MagicMock(side_effect=prepare_request)
+        client._message_handler.get_reply_error = MagicMock(
+            return_value="HTTP 403: The data is not writable"
+        )
+        client.send_bytes = AsyncMock()
+
+        with self.assertRaisesRegex(TydomClientApiClientCommunicationError, "HTTP 403"):
+            await client.get_reply_to_request(
+                "GET", "/cdata?name=productConf&pwd=123456"
+            )
+
     async def test_alarm_product_configuration_uses_encoded_pin(self) -> None:
         """The read command must follow the official query-string protocol."""
         client = self._client()
@@ -206,6 +228,10 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         client.get_reply_to_request.assert_awaited_once_with(
             "GET",
             "/devices/20/endpoints/10/cdata?name=productConf&pwd=12%2634&id=4",
+            headers={
+                "Content-Length": "0",
+                "Content-Type": "application/json; charset=UTF-8",
+            },
         )
         self.assertNotIn("12&34", sanitize_log_message("?pwd=12&34"))
 

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -296,8 +296,8 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         client = self._client()
         client.get_reply_to_request = AsyncMock(return_value=[])
 
-        await client.put_alarm_remote_control_cdata("20", "10", "123456", "LOCK")
-        await client.put_alarm_remote_control_cdata("20", "10", "123456", "UNLOCK")
+        await client.put_alarm_remote_control_cdata("20", "10", "123456", "lock")
+        await client.put_alarm_remote_control_cdata("20", "10", "123456", "unlock")
 
         self.assertEqual(
             client.get_reply_to_request.await_args_list,
@@ -305,12 +305,12 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
                 call(
                     "PUT",
                     "/devices/20/endpoints/10/cdata?name=remoteCtrl",
-                    body={"pwd": "123456", "control": "LOCK"},
+                    body={"pwd": "123456", "control": "lock"},
                 ),
                 call(
                     "PUT",
                     "/devices/20/endpoints/10/cdata?name=remoteCtrl",
-                    body={"pwd": "123456", "control": "UNLOCK"},
+                    body={"pwd": "123456", "control": "unlock"},
                 ),
             ],
         )

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -328,11 +328,7 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             body={
                 "pwd": "123456",
                 "id": 2,
-                "label": {
-                    "nameStd": None,
-                    "number": None,
-                    "nameCustom": "Outbuildings",
-                },
+                "label": {"nameCustom": "Outbuildings"},
             },
         )
 

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -189,8 +189,22 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         self.assertEqual(
             client.get_reply_to_request.await_args_list,
             [
-                call("GET", "/devices/20/endpoints/10/cdata?name=productInfo"),
-                call("GET", "/devices/20/endpoints/10/cdata?name=label"),
+                call(
+                    "GET",
+                    "/devices/20/endpoints/10/cdata?name=productInfo",
+                    headers={
+                        "Content-Length": "0",
+                        "Content-Type": "application/json; charset=UTF-8",
+                    },
+                ),
+                call(
+                    "GET",
+                    "/devices/20/endpoints/10/cdata?name=label",
+                    headers={
+                        "Content-Length": "0",
+                        "Content-Type": "application/json; charset=UTF-8",
+                    },
+                ),
             ],
         )
 

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -172,31 +172,20 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             ],
         )
 
-    async def test_alarm_inventory_reads_product_info_and_labels(self) -> None:
-        """The alarm inventory must combine the two official read commands."""
+    async def test_alarm_inventory_uses_supported_label_command(self) -> None:
+        """Inventory must not depend on optional unsupported productInfo data."""
         client = self._client()
         client.get_reply_to_request = AsyncMock(
-            side_effect=[
-                [{"name": "productInfo", "values": {"products": []}}],
-                [{"name": "label", "values": {"products": [], "zones": []}}],
-            ]
+            return_value=[{"name": "label", "values": {"products": [], "zones": []}}]
         )
 
         result = await client.get_alarm_products_cdata("20", "10")
 
-        self.assertEqual(result["productInfo"]["name"], "productInfo")
+        self.assertIsNone(result["productInfo"])
         self.assertEqual(result["label"]["name"], "label")
         self.assertEqual(
             client.get_reply_to_request.await_args_list,
             [
-                call(
-                    "GET",
-                    "/devices/20/endpoints/10/cdata?name=productInfo",
-                    headers={
-                        "Content-Length": "0",
-                        "Content-Type": "application/json; charset=UTF-8",
-                    },
-                ),
                 call(
                     "GET",
                     "/devices/20/endpoints/10/cdata?name=label",

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -336,7 +336,7 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         )
 
     async def test_alarm_zone_empty_name_clears_label(self) -> None:
-        """An empty name must match the app's empty label reset payload."""
+        """An empty name must remain explicit in the app's reset payload."""
         client = self._client()
         client.get_reply_to_request = AsyncMock(return_value=[])
 
@@ -345,7 +345,7 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         client.get_reply_to_request.assert_awaited_once_with(
             "PUT",
             "/devices/20/endpoints/10/cdata?name=zoneLabelConf",
-            body={"pwd": "123456", "id": 4, "label": {}},
+            body={"pwd": "123456", "id": 4, "label": {"nameCustom": ""}},
         )
 
     async def test_failed_initialisation_closes_candidate(self) -> None:

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -294,6 +294,35 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_alarm_acknowledgement_prefers_authenticated_cdata(self) -> None:
+        """A configured code must use the controlled command advertised by TYXAL."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+        client.put_devices_data = AsyncMock()
+
+        await client.put_ackevents_cdata("20", "10", "123456")
+
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=ackEventCmd",
+            body={"pwd": "123456"},
+        )
+        client.put_devices_data.assert_not_awaited()
+
+    async def test_alarm_acknowledgement_falls_back_to_data_channel(self) -> None:
+        """Firmware rejecting authenticated cdata must retain the proven fallback."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(
+            side_effect=TydomClientApiClientCommunicationError("HTTP 500")
+        )
+        client.put_devices_data = AsyncMock()
+
+        await client.put_ackevents_cdata("20", "10", "123456")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "20", "10", "ackEventCmd", "ACK"
+        )
+
     async def test_alarm_remote_configuration_lock_uses_official_command(self) -> None:
         """Remote TYXAL configuration must be explicitly locked and unlocked."""
         client = self._client()

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -235,13 +235,13 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         )
         self.assertNotIn("12&34", sanitize_log_message("?pwd=12&34"))
 
-    async def test_alarm_product_update_sends_only_requested_fields(self) -> None:
-        """A partial update must not overwrite unrelated product settings."""
+    async def test_alarm_product_zone_update_sends_only_requested_field(self) -> None:
+        """A zone update must not overwrite unrelated product settings."""
         client = self._client()
         client.get_reply_to_request = AsyncMock(return_value=[])
 
         await client.put_alarm_product_configuration_cdata(
-            "20", "10", "123456", 4, active=False, zone=3
+            "20", "10", "123456", 4, zone=3
         )
 
         client.get_reply_to_request.assert_awaited_once_with(
@@ -250,8 +250,45 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
             body={
                 "pwd": "123456",
                 "id": 4,
-                "common": {"inactive": True, "zone": 3},
+                "common": {"zone": 3},
             },
+        )
+
+    async def test_alarm_product_activation_uses_dedicated_command(self) -> None:
+        """Activation must use activeProductConf instead of productConf."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+
+        await client.put_alarm_product_active_cdata("20", "10", "123456", 4, False)
+
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=activeProductConf",
+            body={"pwd": "123456", "id": 4, "activeProduct": False},
+        )
+
+    async def test_alarm_maintenance_commands_await_gateway_reply(self) -> None:
+        """Entering and leaving maintenance must use global alarmCmd writes."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(return_value=[])
+
+        await client.put_alarm_mode_cdata("20", "10", "123456", "MAINTENANCE")
+        await client.put_alarm_mode_cdata("20", "10", "123456", "OFF")
+
+        self.assertEqual(
+            client.get_reply_to_request.await_args_list,
+            [
+                call(
+                    "PUT",
+                    "/devices/20/endpoints/10/cdata?name=alarmCmd",
+                    body={"pwd": "123456", "value": "MAINTENANCE"},
+                ),
+                call(
+                    "PUT",
+                    "/devices/20/endpoints/10/cdata?name=alarmCmd",
+                    body={"pwd": "123456", "value": "OFF"},
+                ),
+            ],
         )
 
     async def test_alarm_zone_rename_uses_custom_label_command(self) -> None:


### PR DESCRIPTION
# Add TYXAL+ remote product and zone management

## Summary

This PR completes the TYXAL+ remote-management work requested in #161 by
exposing product and zone discovery, a controlled installer maintenance
session, safe product-configuration reads, product activation and zone
assignment, zone renaming, a dashboard-ready pending-events sensor and a native
alarm-event acknowledgement button.

The existing `get_events` and `acknowledge_events` actions are retained for
scripts and automations. The sensor and button provide the direct alarm-device
display and control proposed in the issue without duplicating the underlying
protocol commands.

## Why this is needed

The integration can already arm and disarm a TYXAL+ alarm, but Home Assistant
could not use the remote configuration functions which Delta Dore now exposes
through the Tydom application. Users could not:

- list the products and zones configured on the alarm;
- inspect a product's active state and zone assignment;
- activate or deactivate a product;
- move a product to another zone; or
- rename a zone.

These operations are not ordinary alarm commands. A CS8000 requires an
installer-authenticated remote-control lock and maintenance mode before it will
allow product configuration. Sending `productConf` without that locked session
is rejected by the gateway with HTTP 403.

## Home Assistant actions

| Action | Purpose | Maintenance required |
| --- | --- | --- |
| `get_alarm_products` | Return the configured products and zones | No |
| `enter_alarm_maintenance` | Lock remote configuration and put a disarmed CS8000 into maintenance | N/A ? opens the session |
| `get_alarm_product_configuration` | Return a product's safe common settings | Yes |
| `configure_alarm_product` | Activate/deactivate a product and/or assign its zone | Yes |
| `rename_alarm_zone` | Change a zone's custom name | Yes |
| `exit_alarm_maintenance` | Return the CS8000 to its normal disarmed state and unlock remote configuration | N/A ? closes the session |

## Event history and acknowledgement

The existing `get_events` response action supports the four TYXAL history
filters discussed in #161:

- `ALL`;
- `EVENTS`;
- `ON_OFF`; and
- `UNACKED_EVENTS`.

It returns the matching event data for the user to display, template or process
in an automation. The existing `acknowledge_events` action remains available
for scripts and automations.

This PR additionally creates two entities on the TYXAL alarm device:

- **Pending alarm events**, a diagnostic sensor whose state is the number of
  unacknowledged events. Its `events` attribute contains the bounded,
  sanitised list returned by the gateway and `latest_event` provides the most
  recent item for simple dashboard templates and automations. The list can
  identify the event name, date, zone and responsible product when those
  details are supplied by the CS8000.
- **Acknowledge events**, a button suitable for a dashboard. It uses an explicit
  action code when supplied or the alarm code already configured on the
  integration. It first tries the authenticated controlled command advertised
  by the gateway and retains the pin-free data write as a compatibility fallback
  for firmware which rejects the controlled form.

The history request is made only when the CS8000 reports `unackedEvent`, rather
than being polled continuously. After an acknowledgement attempt, the
integration re-reads `UNACKED_EVENTS` and updates the sensor from that
response. It no longer hides an uncleared gateway event merely because the
write received an empty HTTP 200 response. English and French entity names are
included.

The inventory action uses Delta Dore's `label` response, which contains the
configured products and zones. It returns product IDs, user-facing names,
product types and zone assignments, plus the configured zone IDs and labels.
This keeps discovery compatible with CS8000 firmware that exposes the full
inventory through `label` without supporting the optional `productInfo`
enrichment command.

The configuration read deliberately returns only:

- product ID;
- active state;
- zone assignment; and
- auto-protection state, when present.

It does not expose sensitive or unrelated configuration sections returned by
some products.

## TYXAL maintenance workflow

The maintenance actions reproduce the sequence used by the current Delta Dore
application and advertised by the CS8000 metadata:

1. write `remoteCtrl=lock` with the installer code;
2. write `alarmCmd=MAINTENANCE`;
3. perform the required configuration reads or writes;
4. write `alarmCmd=OFF`; and
5. write `remoteCtrl=unlock`.

The values for `remoteCtrl` are intentionally lowercase, matching the live
CS8000 metadata: `lock`, `unlock` and `forceUnlock`.

If entering maintenance fails after acquiring the lock, the integration tries
to unlock the remote session before returning the error. When exiting
maintenance, unlocking is attempted in a `finally` block so it is not skipped
if the preceding `OFF` request fails.

Maintenance is never entered or exited implicitly around a configuration
operation. These remain deliberate user actions, making the alarm's state and
the lifetime of the installer session visible to the user.

## Product and zone commands

- Product activation uses the dedicated `activeProductConf` command.
- Zone assignment uses a partial `productConf.common.zone` update, avoiding
  overwriting unrelated product settings.
- Zone renaming uses `zoneLabelConf` with zone IDs in the CS8000's advertised
  `0` to `7` range.
- Supplying an empty zone name sends the app's explicit blank `nameCustom`
  value, allowing a zone label to be cleared without serialising rejected JSON
  `null` values.

### Zone labels and clearing a name

The inventory preserves the two label forms supplied by Delta Dore:

- `name_custom` is a user-defined name stored by the CS8000;
- `name_standard` is a language-neutral Delta Dore identifier such as `GARDEN`
  or `GARDEN_SHED`. The Tydom app translates those identifiers for display, for
  example `GARDEN` is shown as *Jardin* in French.

The raw standard identifier is retained so action responses and automations do
not change with the Home Assistant language.

Renaming a zone requires an active installer maintenance session. For example:

```yaml
action: deltadore_tydom.rename_alarm_zone
target:
  entity_id: alarm_control_panel.tyxal_alarm
data:
  code: "YOUR_INSTALLER_CODE"
  zone_id: 4
  name: Garage
```

To return a zone to an unnamed state, call the same action in YAML mode with an
explicit empty string:

```yaml
action: deltadore_tydom.rename_alarm_zone
target:
  entity_id: alarm_control_panel.tyxal_alarm
data:
  code: "YOUR_INSTALLER_CODE"
  zone_id: 4
  name: ""
```

This is intentionally different from assigning a generated label such as
`Zone 5`. The empty value reproduces the current Tydom application's reset
request:

```json
{"pwd":"<redacted>","id":4,"label":{"nameCustom":""}}
```

After a successful reset, `get_alarm_products` reports the zone with only its
ID when no standard name is configured:

```yaml
zones:
  - id: 4
```

The CS8000 must be returned to `OFF` and the remote configuration session
unlocked with `exit_alarm_maintenance` after either operation.

## Validation, errors and sensitive data

- Installer codes must contain exactly six hexadecimal characters.
- Installer-code fields use password selectors in Home Assistant.
- Codes in query strings are redacted before URLs reach logs or exceptions.
- HTTP failures are correlated with the request transaction and surfaced as
  useful Home Assistant errors instead of an empty or apparently successful
  response.
- Empty HTTP success responses are accepted as acknowledgements.
- Some CS8000 firmware sends an empty end-of-reply marker immediately before
  the requested single configuration object. The reply handler allows a brief
  grace period for that object while still completing genuinely empty replies,
  preventing a valid response from being reported as missing.
- Reply-cache rollover retains the newly received transaction while evicting
  the oldest cached reply, so repeated maintenance operations continue to
  return their response data correctly.
- English and French action descriptions explain the installer-code and
  maintenance requirements.
- The README documents the required action order and reminds users to leave
  maintenance when finished.

This PR does not expose product deletion, alarm access-code management,
telephone settings, monitoring configuration or siren configuration.

## Testing

### Automated

- `120 passed`
- Ruff checks pass for the changed Python files.

Coverage includes:

- extracting products and zones from the supported `label` response;
- framing the empty `label` read with the zero-length JSON headers used by the
  Delta Dore application;
- filtering sensitive product-configuration sections;
- encoding and redacting installer codes in read requests;
- the exact `activeProductConf`, `productConf`, `zoneLabelConf`, `alarmCmd` and
  `remoteCtrl` request payloads;
- HTTP error propagation and transaction correlation;
- configuration data arriving just after an early end-of-reply marker, and
  genuinely empty replies completing after the grace period;
- reply-cache rollover preserving the current configuration response;
- preserving existing legacy alarm command behaviour;
- sanitising and caching unacknowledged history for the dashboard sensor; and
- authenticated acknowledgement, fallback for firmware supporting only the
  data-channel form, and authoritative post-command history refresh; and
- retaining a pending event when a transport-level success did not clear it.

### Live CS8000 test

Tested on a real TYXAL+ CS8000 through a Tydom gateway:

- inventory returned all 8 configured zones (`0` to `7`) and 28 products,
  including IDs, custom or standard names, product types and zone assignments;
- the complete maintenance lifecycle was confirmed: installer-authenticated
  lock, transition to `MAINTENANCE`, return to `OFF` and remote-control unlock;
- a safe configuration read for a DMB detector returned:

  ```yaml
  id: 2
  active: true
  zone: 2
  auto_protect_active: true
  ```

- that detector was deactivated with `activeProductConf`; a subsequent read
  returned `active: false` while preserving zone `2` and auto-protection;
- the detector was immediately reactivated; the CS8000 acknowledged the write,
  pushed `inactiveProduct: false` and returned `inactive: false` for product
  `2`, confirming restoration of its original active state;
- the same active detector was moved temporarily from zone `2` to unused zone
  `4`; a configuration read returned `zone: 4` while preserving its active and
  auto-protection states;
- it was then reassigned to its original zone `2`; the final read returned
  `active: true`, `zone: 2` and `auto_protect_active: true`;

- renaming zone `4` to a temporary label returned `ACK`; a subsequent inventory
  read reported the new label;
- clearing that label with an explicit blank `nameCustom` value also returned
  successfully; a final inventory read reported zone `4` with only its ID and
  no custom or standard name, confirming restoration of its original state;
- the native **Acknowledge events** button was pressed from the Home Assistant
  UI and the TYXAL endpoint returned HTTP 200;
- `get_events` with the `EVENTS` filter returned the latest ten genuine CS8000
  history entries. The response included event names and dates, multiple
  affected zones with custom or standard labels, the acting access-code label,
  and responsible product names and types where applicable. Observed categories
  included maintenance entry, gateway start-up, refused arming,
  acknowledgement, time synchronisation and IP-fault recovery;
- the **Pending alarm events** sensor was created on the live TYXAL device,
  linked to its Home Assistant device and area, and displayed state `0` with an
  empty `events` list and `latest_event: null` while nothing awaited
  acknowledgement.

A complete live alarm-event lifecycle was subsequently tested:

- the alarm was armed with the monitored entrance closed and all four configured
  zones reported `ON`;
- opening the entrance produced `alarmState: DELAYED`, followed by the genuine
  triggered state `alarmState: ON` after the entry delay expired;
- after disarming, the CS8000 reported `unackedEvent: true`;
- the integration automatically requested `UNACKED_EVENTS` and received one
  `alarmIntrusion` event identifying the affected ground-floor zone and the
  responsible MDO entrance contact;
- Home Assistant displayed state `1` on **Pending alarm events**, confirming the
  populated sensor and its sanitised attributes on live hardware;
- the first acknowledgement attempt used the previous pin-free
  `ackEventCmd=ACK` data write. The gateway returned HTTP 200, but did not emit
  `unackedEvent: false` and the official Tydom application continued to show the
  event. This demonstrated that transport success alone must not clear the
  Home Assistant sensor;
- after deploying the capability-compatible correction and restarting Home
  Assistant, the same still-pending event was acknowledged again. The gateway
  reported `unackedEvent: false`, returned `result: ACK` with `authent: USER`,
  and the integration's authoritative `UNACKED_EVENTS` refresh returned zero
  events. The official Tydom application also removed the unacknowledged fault,
  independently confirming that the event was cleared on the CS8000 rather than
  only in Home Assistant.

This confirms both gateway variants are handled without optimistic state: an
alarm code selects the authenticated cdata command advertised by this CS8000,
while the pin-free data form remains as a fallback for firmware already proven
to require it. In either case, the sensor is updated only from the subsequent
history response.

The installer code, gateway identifiers, precise timestamps, personal
access-code labels, custom zone/product names and unrelated log content have
been excluded or generalised in this testing summary.

### Live-test conclusion

The inventory and read-only workflow, maintenance-session lifecycle, reversible
product activation/deactivation, reversible zone reassignment and renaming,
history retrieval, populated pending-events sensor, and native acknowledgement
button have all been confirmed on live CS8000 hardware. The final configuration
updates also reported `alarmMode: OFF` and `remoteCtrl: unlocked` after the test
product and zone had been restored.

The complete alarm-event lifecycle is now confirmed on live hardware: trigger,
`unackedEvent`, populated and sanitised history, dashboard state `1`, authenticated
acknowledgement, gateway state clear and authoritative dashboard refresh to zero.
Other protocol edge cases are covered by the automated test suite.

Fixes #161
