### PR TITLE
Limit validation workflow token permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     name: "Ruff"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
     name: "Hassfest Validation"


### PR DESCRIPTION
## Summary

Restrict the GitHub token used by the lint, Hassfest and HACS validation workflows to read-only repository access.

## Security impact

These jobs only need to read the checked-out repository. Declaring `contents: read` prevents their tokens from writing repository contents if a third-party action or development dependency is compromised.

The release workflow is unchanged and retains its separately scoped `contents: write` permission for publishing release archives.

This addresses code-scanning alerts 15, 16 and 17.

## Validation

- `git diff --check` passes.
- Both workflow files retain valid GitHub Actions permission syntax.
- No integration runtime files are changed.