### PR TITLE
Correct open and close semantics for awnings

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -436,6 +436,11 @@ class GenericSensor(SensorEntity):
         """Return the native value of the sensor."""
         # Utiliser getattr avec une valeur par défaut pour éviter AttributeError
         value = getattr(self._device, self._attribute, None)
+        if value is not None and self._attribute == "position":
+            position_from_tydom = getattr(self._device, "position_from_tydom", None)
+            if callable(position_from_tydom):
+                with suppress(TypeError, ValueError):
+                    value = position_from_tydom(int(value))
         if (
             value is not None
             and self._attr_device_class == SensorDeviceClass.BATTERY

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -1755,6 +1755,9 @@ class HACover(CoverEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_cover"
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
+        if self._device.device_type == "awning":
+            self._attr_device_class = CoverDeviceClass.AWNING
+            self._attr_icon = "mdi:awning-outline"
         # NOTE: supported_features is intentionally NOT computed here.
         # It is exposed as a dynamic property below so that OPEN/CLOSE/STOP/
         # SET_POSITION/SET_TILT_POSITION reflect the *current* device state.
@@ -1848,7 +1851,8 @@ class HACover(CoverEntity, HAEntity):
             value = int(float(raw))
         except (TypeError, ValueError):
             return None
-        return max(0, min(100, value))
+        value = max(0, min(100, value))
+        return self._device.position_from_tydom(value)
 
     @property
     def is_closed(self) -> bool | None:
@@ -1869,6 +1873,8 @@ class HACover(CoverEntity, HAEntity):
     @property
     def icon(self) -> str:
         """Return the icon for the cover based on position."""
+        if self._device.device_type == "awning":
+            return "mdi:awning-outline"
         position = self.current_cover_position
         if position is None:
             return "mdi:window-shutter"
@@ -1893,11 +1899,11 @@ class HACover(CoverEntity, HAEntity):
     # the cover to the desired position, or open and close it all the way.
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._device.up()
+        await self._device.open()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._device.down()
+        await self._device.close()
 
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -5480,8 +5486,9 @@ class HAGroupEntity(HAEntity):
                 if group_usage in ("shutter", "awning"):
                     # Cover control
                     if action == "open":
-                        if hasattr(device, "up"):
-                            tasks.append(device.up())
+                        movement = "down" if group_usage == "awning" else "up"
+                        if hasattr(device, movement):
+                            tasks.append(getattr(device, movement)())
                         elif hasattr(device, "open"):
                             tasks.append(device.open())
                         elif (
@@ -5491,12 +5498,16 @@ class HAGroupEntity(HAEntity):
                         ):
                             tasks.append(
                                 device._tydom_client.put_devices_data(
-                                    device._id, device._endpoint, "levelCmd", "UP"
+                                    device._id,
+                                    device._endpoint,
+                                    "levelCmd",
+                                    "DOWN" if group_usage == "awning" else "UP",
                                 )
                             )
                     elif action == "close":
-                        if hasattr(device, "down"):
-                            tasks.append(device.down())
+                        movement = "up" if group_usage == "awning" else "down"
+                        if hasattr(device, movement):
+                            tasks.append(getattr(device, movement)())
                         elif hasattr(device, "close"):
                             tasks.append(device.close())
                         elif (
@@ -5506,7 +5517,10 @@ class HAGroupEntity(HAEntity):
                         ):
                             tasks.append(
                                 device._tydom_client.put_devices_data(
-                                    device._id, device._endpoint, "levelCmd", "DOWN"
+                                    device._id,
+                                    device._endpoint,
+                                    "levelCmd",
+                                    "UP" if group_usage == "awning" else "DOWN",
                                 )
                             )
                     elif action == "stop":
@@ -5537,7 +5551,11 @@ class HAGroupEntity(HAEntity):
                                     device._id,
                                     device._endpoint,
                                     "levelCmd",
-                                    str(position),
+                                    str(
+                                        100 - position
+                                        if group_usage == "awning"
+                                        else position
+                                    ),
                                 )
                             )
                 elif group_usage in ("light", "plug"):
@@ -5813,12 +5831,13 @@ class HACoverGroup(CoverEntity, HAGroupEntity):
             return []
 
         states: list[bool] = []
+        closed_position = 100 if self._device.group_usage == "awning" else 0
         for member in members:
             position = getattr(member, "position", None)
             if position is None:
                 continue
             try:
-                states.append(float(position) == 0)
+                states.append(float(position) == closed_position)
             except (TypeError, ValueError):
                 continue
         return states

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -157,6 +157,33 @@ class Tydom(TydomDevice):
 class TydomShutter(TydomDevice):
     """Represents a shutter."""
 
+    @property
+    def is_awning(self) -> bool:
+        """Return whether Delta Dore identifies this cover as an awning."""
+        return self._type == "awning"
+
+    def position_from_tydom(self, position: int) -> int:
+        """Translate a Delta Dore position into Home Assistant semantics."""
+        return 100 - position if self.is_awning else position
+
+    def position_to_tydom(self, position: int) -> int:
+        """Translate a Home Assistant position into Delta Dore semantics."""
+        return 100 - position if self.is_awning else position
+
+    async def open(self) -> None:
+        """Open the cover using semantics appropriate to its usage."""
+        if self.is_awning:
+            await self.down()
+        else:
+            await self.up()
+
+    async def close(self) -> None:
+        """Close the cover using semantics appropriate to its usage."""
+        if self.is_awning:
+            await self.up()
+        else:
+            await self.down()
+
     async def down(self) -> None:
         """Tell cover to go down."""
         await self._tydom_client.put_devices_data(
@@ -184,8 +211,11 @@ class TydomShutter(TydomDevice):
 
             raise HomeAssistantError(error_msg or f"Valeur invalide: {position}")
 
+        # Delta Dore reports an awning at 100 when it is retracted, whereas
+        # Home Assistant cover semantics use 0 for closed and 100 for open.
+        native_position = self.position_to_tydom(position)
         await self._tydom_client.put_devices_data(
-            self._id, self._endpoint, "position", str(position)
+            self._id, self._endpoint, "position", str(native_position)
         )
 
     # FIXME replace command

--- a/tests/test_cover_position_sensor.py
+++ b/tests/test_cover_position_sensor.py
@@ -1,0 +1,99 @@
+"""Regression tests for cover position diagnostic sensors."""
+
+from __future__ import annotations
+
+import ast
+from contextlib import suppress
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+
+
+def _load_generic_sensor_class():
+    """Load GenericSensor without importing Home Assistant."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "GenericSensor"
+    )
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            class_node,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class SensorEntity:
+        pass
+
+    class SensorDeviceClass:
+        BATTERY = "battery"
+
+    class EntityCategory:
+        DIAGNOSTIC = "diagnostic"
+
+    class SensorEntityDescription:
+        def __init__(self, **kwargs) -> None:
+            self.__dict__.update(kwargs)
+
+    namespace = {
+        "DOMAIN": "deltadore_tydom",
+        "EntityCategory": EntityCategory,
+        "SensorDeviceClass": SensorDeviceClass,
+        "SensorEntity": SensorEntity,
+        "SensorEntityDescription": SensorEntityDescription,
+        "ranged_value_to_percentage": lambda _range, value: value,
+        "suppress": suppress,
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["GenericSensor"]
+
+
+GenericSensor = _load_generic_sensor_class()
+
+
+class CoverPositionSensorTests(TestCase):
+    """Exercise translation of raw cover positions shown as sensors."""
+
+    @staticmethod
+    def _sensor(device):
+        return GenericSensor(device, None, None, "Position", "position", "%")
+
+    def test_awning_position_uses_home_assistant_semantics(self) -> None:
+        """Convert the raw retracted percentage exposed by an awning."""
+        device = SimpleNamespace(
+            device_id="awning_1",
+            position="64",
+            position_from_tydom=lambda position: 100 - position,
+        )
+
+        self.assertEqual(self._sensor(device).native_value, 36)
+
+    def test_shutter_position_remains_unchanged(self) -> None:
+        """Do not invert the position of an ordinary shutter."""
+        device = SimpleNamespace(
+            device_id="shutter_1",
+            position=64,
+            position_from_tydom=lambda position: position,
+        )
+
+        self.assertEqual(self._sensor(device).native_value, 64)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/test_level_command_covers.py
+++ b/tests/test_level_command_covers.py
@@ -53,6 +53,7 @@ spec.loader.exec_module(devices_module)
 
 TydomGarage = devices_module.TydomGarage
 TydomGate = devices_module.TydomGate
+TydomShutter = devices_module.TydomShutter
 
 for name, original in _original_modules.items():
     if original is _MISSING:
@@ -77,6 +78,23 @@ def _cover(device_class, commands, *, level_metadata=None, data=None):
         "10",
         metadata,
         data,
+    )
+    return device, client
+
+
+def _position_cover(usage: str):
+    """Create a position-command cover for one Delta Dore usage."""
+    client = MagicMock()
+    client.put_devices_data = AsyncMock()
+    device = TydomShutter(
+        client,
+        "10_20",
+        "20",
+        "Cover",
+        usage,
+        "10",
+        {"positionCmd": {"permission": "w"}},
+        {"position": 0},
     )
     return device, client
 
@@ -198,6 +216,41 @@ class LevelCommandCoverTests(IsolatedAsyncioTestCase):
         self.assertEqual(
             client.put_devices_data.await_args_list,
             [call("20", "10", "levelCmd", "TOGGLE")],
+        )
+
+    async def test_shutter_open_and_close_use_up_and_down(self) -> None:
+        """A shutter opens upwards and closes downwards."""
+        shutter, client = _position_cover("shutter")
+
+        self.assertEqual(shutter.position_from_tydom(100), 100)
+        await shutter.open()
+        await shutter.close()
+
+        self.assertEqual(
+            client.put_devices_data.await_args_list,
+            [
+                call("20", "10", "positionCmd", "UP"),
+                call("20", "10", "positionCmd", "DOWN"),
+            ],
+        )
+
+    async def test_awning_open_and_close_deploy_and_retract(self) -> None:
+        """An awning opens downwards and closes upwards."""
+        awning, client = _position_cover("awning")
+
+        self.assertEqual(awning.position_from_tydom(100), 0)
+        self.assertEqual(awning.position_from_tydom(0), 100)
+        await awning.open()
+        await awning.close()
+        await awning.set_position(25)
+
+        self.assertEqual(
+            client.put_devices_data.await_args_list,
+            [
+                call("20", "10", "positionCmd", "DOWN"),
+                call("20", "10", "positionCmd", "UP"),
+                call("20", "10", "position", "75"),
+            ],
         )
 
 

--- a/tests/test_native_group_entities.py
+++ b/tests/test_native_group_entities.py
@@ -258,6 +258,19 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
         self.assertFalse(entity.is_closed)
         self.assertIsNone(entity._assumed_is_closed)
 
+    async def test_awning_group_opens_downwards_and_closes_upwards(self) -> None:
+        """Translate HA awning semantics into Delta Dore movement commands."""
+        member = MemberDevice("1", position=100)
+        entity = self._entity(HACoverGroup, "awning", [member])
+
+        self.assertTrue(entity.is_closed)
+        await entity.async_open_cover()
+        await entity.async_close_cover()
+
+        member.down.assert_awaited_once_with()
+        member.up.assert_awaited_once_with()
+        entity._clear_assumed_state()
+
     async def test_switch_group_reports_any_member_on(self) -> None:
         """Represent plug groups as switches with aggregate state."""
         first = MemberDevice("1", on=False)


### PR DESCRIPTION
## Summary

Delta Dore identifies awnings separately from shutters through the explicit
`last_usage: awning` value.

The integration currently applies shutter semantics to both usages:

- **Open** sends `UP`;
- **Close** sends `DOWN`;
- the reported position is exposed without conversion.

This is correct for roller shutters, but reversed for an awning. Opening an
awning means deploying it with `DOWN`, while closing it means retracting it
with `UP`.

## Changes

- Use the Delta Dore `awning` usage rather than hard-coding specific receiver
  models.
- Translate Home Assistant **Open** into Delta Dore `DOWN` for awnings.
- Translate Home Assistant **Close** into Delta Dore `UP` for awnings.
- Preserve the existing `UP`/`DOWN` behaviour for shutters.
- Convert awning positions in both directions, including the separately
  exposed `Position` sensor:
  - Delta Dore `100` retracted becomes Home Assistant `0` closed;
  - Delta Dore `0` deployed becomes Home Assistant `100` open.
- Apply the same command and state semantics to native `awning` groups.
- Expose individual awnings with `CoverDeviceClass.AWNING` and the awning icon.
- Leave the stop command unchanged.

## Evidence

A debug capture supplied by Pat confirms that the TYXIA 5731 endpoint is
explicitly declared by the gateway with:

```text
last_usage: awning
```

The capture also shows that Pat's Delta Dore “FERMETURE BANNE” automation
retracts the awning by sending:

```text
position: 100
```

This confirms that the awning position must be converted before being exposed
using Home Assistant cover semantics.

Pat also confirmed the existing user-visible problem: the current **Open**
action retracts the awning and **Close** deploys it. He currently works around
this by reversing the commands in a Lovelace template.

## Testing

Automated tests cover:

- unchanged shutter commands: Open → `UP`, Close → `DOWN`;
- awning commands: Open → `DOWN`, Close → `UP`;
- conversion of Home Assistant position `25` into Delta Dore position `75`;
- conversion of Delta Dore awning positions into Home Assistant semantics;
- conversion of the separately exposed awning `Position` sensor;
- unchanged `Position` sensor values for ordinary shutters;
- command and closed-state handling for native `awning` groups.

Validation completed:

- Ruff checks pass;
- Ruff formatting passes;
- all 129 automated tests pass.

Pat validated the individual TYXIA 5731 on hardware through the combined test
branch:

- **Open** deploys the awning;
- **Close** retracts it;
- **Stop** interrupts movement;
- the cover `current_position` correctly converts fully retracted, fully
  deployed and intermediate positions into Home Assistant semantics.

This testing also identified that the separately exposed `Position` sensor
still displayed the raw Delta Dore value. The sensor now uses the same
usage-aware conversion as the cover, with regression coverage confirming that
ordinary shutter positions remain unchanged. A final hardware check of this
sensor and the **All awnings** group remains requested.

The fix is also included in the combined test branch:

https://github.com/Sleinous/hass-deltadore-tydom-component/tree/test/current-development

Fixes #380
