### PR TITLE
Normalisation des binary_sensor et des entités binaires mal enregistrées

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -2,6 +2,9 @@
 
 target-version = "py312"
 
+[format]
+indent-style = "space"
+
 [lint]
 select = [
     "B007", # Loop control variable {name} not used within loop body

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -121,6 +121,67 @@ from .const import (
 from .tydom.MessageHandler import device_name, groups_data
 
 
+_BINARY_TRUE_VALUES = frozenset({"1", "on", "true", "yes"})
+_BINARY_FALSE_VALUES = frozenset({"0", "off", "false", "no"})
+
+
+def normalize_binary_state(value: Any, *, allow_numeric: bool = False) -> bool | None:
+    """Convert values used by TYDOM for binary states to a HA boolean.
+
+    A BinarySensorEntity must only expose a boolean (or ``None`` for an unknown
+    state).  In particular, returning an unnormalised ``"ON"``/``"OFF"`` value
+    makes Home Assistant publish a non-standard state.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _BINARY_TRUE_VALUES:
+            return True
+        if normalized in _BINARY_FALSE_VALUES:
+            return False
+    if allow_numeric and isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    return None
+
+
+def is_binary_attribute(
+    device: TydomDevice,
+    attribute: str,
+    value: Any,
+    device_class: Any = None,
+) -> bool:
+    """Return whether an attribute is known to have only two possible states.
+
+    A current value of ``"off"`` is not enough: a TYDOM enum may also expose
+    ``1``, ``2`` and ``3``. Textual values are therefore considered binary only
+    when the device metadata advertises an enum entirely made of binary values,
+    or when the integration explicitly assigns a binary device class.
+    """
+    if isinstance(value, bool):
+        return True
+
+    if isinstance(device_class, BinarySensorDeviceClass):
+        return normalize_binary_state(value, allow_numeric=True) is not None
+
+    metadata = getattr(device, "_metadata", None)
+    attribute_metadata = metadata.get(attribute) if isinstance(metadata, dict) else None
+    enum_values = (
+        attribute_metadata.get("enum_values")
+        if isinstance(attribute_metadata, dict)
+        else None
+    )
+    return (
+        isinstance(enum_values, (list, tuple, set))
+        and bool(enum_values)
+        and all(
+            normalize_binary_state(enum_value, allow_numeric=True) is not None
+            for enum_value in enum_values
+        )
+        and normalize_binary_state(value, allow_numeric=True) is not None
+    )
+
+
 class HAEntity:
     """Generic abstract HA entity."""
 
@@ -266,7 +327,10 @@ class HAEntity:
                 elif alt_name in self.units:
                     unit = self.units[alt_name]
 
-                if isinstance(value, bool):
+                is_binary_sensor = is_binary_attribute(
+                    self._device, attribute, value, sensor_class
+                )
+                if is_binary_sensor:
                     sensors.append(
                         GenericBinarySensor(
                             self._device, sensor_class, attribute, attribute
@@ -288,7 +352,7 @@ class HAEntity:
                     "Nouveau capteur créé: %s.%s (type: %s, valeur: %s)",
                     self._device.device_id,
                     attribute,
-                    "binary" if isinstance(value, bool) else "sensor",
+                    "binary" if is_binary_sensor else "sensor",
                     value,
                 )
 
@@ -825,8 +889,9 @@ class GenericBinarySensor(BinarySensorBase):
     @property
     def is_on(self):
         """Return the state of the sensor."""
-        # Utiliser getattr avec une valeur par défaut pour éviter AttributeError
-        return getattr(self._device, self._attribute, False)
+        return normalize_binary_state(
+            getattr(self._device, self._attribute, None), allow_numeric=True
+        )
 
 
 class ClockSensor(SensorEntity):
@@ -1181,11 +1246,12 @@ class ProtocolBinarySensor(BinarySensorBase):
     def is_on(self) -> bool:
         """Return True if protocol attribute is active."""
         value = self._protocol_data.get(self._attribute, False)
-        if isinstance(value, bool):
-            return value
+        normalized = normalize_binary_state(value)
+        if normalized is not None:
+            return normalized
         if isinstance(value, str):
             # For status, check if it's "running" or "idle"
-            return value.lower() in ("running", "idle", "on", "true", "yes", "1")
+            return value.lower() in ("running", "idle")
         return bool(value)
 
     @property
@@ -3764,6 +3830,42 @@ class HaSun(SensorEntity, HAEntity):
                 "model": "Tysense Sun",
             }
         )
+
+
+class HAGenericBinarySensor(BinarySensorEntity, HAEntity):
+    """Primary binary sensor for an otherwise unknown TYDOM device."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(self, device: TydomDevice, hass: Any, attribute: str) -> None:
+        """Initialize a generic device whose primary state is binary."""
+        self.hass = hass
+        self._device = device
+        self._attribute = attribute
+        self._attr_unique_id = f"{self._device.device_id}_sensor"
+        self._attr_name = None
+        self._registered_sensors = [attribute]
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the primary TYDOM state as a HA boolean."""
+        return normalize_binary_state(
+            getattr(self._device, self._attribute, None), allow_numeric=True
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return information for the unknown physical device."""
+        device_info = self._get_device_info()
+        info: DeviceInfo = {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": device_info["manufacturer"],
+        }
+        if "model" in device_info:
+            info["model"] = device_info["model"]
+        return self._enrich_device_info(info)
 
 
 class HASensor(SensorEntity, HAEntity):

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2166,8 +2166,10 @@ class HASmoke(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._state = False
         self._registered_sensors = []
-        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        # This is the detector's primary entity. Keep it visible as a smoke
+        # sensor; battDefect and techSmokeDefect are exposed separately as
+        # diagnostic problem entities by generic sensor discovery.
+        self._attr_device_class = BinarySensorDeviceClass.SMOKE
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2166,10 +2166,8 @@ class HASmoke(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._state = False
         self._registered_sensors = []
-        # This is the detector's primary entity. Keep it visible as a smoke
-        # sensor; battDefect and techSmokeDefect are exposed separately as
-        # diagnostic problem entities by generic sensor discovery.
-        self._attr_device_class = BinarySensorDeviceClass.SMOKE
+        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -123,6 +123,7 @@ from .tydom.MessageHandler import device_name, groups_data
 
 _BINARY_TRUE_VALUES = frozenset({"1", "on", "true", "yes"})
 _BINARY_FALSE_VALUES = frozenset({"0", "off", "false", "no"})
+_PROBLEM_ATTRIBUTE_MARKERS = ("defect", "empty", "intrusion")
 
 
 def normalize_binary_state(value: Any, *, allow_numeric: bool = False) -> bool | None:
@@ -143,6 +144,12 @@ def normalize_binary_state(value: Any, *, allow_numeric: bool = False) -> bool |
     if allow_numeric and isinstance(value, int) and value in (0, 1):
         return bool(value)
     return None
+
+
+def is_problem_attribute(attribute: str) -> bool:
+    """Return whether a binary attribute denotes a reported problem."""
+    normalized = attribute.casefold()
+    return any(marker in normalized for marker in _PROBLEM_ATTRIBUTE_MARKERS)
 
 
 def is_binary_attribute(
@@ -331,9 +338,17 @@ class HAEntity:
                     self._device, attribute, value, sensor_class
                 )
                 if is_binary_sensor:
+                    binary_sensor_class = (
+                        BinarySensorDeviceClass.PROBLEM
+                        if is_problem_attribute(attribute)
+                        else sensor_class
+                    )
                     sensors.append(
                         GenericBinarySensor(
-                            self._device, sensor_class, attribute, attribute
+                            self._device,
+                            binary_sensor_class,
+                            attribute,
+                            attribute,
                         )
                     )
                 else:
@@ -1297,10 +1312,8 @@ class HATydom(UpdateEntity, HAEntity):
 
     # Binary sensor classes for system status
     binary_sensor_classes = {
-        "bddEmpty": BinarySensorDeviceClass.PROBLEM,
         "apiMode": None,  # No specific device class
         "pltRegistered": None,
-        "passwordEmpty": BinarySensorDeviceClass.PROBLEM,
     }
 
     filtered_attrs = [
@@ -1575,10 +1588,8 @@ class HATydom(UpdateEntity, HAEntity):
         # These are created automatically by get_sensors() from parent class
         # but we ensure they use the right device classes
         status_attrs = {
-            "bddEmpty": BinarySensorDeviceClass.PROBLEM,
             "apiMode": None,
             "pltRegistered": None,
-            "passwordEmpty": BinarySensorDeviceClass.PROBLEM,
         }
 
         for attr, device_class in status_attrs.items():
@@ -1803,15 +1814,6 @@ class HACover(CoverEntity, HAEntity):
     _attr_device_class = CoverDeviceClass.SHUTTER
     _attr_icon = "mdi:window-shutter"
     _attr_has_entity_name = True
-
-    sensor_classes = {
-        "batt_defect": BinarySensorDeviceClass.PROBLEM,
-        "thermic_defect": BinarySensorDeviceClass.PROBLEM,
-        "up_defect": BinarySensorDeviceClass.PROBLEM,
-        "down_defect": BinarySensorDeviceClass.PROBLEM,
-        "obstacle_defect": BinarySensorDeviceClass.PROBLEM,
-        "intrusion": BinarySensorDeviceClass.PROBLEM,
-    }
 
     def __init__(self, device: TydomShutter, hass) -> None:
         """Initialize the sensor."""
@@ -2155,8 +2157,6 @@ class HASmoke(BinarySensorEntity, HAEntity):
     _attr_icon = "mdi:smoke-detector"
     _attr_has_entity_name = True
 
-    sensor_classes = {"batt_defect": BinarySensorDeviceClass.PROBLEM}
-
     def __init__(self, device: TydomSmoke, hass) -> None:
         """Initialize TydomSmoke."""
         self.hass = hass
@@ -2166,7 +2166,8 @@ class HASmoke(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._state = False
         self._registered_sensors = []
-        self._attr_device_class = BinarySensorDeviceClass.SMOKE
+        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -2219,11 +2220,6 @@ class HaClimate(ClimateEntity, HAEntity):
     sensor_classes = {
         "temperature": SensorDeviceClass.TEMPERATURE,
         "outTemperature": SensorDeviceClass.TEMPERATURE,
-        "TempSensorDefect": BinarySensorDeviceClass.PROBLEM,
-        "TempSensorOpenCirc": BinarySensorDeviceClass.PROBLEM,
-        "TempSensorShortCut": BinarySensorDeviceClass.PROBLEM,
-        "ProductionDefect": BinarySensorDeviceClass.PROBLEM,
-        "BatteryCmdDefect": BinarySensorDeviceClass.PROBLEM,
         "battLevel": SensorDeviceClass.BATTERY,
     }
 
@@ -2870,23 +2866,12 @@ class HaWindowOpening(HaOpeningBinarySensor):
     _attr_icon = "mdi:window-open"
     _opening_device_class = BinarySensorDeviceClass.WINDOW
 
-    sensor_classes = {
-        "battDefect": BinarySensorDeviceClass.PROBLEM,
-        "intrusionDetect": BinarySensorDeviceClass.PROBLEM,
-    }
-
 
 class HaDoorOpening(HaOpeningBinarySensor):
     """Binary sensor for a passive (non-motorized) Tydom door."""
 
     _attr_icon = "mdi:door"
     _opening_device_class = BinarySensorDeviceClass.DOOR
-
-    sensor_classes = {
-        "battDefect": BinarySensorDeviceClass.PROBLEM,
-        "calibrationDefect": BinarySensorDeviceClass.PROBLEM,
-        "intrusionDetect": BinarySensorDeviceClass.PROBLEM,
-    }
 
 
 class HaWindow(CoverEntity, HAEntity):
@@ -2897,11 +2882,6 @@ class HaWindow(CoverEntity, HAEntity):
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_icon = "mdi:window-open"
     _attr_has_entity_name = True
-
-    sensor_classes = {
-        "battDefect": BinarySensorDeviceClass.PROBLEM,
-        "intrusionDetect": BinarySensorDeviceClass.PROBLEM,
-    }
 
     def __init__(self, device: TydomWindow, hass) -> None:
         """Initialize the sensor."""
@@ -2971,11 +2951,6 @@ class HaDoor(CoverEntity, HAEntity):
     _attr_device_class = CoverDeviceClass.DOOR
     _attr_icon = "mdi:door"
     _attr_has_entity_name = True
-    sensor_classes = {
-        "battDefect": BinarySensorDeviceClass.PROBLEM,
-        "calibrationDefect": BinarySensorDeviceClass.PROBLEM,
-        "intrusionDetect": BinarySensorDeviceClass.PROBLEM,
-    }
 
     def __init__(self, device: TydomDoor, hass) -> None:
         """Initialize the sensor."""
@@ -3153,9 +3128,6 @@ class HaGarage(CoverEntity, HAEntity):
     _attr_device_class = CoverDeviceClass.GARAGE
     _attr_icon = "mdi:garage"
     _attr_has_entity_name = True
-    sensor_classes = {
-        "thermic_defect": BinarySensorDeviceClass.PROBLEM,
-    }
 
     def __init__(self, device: TydomGarage, hass) -> None:
         """Initialize the sensor."""
@@ -3242,9 +3214,6 @@ class HaLight(LightEntity, HAEntity):
     _attr_should_poll = False
     _attr_icon = "mdi:lightbulb"
     _attr_has_entity_name = True
-    sensor_classes = {
-        "thermic_defect": BinarySensorDeviceClass.PROBLEM,
-    }
     _attr_color_mode: ColorMode | str | None = None
     _attr_supported_color_modes: set[ColorMode] | set[str] | None = None
 
@@ -3356,17 +3325,6 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
     _attr_icon = "mdi:shield-home"
     _attr_has_entity_name = True
     sensor_classes = {
-        "networkDefect": BinarySensorDeviceClass.PROBLEM,
-        "remoteSurveyDefect": BinarySensorDeviceClass.PROBLEM,
-        "simDefect": BinarySensorDeviceClass.PROBLEM,
-        "systAlarmDefect": BinarySensorDeviceClass.PROBLEM,
-        "systBatteryDefect": BinarySensorDeviceClass.PROBLEM,
-        "systSectorDefect": BinarySensorDeviceClass.PROBLEM,
-        "systSupervisionDefect": BinarySensorDeviceClass.PROBLEM,
-        "systTechnicalDefect": BinarySensorDeviceClass.PROBLEM,
-        "unitBatteryDefect": BinarySensorDeviceClass.PROBLEM,
-        "unitInternalDefect": BinarySensorDeviceClass.PROBLEM,
-        "videoLinkDefect": BinarySensorDeviceClass.PROBLEM,
         "outTemperature": SensorDeviceClass.TEMPERATURE,
     }
 
@@ -3677,8 +3635,6 @@ class HaMoisture(BinarySensorEntity, HAEntity):
     _attr_icon = "mdi:water"
     _attr_has_entity_name = True
 
-    sensor_classes = {"batt_defect": BinarySensorDeviceClass.PROBLEM}
-
     def __init__(self, device: TydomWater, hass) -> None:
         """Initialize TydomSmoke."""
         self.hass = hass
@@ -3688,7 +3644,8 @@ class HaMoisture(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._state = False
         self._registered_sensors = []
-        self._attr_device_class = BinarySensorDeviceClass.MOISTURE
+        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -3787,8 +3744,6 @@ class HaSun(SensorEntity, HAEntity):
     _attr_device_class = SensorDeviceClass.IRRADIANCE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "W/m²"
-
-    sensor_classes = {"battDefect": BinarySensorDeviceClass.PROBLEM}
 
     def __init__(self, device: TydomSun, hass) -> None:
         """Initialise a Tysense Sun sensor."""
@@ -6508,7 +6463,7 @@ class HARemoteBattery(BinarySensorEntity, HAEntity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
-    _attr_device_class = BinarySensorDeviceClass.BATTERY
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = "Battery fault"
 
@@ -6692,7 +6647,7 @@ class HAInterrupterBattery(BinarySensorEntity, HAEntity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
-    _attr_device_class = BinarySensorDeviceClass.BATTERY
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = "Battery fault"
 

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Callable
 from aiohttp import ClientWebSocketResponse, ClientSession
 
+from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from .tydom.tydom_client import TydomClient
@@ -55,6 +56,7 @@ from .ha_entities import (
     HaMoisture,
     HaThermo,
     HaSun,
+    HAGenericBinarySensor,
     HASensor,
     HAScene,
     HASwitch,
@@ -69,6 +71,7 @@ from .ha_entities import (
     HAMoment,
     HARemoteBattery,
     HARemoteEvent,
+    is_binary_attribute,
 )
 
 from .const import LOGGER, get_polling_interval_for_validity, STRUCTURED_LOGGER
@@ -258,6 +261,7 @@ class Hub:
             and self.add_number_callback is not None
             and self.add_select_callback is not None
             and self.add_event_callback is not None
+            and self.add_binary_sensor_callback is not None
         )
         # Créer le bouton de rechargement une fois que les callbacks sont prêts
         if (
@@ -270,6 +274,20 @@ class Hub:
             self._reload_button_created = True
             LOGGER.debug("Bouton de rechargement créé")
         return is_ready
+
+    def _add_discovered_entities(self, entities: list) -> None:
+        """Add discovered entities to the platform matching their entity type."""
+        binary_sensors = [
+            entity for entity in entities if isinstance(entity, BinarySensorEntity)
+        ]
+        sensors = [
+            entity for entity in entities if not isinstance(entity, BinarySensorEntity)
+        ]
+
+        if sensors and self.add_sensor_callback is not None:
+            self.add_sensor_callback(sensors)
+        if binary_sensors and self.add_binary_sensor_callback is not None:
+            self.add_binary_sensor_callback(binary_sensors)
 
     async def setup(self, connection: ClientWebSocketResponse) -> None:
         """Listen to tydom events."""
@@ -394,8 +412,7 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_update_callback is not None:
             self.add_update_callback([ha_device])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
         # Le bouton de rechargement est créé dans ready() pour être toujours présent
 
     async def _create_shutter_device(self, device: TydomShutter) -> None:
@@ -405,8 +422,7 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_cover_callback is not None:
             self.add_cover_callback([ha_device])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_energy_device(self, device: TydomEnergy) -> None:
         """Create energy consumption device."""
@@ -416,8 +432,7 @@ class Hub:
         # HAEnergy itself carries no device_class/unit/value: it only groups
         # the per-attribute sensors below and must not be added as an entity,
         # or it shows up as a useless "unknown" sensor (e.g. sensor.tywatt_tywatt).
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
         # The device has no energy* attribute yet at first discovery (they only
         # appear once the first cdata poll response is parsed), so this rarely
         # creates the button here -- update_ha_device() does it once data arrives.
@@ -453,9 +468,7 @@ class Hub:
         LOGGER.debug("Create smoke %s", device.device_id)
         ha_device = HASmoke(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback([ha_device])
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities([ha_device, *ha_device.get_sensors()])
 
     async def _create_boiler_device(self, device: TydomBoiler) -> None:
         """Create boiler/climate device."""
@@ -464,8 +477,7 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_climate_callback is not None:
             self.add_climate_callback([ha_device])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_window_device(self, device: TydomWindow) -> None:
         """Create window device (cover if motorized, else binary_sensor)."""
@@ -492,8 +504,7 @@ class Hub:
                 self.add_binary_sensor_callback([ha_device])
 
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_door_device(self, device: TydomDoor) -> None:
         """Create door device (cover if motorized, else binary_sensor)."""
@@ -528,8 +539,7 @@ class Hub:
                 self.add_binary_sensor_callback([ha_device])
 
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_gate_device(self, device: TydomGate) -> None:
         """Create gate device."""
@@ -550,8 +560,7 @@ class Hub:
             if self.add_cover_callback is not None:
                 self.add_cover_callback([ha_device])
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_garage_device(self, device: TydomGarage) -> None:
         """Create garage device."""
@@ -572,8 +581,7 @@ class Hub:
             if self.add_cover_callback is not None:
                 self.add_cover_callback([ha_device])
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_light_device(self, device: TydomLight) -> None:
         """Create light device."""
@@ -582,8 +590,7 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_light_callback is not None:
             self.add_light_callback([ha_device])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_interrupter_device(self, device: TydomInterrupter) -> None:
         """Create a wall-switch event entity and one battery diagnostic."""
@@ -609,8 +616,7 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_switch_callback is not None:
             self.add_switch_callback([ha_device])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_alarm_device(self, device: TydomAlarm) -> None:
         """Create alarm device."""
@@ -621,13 +627,9 @@ class Hub:
             self.add_alarm_callback([ha_device])
         if self.add_button_callback is not None:
             self.add_button_callback([HAAlarmAcknowledgeButton(device, self._hass)])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(
-                [
-                    HAAlarmPendingEventsSensor(device, self._hass),
-                    *ha_device.get_sensors(),
-                ]
-            )
+        self._add_discovered_entities(
+            [HAAlarmPendingEventsSensor(device, self._hass), *ha_device.get_sensors()]
+        )
 
     async def _create_weather_device(self, device: TydomWeather) -> None:
         """Create weather device."""
@@ -636,35 +638,28 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_weather_callback is not None:
             self.add_weather_callback([ha_device])
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_water_device(self, device: TydomWater) -> None:
         """Create water/moisture device."""
         LOGGER.debug("Create moisture %s", device.device_id)
         ha_device = HaMoisture(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback([ha_device])
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities([ha_device, *ha_device.get_sensors()])
 
     async def _create_thermo_device(self, device: TydomThermo) -> None:
         """Create thermostat device."""
         LOGGER.debug("Create thermo %s", device.device_id)
         ha_device = HaThermo(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback([ha_device])
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities([ha_device, *ha_device.get_sensors()])
 
     async def _create_sun_device(self, device: TydomSun) -> None:
         """Create a Tysense Sun irradiance sensor."""
         LOGGER.debug("Create Tysense Sun %s", device.device_id)
         ha_device = HaSun(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback([ha_device])
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities([ha_device, *ha_device.get_sensors()])
 
     async def _create_scene_device(self, device: TydomScene) -> None:
         """Create scene device."""
@@ -731,11 +726,25 @@ class Hub:
     async def _create_generic_device(self, device: TydomDevice) -> None:
         """Create generic sensor device."""
         LOGGER.debug("Create generic sensor %s", device.device_id)
-        ha_device = HASensor(device, self._hass)
+        primary_binary_attribute = next(
+            (
+                attribute
+                for attribute in ("on", "state")
+                if hasattr(device, attribute)
+                and is_binary_attribute(
+                    device, attribute, getattr(device, attribute)
+                )
+            ),
+            None,
+        )
+        if primary_binary_attribute is not None:
+            ha_device = HAGenericBinarySensor(
+                device, self._hass, primary_binary_attribute
+            )
+        else:
+            ha_device = HASensor(device, self._hass)
         self.ha_devices[device.device_id] = ha_device
-        if self.add_sensor_callback is not None:
-            self.add_sensor_callback([ha_device])
-            self.add_sensor_callback(ha_device.get_sensors())
+        self._add_discovered_entities([ha_device, *ha_device.get_sensors()])
 
         # Try to detect if device should also be a switch
         # Check for on/off capabilities that aren't already handled
@@ -773,7 +782,7 @@ class Hub:
                 await ha_device.async_device_update(device)
 
             new_sensors = ha_device.get_sensors()
-            if len(new_sensors) > 0 and self.add_sensor_callback is not None:
+            if new_sensors:
                 # add new sensors
                 LOGGER.debug(
                     "Ajout de %d nouveau(x) capteur(s) pour le device %s: %s",
@@ -781,7 +790,7 @@ class Hub:
                     device.device_id,
                     [s._attr_name for s in new_sensors],
                 )
-                self.add_sensor_callback(new_sensors)
+                self._add_discovered_entities(new_sensors)
             if isinstance(ha_device, HAEnergy):
                 self._maybe_create_refresh_energy_button(stored_device, ha_device)
             # ha_device.publish_updates()

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -731,9 +731,7 @@ class Hub:
                 attribute
                 for attribute in ("on", "state")
                 if hasattr(device, attribute)
-                and is_binary_attribute(
-                    device, attribute, getattr(device, attribute)
-                )
+                and is_binary_attribute(device, attribute, getattr(device, attribute))
             ),
             None,
         )

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -43,12 +43,20 @@ def _load_ha_entity_class():
         def __init__(self, *_args) -> None:
             pass
 
+    class BinarySensorDeviceClass:
+        PROBLEM = "problem"
+
     namespace = {
         "Any": object,
+        "BinarySensorDeviceClass": BinarySensorDeviceClass,
         "DOMAIN": "deltadore_tydom",
         "LOGGER": MagicMock(),
         "GenericBinarySensor": GenericBinarySensor,
         "GenericSensor": GenericSensor,
+        "is_binary_attribute": lambda _device, _attribute, value, _class: isinstance(
+            value, bool
+        ),
+        "is_problem_attribute": lambda attribute: "defect" in attribute.casefold(),
     }
     exec(compile(isolated_module, source_path, "exec"), namespace)
     return namespace["HAEntity"]

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -117,38 +117,6 @@ class EntitySensorRegistrationTests(TestCase):
         self.assertEqual(entity.get_sensors(), [])
         self.assertNotIn("_registered_sensors", entity.__dict__)
 
-    def test_smoke_detector_primary_entity_remains_a_smoke_sensor(self) -> None:
-        """Binary normalisation must not turn a DFR into a hidden diagnostic."""
-        source_path = (
-            Path(__file__).parents[1]
-            / "custom_components"
-            / "deltadore_tydom"
-            / "ha_entities.py"
-        )
-        module = ast.parse(source_path.read_text(encoding="utf-8"))
-        smoke_class = next(
-            node
-            for node in module.body
-            if isinstance(node, ast.ClassDef) and node.name == "HASmoke"
-        )
-        init = next(
-            node
-            for node in smoke_class.body
-            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
-        )
-        assignments = {
-            target.attr: ast.unparse(statement.value)
-            for statement in init.body
-            if isinstance(statement, ast.Assign)
-            for target in statement.targets
-            if isinstance(target, ast.Attribute)
-        }
-
-        self.assertEqual(
-            assignments["_attr_device_class"], "BinarySensorDeviceClass.SMOKE"
-        )
-        self.assertNotIn("_attr_entity_category", assignments)
-
 
 if __name__ == "__main__":
     import unittest

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -117,6 +117,38 @@ class EntitySensorRegistrationTests(TestCase):
         self.assertEqual(entity.get_sensors(), [])
         self.assertNotIn("_registered_sensors", entity.__dict__)
 
+    def test_smoke_detector_primary_entity_remains_a_smoke_sensor(self) -> None:
+        """Binary normalisation must not turn a DFR into a hidden diagnostic."""
+        source_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "deltadore_tydom"
+            / "ha_entities.py"
+        )
+        module = ast.parse(source_path.read_text(encoding="utf-8"))
+        smoke_class = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.ClassDef) and node.name == "HASmoke"
+        )
+        init = next(
+            node
+            for node in smoke_class.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+        assignments = {
+            target.attr: ast.unparse(statement.value)
+            for statement in init.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Attribute)
+        }
+
+        self.assertEqual(
+            assignments["_attr_device_class"], "BinarySensorDeviceClass.SMOKE"
+        )
+        self.assertNotIn("_attr_entity_category", assignments)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
- Certaines entités binaires (par exemple le détecteur de fumée) ne sont pas déclarées comme binary sensor car Tydom ne renvoie pas toujours clairement des booléens.
- Certains binary_sensor ont des valeurs booléennes mais pas forcément au bon format pour home assistant.

Je propose donc une meilleure vérification des données booléennes. L'inconvénient est que certaines entités vont être renommées et qu'il faudra éventuellement adapter des scripts — notamment le détecteur de fumée et certains états de l'alarme — puisqu'ils seront maintenant binary_sensor au lieu de sensor. Mais je suis convaincu que c'est un mal nécessaire pour une intégration propre. 

Remarques
- alarmMode et zoneXState ne sont pas booléens car ils peuvent avoir plus de 2 valeurs distinctes, donc à priori c'est correct.
- j'ai a nouveau le fichier .ruff.toml qui remonte mais c'est, je pense, utile de le laisser : en effet, comme toute personne censée, chez moi j'indente avec des tabulations. Il me faut donc explicitement dire à ruff pour ce répertoire de pervertir l'utilisation naturelle des espaces pour les utiliser comme indentation. Et blague à part, il me semble utile d'afficher en clair la norme pour ce projet plutôt que de laisser une valeur par défaut qui peut ne pas être la même chez tout le monde.