### PR TITLE
Use the configured refresh interval for TYWATT cdata

### DIFF
--- a/custom_components/deltadore_tydom/__init__.py
+++ b/custom_components/deltadore_tydom/__init__.py
@@ -367,9 +367,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             target=tydom_hub.refresh_data(), hass=hass, name="Tydom refresh data"
         )
         entry.async_create_background_task(
-            target=tydom_hub.refresh_data_5m(),
+            target=tydom_hub.refresh_cdata(),
             hass=hass,
-            name="Tydom refresh cdata 5m",
+            name="Tydom refresh cdata",
         )
 
     except asyncio.CancelledError:

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -929,7 +929,7 @@ class Hub:
         """Poll one Tywatt cdata endpoint immediately, on demand."""
         await self._tydom_client.poll_devices_data_5m(device_id, endpoint_id)
 
-    async def refresh_data_5m(self) -> None:
+    async def refresh_cdata(self) -> None:
         """Periodically poll the cdata endpoints registered for devices like Tywatt.
 
         Endpoints such as energyIndex, energyInstant, energyHisto and
@@ -940,13 +940,17 @@ class Hub:
         any other device exposes validity metadata (the common case), that
         branch never runs and these cdata endpoints (e.g. the Tywatt instant
         consumption sensor) would never be queried.
+
+        Poll once at startup, then follow the refresh interval selected in the
+        integration options. The per-device Refresh button remains available
+        for an immediate reading between scheduled polls.
         """
         while not self._shutting_down:
             try:
                 await self._tydom_client.poll_devices_data_5m()
             except Exception:
                 LOGGER.exception("Error polling registered cdata endpoints")
-            await self._interruptible_sleep(300)
+            await self._interruptible_sleep(self._refresh_interval)
 
     async def reload_devices(self) -> None:
         """Recharger tous les appareils et entités comme au démarrage initial.

--- a/tests/test_tywatt_refresh_interval.py
+++ b/tests/test_tywatt_refresh_interval.py
@@ -1,0 +1,77 @@
+"""Tests for the configured TYWATT cdata refresh interval."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _load_refresh_cdata():
+    """Load Hub.refresh_cdata without Home Assistant dependencies."""
+    source_path = (
+        Path(__file__).parents[1] / "custom_components" / "deltadore_tydom" / "hub.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    hub_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "Hub"
+    )
+    refresh_method = next(
+        node
+        for node in hub_class.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "refresh_cdata"
+    )
+    isolated_class = ast.ClassDef(
+        name="RefreshCdataMixin",
+        bases=[],
+        keywords=[],
+        body=[refresh_method],
+        decorator_list=[],
+    )
+    isolated_module = ast.Module(body=[isolated_class], type_ignores=[])
+    ast.fix_missing_locations(isolated_module)
+    namespace = {"LOGGER": MagicMock()}
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["RefreshCdataMixin"]
+
+
+RefreshCdataMixin = _load_refresh_cdata()
+
+
+class TywattRefreshIntervalTests(IsolatedAsyncioTestCase):
+    """Ensure TYWATT cdata follows the integration refresh option."""
+
+    async def test_configured_interval_is_used_after_polling(self) -> None:
+        """Poll immediately, then sleep for the configured number of seconds."""
+        hub = RefreshCdataMixin()
+        hub._shutting_down = False
+        hub._refresh_interval = 1800
+        hub._tydom_client = MagicMock()
+        hub._tydom_client.poll_devices_data_5m = AsyncMock()
+
+        async def sleep_once(interval: int) -> None:
+            self.assertEqual(interval, 1800)
+            hub._shutting_down = True
+
+        hub._interruptible_sleep = sleep_once
+
+        await hub.refresh_cdata()
+
+        hub._tydom_client.poll_devices_data_5m.assert_awaited_once_with()
+
+    def test_background_task_uses_frequency_neutral_name(self) -> None:
+        """The integration setup must not describe cdata as fixed at five minutes."""
+        init_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "deltadore_tydom"
+            / "__init__.py"
+        )
+        source = init_path.read_text(encoding="utf-8")
+
+        self.assertIn("target=tydom_hub.refresh_cdata()", source)
+        self.assertIn('name="Tydom refresh cdata"', source)
+        self.assertNotIn("refresh_data_5m", source)


### PR DESCRIPTION
## Summary

Follow-up to #374.

The independent TYWATT `cdata` task introduced by #374 currently uses a hard-coded five-minute interval. That frequency is an integration choice rather than a value advertised by the TYDOM gateway.

This change keeps the independent task, which prevents TYWATT polling from being blocked by adaptive device polling, but schedules subsequent requests using the refresh interval selected in the integration options. The default therefore becomes 30 minutes, while users who need more frequent automatic readings can select a shorter interval.

The per-device **Refresh** button remains available for an immediate reading.

## Changes

- Poll registered TYWATT `cdata` endpoints once at start-up, then use the configured refresh interval.
- Rename the background task from `refresh_data_5m` to the frequency-neutral `refresh_cdata`.
- Remove the fixed five-minute wording from the background task name.
- Add regression tests for the configured interval and task wiring.

## Testing

- Ruff checks pass.
- Ruff formatting passes for the changed files.
- All 126 automated tests pass.