### PR TITLE
Automate release manifest versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,15 @@ jobs:
 
       - name: "Adjust version number"
         shell: "bash"
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
         run: |
-          yq -i -o json '.version="${{ github.event.release.tag_name }}"' \
+          if [[ ! "${RELEASE_VERSION}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release tag: ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+
+          yq -i -o json '.version = strenv(RELEASE_VERSION)' \
             "${{ github.workspace }}/custom_components/deltadore_tydom/manifest.json"
 
       - name: "ZIP the integration directory"
@@ -28,6 +35,20 @@ jobs:
         run: |
           cd "${{ github.workspace }}/custom_components/deltadore_tydom"
           zip deltadore_tydom.zip -r ./
+
+      - name: "Verify the release archive"
+        shell: "bash"
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          manifest_version="$(unzip -p \
+            "${{ github.workspace }}/custom_components/deltadore_tydom/deltadore_tydom.zip" \
+            manifest.json | jq -r '.version')"
+
+          if [[ "${manifest_version}" != "${RELEASE_VERSION}" ]]; then
+            echo "Archive manifest version '${manifest_version}' does not match '${RELEASE_VERSION}'" >&2
+            exit 1
+          fi
 
       - name: "Upload the ZIP file to the release"
         uses: softprops/action-gh-release@v3.0.1

--- a/custom_components/deltadore_tydom/manifest.json
+++ b/custom_components/deltadore_tydom/manifest.json
@@ -21,5 +21,5 @@
   "requirements": [
     "websockets>=9.1"
   ],
-  "version": "v0.26"
+  "version": "0.0.0"
 }


### PR DESCRIPTION
## Summary

Prepare reliable manifest versioning for future releases without requiring a manual source-code version bump each time.

The repository currently keeps `v0.26` in `manifest.json`, which caused the installed integration version to remain stale around the v0.27 and v0.28 releases. The source manifest now uses the valid development placeholder `0.0.0`, while the release workflow injects the published Git tag into the manifest included in the HACS archive.

## Changes

- replace the stale source version `v0.26` with the neutral development version `0.0.0`;
- pass the release tag to `yq` through an environment variable;
- reject release tags that do not follow the expected version format;
- inspect the generated ZIP and fail the workflow if its manifest version does not match the release tag.

## Result

For v0.29, the source tree will continue to show `0.0.0`, but `deltadore_tydom.zip` will contain `version: v0.29`. The same process will apply automatically to later releases.

## Validation

- manifest JSON parsed successfully;
- Ruff checks pass;
- Ruff formatting checks pass;
- `0.0.0` is a valid version accepted by Home Assistant for custom-integration development manifests.