### PR TITLE
Avoid duplicate entities for primary TYDOM attributes

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -197,6 +197,7 @@ class HAEntity:
     state_classes: dict[str, Any] = {}
     units: dict[str, Any] = {}
     filtered_attrs: list[str] = []
+    consumed_attrs: frozenset[str] = frozenset()
     _device: Any = None
     _registered_sensors: list[str]
     hass: Any = None
@@ -308,6 +309,7 @@ class HAEntity:
         if registered_sensors is None:
             return sensors
 
+        consumed_attrs = self._get_consumed_attrs()
         for attribute, value in self._device.__dict__.items():
             if (
                 attribute[:1] != "_"
@@ -316,6 +318,8 @@ class HAEntity:
             ):
                 alt_name = attribute.split("_")[0]
                 if attribute in self.filtered_attrs or alt_name in self.filtered_attrs:
+                    continue
+                if attribute in consumed_attrs or alt_name in consumed_attrs:
                     continue
                 sensor_class = None
                 if attribute in self.sensor_classes:
@@ -373,6 +377,16 @@ class HAEntity:
                 )
 
         return sensors
+
+    def _get_consumed_attrs(self) -> set[str]:
+        """Return raw attributes already represented by this primary entity.
+
+        Unlike ``filtered_attrs``, these are valid TYDOM values which should
+        remain available on devices where they provide independent information.
+        Entity wrappers declare them consumed only when their own state already
+        exposes the same value.
+        """
+        return set(self.consumed_attrs)
 
     def _get_device_info(self) -> dict[str, str]:
         """Get manufacturer and model from device attributes."""
@@ -2168,6 +2182,7 @@ class HASmoke(BinarySensorEntity, HAEntity):
     _attr_supported_features: int | None = None
     _attr_icon = "mdi:smoke-detector"
     _attr_has_entity_name = True
+    consumed_attrs = frozenset({"techSmokeDefect"})
 
     def __init__(self, device: TydomSmoke, hass) -> None:
         """Initialize TydomSmoke."""
@@ -2179,8 +2194,7 @@ class HASmoke(BinarySensorEntity, HAEntity):
         self._state = False
         self._registered_sensors = []
         # This is the detector's primary entity. Keep it visible as a smoke
-        # sensor; battDefect and techSmokeDefect are exposed separately as
-        # diagnostic problem entities by generic sensor discovery.
+        # sensor; independent diagnostics such as battDefect remain available.
         self._attr_device_class = BinarySensorDeviceClass.SMOKE
 
     async def async_added_to_hass(self) -> None:
@@ -2822,6 +2836,16 @@ class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
         self._registered_sensors = []
         self._attr_device_class = self._opening_device_class
 
+    def _get_consumed_attrs(self) -> set[str]:
+        """Hide intrusionDetect only when it is the primary opening state."""
+        consumed = super()._get_consumed_attrs()
+        if (
+            getattr(self._device, "openState", None) is None
+            and getattr(self._device, "intrusionDetect", None) is not None
+        ):
+            consumed.add("intrusionDetect")
+        return consumed
+
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
         await super().async_added_to_hass()
@@ -2906,6 +2930,16 @@ class HaWindow(CoverEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
 
+    def _get_consumed_attrs(self) -> set[str]:
+        """Hide intrusionDetect only when it backs the window state."""
+        consumed = super()._get_consumed_attrs()
+        if (
+            not hasattr(self._device, "openState")
+            and getattr(self._device, "intrusionDetect", None) is not None
+        ):
+            consumed.add("intrusionDetect")
+        return consumed
+
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
         await super().async_added_to_hass()
@@ -2974,6 +3008,17 @@ class HaDoor(CoverEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_cover"
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
+
+    def _get_consumed_attrs(self) -> set[str]:
+        """Hide intrusionDetect only when it backs the door state."""
+        consumed = super()._get_consumed_attrs()
+        if (
+            not hasattr(self._device, "podPosition")
+            and not hasattr(self._device, "openState")
+            and getattr(self._device, "intrusionDetect", None) is not None
+        ):
+            consumed.add("intrusionDetect")
+        return consumed
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -3648,6 +3693,7 @@ class HaMoisture(BinarySensorEntity, HAEntity):
     _attr_supported_features: int | None = None
     _attr_icon = "mdi:water"
     _attr_has_entity_name = True
+    consumed_attrs = frozenset({"techWaterDefect"})
 
     def __init__(self, device: TydomWater, hass) -> None:
         """Initialize TydomSmoke."""
@@ -3658,8 +3704,7 @@ class HaMoisture(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._state = False
         self._registered_sensors = []
-        self._attr_device_class = BinarySensorDeviceClass.PROBLEM
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_class = BinarySensorDeviceClass.MOISTURE
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -3700,6 +3745,7 @@ class HaThermo(SensorEntity, HAEntity):
 
     _attr_icon = "mdi:thermometer"
     _attr_has_entity_name = True
+    consumed_attrs = frozenset({"outTemperature"})
 
     def __init__(self, device: TydomThermo, hass) -> None:
         """Initialize TydomSmoke."""
@@ -3709,7 +3755,7 @@ class HaThermo(SensorEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_thermos"
         self._attr_name = None  # primary entity inherits device name
         self._state = False
-        self._registered_sensors = ["outTemperature"]
+        self._registered_sensors = []
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
@@ -3758,6 +3804,7 @@ class HaSun(SensorEntity, HAEntity):
     _attr_device_class = SensorDeviceClass.IRRADIANCE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "W/m²"
+    consumed_attrs = frozenset({"lightPower"})
 
     def __init__(self, device: TydomSun, hass) -> None:
         """Initialise a Tysense Sun sensor."""
@@ -3768,7 +3815,7 @@ class HaSun(SensorEntity, HAEntity):
         # entry and recorder history can survive the dedicated implementation.
         self._attr_unique_id = f"{self._device.device_id}_lightPower"
         self._attr_name = None
-        self._registered_sensors = ["lightPower"]
+        self._registered_sensors = []
 
     async def async_added_to_hass(self) -> None:
         """Refresh the entity on every device push."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2815,6 +2815,7 @@ class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    consumed_attrs = frozenset({"openState", "intrusionDetect"})
 
     # Overridden by the window/door subclasses.
     _opening_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.WINDOW
@@ -2835,16 +2836,6 @@ class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
         self._attr_device_class = self._opening_device_class
-
-    def _get_consumed_attrs(self) -> set[str]:
-        """Hide intrusionDetect only when it is the primary opening state."""
-        consumed = super()._get_consumed_attrs()
-        if (
-            getattr(self._device, "openState", None) is None
-            and getattr(self._device, "intrusionDetect", None) is not None
-        ):
-            consumed.add("intrusionDetect")
-        return consumed
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -2920,6 +2911,7 @@ class HaWindow(CoverEntity, HAEntity):
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_icon = "mdi:window-open"
     _attr_has_entity_name = True
+    consumed_attrs = frozenset({"openState", "intrusionDetect"})
 
     def __init__(self, device: TydomWindow, hass) -> None:
         """Initialize the sensor."""
@@ -2929,16 +2921,6 @@ class HaWindow(CoverEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_cover"
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
-
-    def _get_consumed_attrs(self) -> set[str]:
-        """Hide intrusionDetect only when it backs the window state."""
-        consumed = super()._get_consumed_attrs()
-        if (
-            not hasattr(self._device, "openState")
-            and getattr(self._device, "intrusionDetect", None) is not None
-        ):
-            consumed.add("intrusionDetect")
-        return consumed
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -3010,14 +2992,10 @@ class HaDoor(CoverEntity, HAEntity):
         self._registered_sensors = []
 
     def _get_consumed_attrs(self) -> set[str]:
-        """Hide intrusionDetect only when it backs the door state."""
+        """Hide raw contact aliases when they back the door's primary state."""
         consumed = super()._get_consumed_attrs()
-        if (
-            not hasattr(self._device, "podPosition")
-            and not hasattr(self._device, "openState")
-            and getattr(self._device, "intrusionDetect", None) is not None
-        ):
-            consumed.add("intrusionDetect")
+        if not hasattr(self._device, "podPosition"):
+            consumed.update({"openState", "intrusionDetect"})
         return consumed
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -125,6 +125,7 @@ from .tydom.MessageHandler import device_name, groups_data
 _BINARY_TRUE_VALUES = frozenset({"1", "on", "true", "yes"})
 _BINARY_FALSE_VALUES = frozenset({"0", "off", "false", "no"})
 _PROBLEM_ATTRIBUTE_MARKERS = ("defect", "empty", "intrusion")
+_BINARY_OPEN_STATES = frozenset({"LOCKED", "UNLOCKED"})
 
 
 def normalize_binary_state(value: Any, *, allow_numeric: bool = False) -> bool | None:
@@ -151,6 +152,33 @@ def is_problem_attribute(attribute: str) -> bool:
     """Return whether a binary attribute denotes a reported problem."""
     normalized = attribute.casefold()
     return any(marker in normalized for marker in _PROBLEM_ATTRIBUTE_MARKERS)
+
+
+def get_consumed_opening_attrs(device: Any) -> set[str]:
+    """Return raw attributes already represented by an opening entity.
+
+    ``intrusionDetect`` is a boolean alias of the primary open/closed state.
+    ``openState`` is also redundant when metadata advertises only LOCKED and
+    UNLOCKED, but must remain available when it distinguishes richer states
+    such as a French window opened normally or in hopper mode.
+    """
+    consumed = {"intrusionDetect"}
+    metadata = getattr(device, "_metadata", None)
+    open_state_metadata = (
+        metadata.get("openState") if isinstance(metadata, dict) else None
+    )
+    enum_values = (
+        open_state_metadata.get("enum_values")
+        if isinstance(open_state_metadata, dict)
+        else None
+    )
+    if (
+        isinstance(enum_values, (list, tuple, set))
+        and bool(enum_values)
+        and set(enum_values).issubset(_BINARY_OPEN_STATES)
+    ):
+        consumed.add("openState")
+    return consumed
 
 
 def is_binary_attribute(
@@ -2815,7 +2843,6 @@ class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
-    consumed_attrs = frozenset({"openState", "intrusionDetect"})
 
     # Overridden by the window/door subclasses.
     _opening_device_class: BinarySensorDeviceClass = BinarySensorDeviceClass.WINDOW
@@ -2836,6 +2863,10 @@ class HaOpeningBinarySensor(BinarySensorEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
         self._attr_device_class = self._opening_device_class
+
+    def _get_consumed_attrs(self) -> set[str]:
+        """Hide only contact attributes which add no opening detail."""
+        return super()._get_consumed_attrs() | get_consumed_opening_attrs(self._device)
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -2911,7 +2942,6 @@ class HaWindow(CoverEntity, HAEntity):
     _attr_device_class = CoverDeviceClass.WINDOW
     _attr_icon = "mdi:window-open"
     _attr_has_entity_name = True
-    consumed_attrs = frozenset({"openState", "intrusionDetect"})
 
     def __init__(self, device: TydomWindow, hass) -> None:
         """Initialize the sensor."""
@@ -2921,6 +2951,10 @@ class HaWindow(CoverEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_cover"
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
+
+    def _get_consumed_attrs(self) -> set[str]:
+        """Hide only contact attributes which add no opening detail."""
+        return super()._get_consumed_attrs() | get_consumed_opening_attrs(self._device)
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -2995,7 +3029,7 @@ class HaDoor(CoverEntity, HAEntity):
         """Hide raw contact aliases when they back the door's primary state."""
         consumed = super()._get_consumed_attrs()
         if not hasattr(self._device, "podPosition"):
-            consumed.update({"openState", "intrusionDetect"})
+            consumed.update(get_consumed_opening_attrs(self._device))
         return consumed
 
     async def async_added_to_hass(self) -> None:

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -65,6 +65,51 @@ def _load_ha_entity_class():
 HAEntity = _load_ha_entity_class()
 
 
+def _load_opening_consumed_attrs():
+    """Load the metadata helper without Home Assistant dependencies."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    selected_nodes = [
+        node
+        for node in module.body
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name)
+                and target.id == "_BINARY_OPEN_STATES"
+                for target in node.targets
+            )
+        )
+        or (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "get_consumed_opening_attrs"
+        )
+    ]
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            *selected_nodes,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+    namespace = {"Any": object}
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["get_consumed_opening_attrs"]
+
+
+get_consumed_opening_attrs = _load_opening_consumed_attrs()
+
+
 class EntitySensorRegistrationTests(TestCase):
     """Ensure generic sensor discovery is isolated between entity instances."""
 
@@ -225,36 +270,41 @@ class EntitySensorRegistrationTests(TestCase):
                 expected_attribute, ast.literal_eval(assignment.value.args[0])
             )
 
-    def test_opening_entities_consume_both_contact_state_aliases(self) -> None:
-        """Opening wrappers must handle single and dual-reporting endpoints."""
-        source_path = (
-            Path(__file__).parents[1]
-            / "custom_components"
-            / "deltadore_tydom"
-            / "ha_entities.py"
+    def test_binary_open_state_is_consumed(self) -> None:
+        """A two-state openState adds nothing beyond the primary entity."""
+        device = MagicMock()
+        device._metadata = {
+            "openState": {"enum_values": ["LOCKED", "UNLOCKED"]}
+        }
+
+        self.assertEqual(
+            get_consumed_opening_attrs(device),
+            {"openState", "intrusionDetect"},
         )
-        module = ast.parse(source_path.read_text(encoding="utf-8"))
 
-        for class_name in ("HaOpeningBinarySensor", "HaWindow"):
-            entity_class = next(
-                node
-                for node in module.body
-                if isinstance(node, ast.ClassDef) and node.name == class_name
-            )
-            assignment = next(
-                statement
-                for statement in entity_class.body
-                if isinstance(statement, ast.Assign)
-                and any(
-                    isinstance(target, ast.Name) and target.id == "consumed_attrs"
-                    for target in statement.targets
-                )
-            )
+    def test_detailed_open_state_is_retained(self) -> None:
+        """French-window opening modes must remain separately observable."""
+        device = MagicMock()
+        device._metadata = {
+            "openState": {
+                "enum_values": ["LOCKED", "OPEN_FRENCH", "OPEN_HOPPER"]
+            }
+        }
 
-            self.assertEqual(
-                ast.literal_eval(assignment.value.args[0]),
-                {"openState", "intrusionDetect"},
-            )
+        self.assertEqual(
+            get_consumed_opening_attrs(device),
+            {"intrusionDetect"},
+        )
+
+    def test_open_state_is_retained_without_metadata(self) -> None:
+        """Missing metadata must favour preserving information."""
+        device = MagicMock()
+        device._metadata = None
+
+        self.assertEqual(
+            get_consumed_opening_attrs(device),
+            {"intrusionDetect"},
+        )
 
     def test_leak_detector_primary_entity_remains_a_moisture_sensor(self) -> None:
         """A leak detector belongs in Sensors, not hidden in Diagnostics."""

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -122,11 +122,26 @@ class EntitySensorRegistrationTests(TestCase):
         entity = self._entity("opening_1")
         entity._device.intrusionDetect = False
         entity._device.battDefect = False
-        entity.consumed_attrs = frozenset({"intrusionDetect"})
+        entity.consumed_attrs = frozenset({"openState", "intrusionDetect"})
 
         sensors = entity.get_sensors()
 
         self.assertEqual(len(sensors), 2)
+        self.assertNotIn("intrusionDetect", entity._registered_sensors)
+        self.assertIn("battDefect", entity._registered_sensors)
+
+    def test_both_opening_state_aliases_are_consumed(self) -> None:
+        """A dual-reporting opening must still expose one primary state."""
+        entity = self._entity("opening_1")
+        entity._device.openState = "LOCKED"
+        entity._device.intrusionDetect = False
+        entity._device.battDefect = False
+        entity.consumed_attrs = frozenset({"openState", "intrusionDetect"})
+
+        sensors = entity.get_sensors()
+
+        self.assertEqual(len(sensors), 2)
+        self.assertNotIn("openState", entity._registered_sensors)
         self.assertNotIn("intrusionDetect", entity._registered_sensors)
         self.assertIn("battDefect", entity._registered_sensors)
 
@@ -208,6 +223,37 @@ class EntitySensorRegistrationTests(TestCase):
             )
             self.assertIn(
                 expected_attribute, ast.literal_eval(assignment.value.args[0])
+            )
+
+    def test_opening_entities_consume_both_contact_state_aliases(self) -> None:
+        """Opening wrappers must handle single and dual-reporting endpoints."""
+        source_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "deltadore_tydom"
+            / "ha_entities.py"
+        )
+        module = ast.parse(source_path.read_text(encoding="utf-8"))
+
+        for class_name in ("HaOpeningBinarySensor", "HaWindow"):
+            entity_class = next(
+                node
+                for node in module.body
+                if isinstance(node, ast.ClassDef) and node.name == class_name
+            )
+            assignment = next(
+                statement
+                for statement in entity_class.body
+                if isinstance(statement, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name) and target.id == "consumed_attrs"
+                    for target in statement.targets
+                )
+            )
+
+            self.assertEqual(
+                ast.literal_eval(assignment.value.args[0]),
+                {"openState", "intrusionDetect"},
             )
 
     def test_leak_detector_primary_entity_remains_a_moisture_sensor(self) -> None:

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -117,6 +117,33 @@ class EntitySensorRegistrationTests(TestCase):
         self.assertEqual(entity.get_sensors(), [])
         self.assertNotIn("_registered_sensors", entity.__dict__)
 
+    def test_consumed_attribute_is_not_exposed_as_generic_sensor(self) -> None:
+        """A primary state must not also become a raw generic sensor."""
+        entity = self._entity("opening_1")
+        entity._device.intrusionDetect = False
+        entity._device.battDefect = False
+        entity.consumed_attrs = frozenset({"intrusionDetect"})
+
+        sensors = entity.get_sensors()
+
+        self.assertEqual(len(sensors), 2)
+        self.assertNotIn("intrusionDetect", entity._registered_sensors)
+        self.assertIn("battDefect", entity._registered_sensors)
+
+    def test_consumed_attribute_is_evaluated_for_each_entity(self) -> None:
+        """Consumed state on one wrapper must not suppress another device."""
+        consumed = self._entity("opening_1")
+        retained = self._entity("shutter_1")
+        consumed._device.intrusionDetect = False
+        retained._device.intrusionDetect = False
+        consumed.consumed_attrs = frozenset({"intrusionDetect"})
+
+        consumed.get_sensors()
+        retained.get_sensors()
+
+        self.assertNotIn("intrusionDetect", consumed._registered_sensors)
+        self.assertIn("intrusionDetect", retained._registered_sensors)
+
     def test_smoke_detector_primary_entity_remains_a_smoke_sensor(self) -> None:
         """Binary normalisation must not turn a DFR into a hidden diagnostic."""
         source_path = (
@@ -146,6 +173,72 @@ class EntitySensorRegistrationTests(TestCase):
 
         self.assertEqual(
             assignments["_attr_device_class"], "BinarySensorDeviceClass.SMOKE"
+        )
+        self.assertNotIn("_attr_entity_category", assignments)
+
+    def test_primary_entities_consume_their_raw_state(self) -> None:
+        """Dedicated entities must not expose their source value twice."""
+        source_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "deltadore_tydom"
+            / "ha_entities.py"
+        )
+        module = ast.parse(source_path.read_text(encoding="utf-8"))
+
+        for class_name, expected_attribute in (
+            ("HASmoke", "techSmokeDefect"),
+            ("HaMoisture", "techWaterDefect"),
+            ("HaThermo", "outTemperature"),
+            ("HaSun", "lightPower"),
+        ):
+            entity_class = next(
+                node
+                for node in module.body
+                if isinstance(node, ast.ClassDef) and node.name == class_name
+            )
+            assignment = next(
+                statement
+                for statement in entity_class.body
+                if isinstance(statement, ast.Assign)
+                and any(
+                    isinstance(target, ast.Name) and target.id == "consumed_attrs"
+                    for target in statement.targets
+                )
+            )
+            self.assertIn(
+                expected_attribute, ast.literal_eval(assignment.value.args[0])
+            )
+
+    def test_leak_detector_primary_entity_remains_a_moisture_sensor(self) -> None:
+        """A leak detector belongs in Sensors, not hidden in Diagnostics."""
+        source_path = (
+            Path(__file__).parents[1]
+            / "custom_components"
+            / "deltadore_tydom"
+            / "ha_entities.py"
+        )
+        module = ast.parse(source_path.read_text(encoding="utf-8"))
+        moisture_class = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.ClassDef) and node.name == "HaMoisture"
+        )
+        init = next(
+            node
+            for node in moisture_class.body
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__"
+        )
+        assignments = {
+            target.attr: ast.unparse(statement.value)
+            for statement in init.body
+            if isinstance(statement, ast.Assign)
+            for target in statement.targets
+            if isinstance(target, ast.Attribute)
+        }
+
+        self.assertEqual(
+            assignments["_attr_device_class"], "BinarySensorDeviceClass.MOISTURE"
         )
         self.assertNotIn("_attr_entity_category", assignments)
 


### PR DESCRIPTION
## Summary

Prevent TYDOM attributes from being exposed twice when a dedicated Home Assistant entity already represents the same value, without discarding attributes which carry additional information.

Generic sensor discovery currently creates an additional raw entity even when that attribute is already used as the primary state of a window, door, smoke detector, leak detector, temperature sensor or solar irradiance sensor.

For example, on an opening using `intrusionDetect`:

- `intrusionDetect: false` is already displayed by Home Assistant as **Closed**;
- `intrusionDetect: true` is already displayed as **Open**.

Some endpoints also provide `openState`. Its usefulness is determined from the endpoint metadata: a two-state value duplicates the primary opening entity, while a multi-state value can distinguish different opening modes.

## Changes

Introduce a reusable `consumed_attrs` mechanism. A dedicated entity can declare which raw TYDOM attributes it already represents, preventing generic discovery from creating a duplicate entity.

| Device/entity | Raw TYDOM attribute handling |
|---|---|
| Window or door using `intrusionDetect` | Consumed by the primary open/closed entity |
| Opening with two-state `openState` (`LOCKED`/`UNLOCKED`) | Consumed by the primary open/closed entity |
| Opening with detailed `openState` | Retained as an additional sensor |
| DFR smoke detector | `techSmokeDefect` consumed by the primary smoke entity |
| Water-leak detector | `techWaterDefect` consumed by the primary moisture entity |
| Outdoor temperature sensor | `outTemperature` consumed by the primary temperature entity |
| Tysense Sun sensor | `lightPower` consumed by the primary irradiance entity |

The water-leak primary entity is also classified as a Home Assistant moisture sensor rather than a generic diagnostic problem.

## Capability-based opening handling

The opening logic uses the metadata supplied by each endpoint rather than model names or installation-specific exceptions:

- an endpoint exposing only `intrusionDetect` retains one primary open/closed entity;
- an endpoint whose `openState` metadata contains only `LOCKED` and `UNLOCKED` consumes both raw contact aliases;
- a French-window endpoint advertising `LOCKED`, `OPEN_FRENCH` and `OPEN_HOPPER` retains `openState`, because it distinguishes normal opening from hopper/tilt opening;
- when metadata is absent or incomplete, `openState` is retained conservatively;
- a motorised door exposing `podPosition` retains its additional contact values because they may represent information independent of its motorised state.

This supports single-reporting, ordinary dual-reporting and detailed multi-state openings without hard-coded receiver models.

## Safety

Suppression is evaluated for each individual entity rather than globally and applies only to recognised entity wrappers whose primary state already represents the attribute.

`intrusionDetect` remains available on unrelated devices where it is not consumed by a dedicated opening entity. Other diagnostic attributes, including battery, calibration and communication faults, also remain available.

No registry migration is performed. Existing duplicate entities may become unavailable after upgrading and can then be removed by the user through Home Assistant.

## Testing

Automated tests verify that:

- consumed attributes are not registered a second time;
- two-state `openState` metadata is consumed;
- detailed `openState` metadata remains exposed;
- missing metadata favours retaining information;
- suppression remains isolated per device;
- unrelated diagnostics remain available;
- dedicated DFR and leak-detector entities retain their intended Home Assistant device classes;
- temperature and irradiance entities retain their existing identifiers and recorder history.

Live captures have covered the relevant TYDOM representations:

- on a single-reporting endpoint, opening and closing changed `intrusionDetect` and the existing Home Assistant opening entity together;
- a sliding-window capture reported `openState=LOCKED` with `intrusionDetect=false`, then `openState=UNLOCKED` with `intrusionDetect=true` in the same updates;
- MrYann's French-window capture advertised `LOCKED`, `OPEN_FRENCH` and `OPEN_HOPPER` in metadata and demonstrated both opening modes while `intrusionDetect` remained only boolean.

The last capture confirms why `intrusionDetect` is redundant for the primary state but multi-state `openState` must remain visible.

Validation completed successfully on the current revision:

- Ruff checks pass;
- Ruff formatting passes;
- Hassfest validation passes;
- HACS validation passes.

Further hardware confirmation is requested for the revised French-window behaviour and for available doors, temperature sensors, Tysense Sun sensors and water-leak detectors before this PR is marked ready for review.
