### PR TITLE
Keep Tywell companion entities grouped across controller configurations

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -4504,26 +4504,26 @@ class HAScene(Scene, HAEntity):
 
             # TWC_UP/DOWN/STOP scenes generally target shutter groups, not the
             # controller endpoint itself. In that case grpAct/epAct cannot lead
-            # us back to the physical Tywell controller. The endpoint advertised
-            # as re2020ControlPassive is the controller which exposes the
-            # tywell_control widget in /configs/file.
-            passive_controllers = [
+            # us back to the physical Tywell controller. Depending on its area
+            # association, the same wall controller may be advertised as a
+            # passive endpoint or as an unlinked boiler endpoint.
+            physical_controllers = [
                 (device_id, device)
                 for device_id, device in hub_instance.devices.items()
-                if getattr(device, "device_type", None) == "re2020ControlPassive"
+                if getattr(device, "is_physical_tywell_control", False)
             ]
 
             if zone:
                 zone_controllers = [
                     (device_id, device)
-                    for device_id, device in passive_controllers
+                    for device_id, device in physical_controllers
                     if self._get_zone_from_device(device) == zone
                 ]
                 if len(zone_controllers) == 1:
-                    passive_controllers = zone_controllers
+                    physical_controllers = zone_controllers
 
-            if len(passive_controllers) == 1:
-                device_id = passive_controllers[0][0]
+            if len(physical_controllers) == 1:
+                device_id = physical_controllers[0][0]
                 self._cached_tywell_device_id = device_id
                 LOGGER.debug(
                     "Using physical Tywell controller %s for scene %s",

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -37,6 +37,7 @@ from .tydom_devices import (
     TydomSun,
     TydomScene,
     is_binary_tyxia_receiver_profile,
+    is_physical_tywell_control_profile,
     resolve_device_model,
 )
 
@@ -250,13 +251,6 @@ _AREA_CONTROL_ATTRIBUTES = {
     "coolSetpoint",
 }
 
-_TYWELL_CONTROL_SENSOR_ATTRIBUTES = {
-    "hygroIn",
-    "isReference",
-    "shutterCmd",
-    "synchroRadio",
-}
-
 
 def _is_physical_tywell_control_endpoint(
     uid: str, metadata: dict | None, data: dict | None
@@ -269,11 +263,12 @@ def _is_physical_tywell_control_endpoint(
     capabilities when configuration metadata is incomplete. Orphaned thermal
     proxies must not create misleading climate entities.
     """
-    if str(device_tutorial_id.get(uid, "")).casefold() == "tywell_control":
-        return True
-
-    attributes = set(metadata or {}) | set(data or {})
-    return bool(attributes & _TYWELL_CONTROL_SENSOR_ATTRIBUTES)
+    return is_physical_tywell_control_profile(
+        device_tutorial_id.get(uid),
+        device_type.get(uid),
+        metadata,
+        data,
+    )
 
 
 def _area_metadata_score(metadata: dict) -> int:
@@ -979,13 +974,17 @@ class MessageHandler:
                     device_metadata.get(uid),
                     data,
                 )
-                passive_controllers = [
+                physical_controllers = [
                     controller_uid
                     for controller_uid, controller_type in device_type.items()
-                    if controller_type == "re2020ControlPassive"
+                    if is_physical_tywell_control_profile(
+                        device_tutorial_id.get(controller_uid),
+                        controller_type,
+                        device_metadata.get(controller_uid),
+                    )
                 ]
-                if len(passive_controllers) == 1:
-                    controller_uid = passive_controllers[0]
+                if len(physical_controllers) == 1:
+                    controller_uid = physical_controllers[0]
                     weather_device.group_with_registry_device(
                         controller_uid,
                         device_name.get(controller_uid, "Tywell Control"),

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -36,6 +36,59 @@ _TUTORIAL_PREFIX_MODELS = {
     "tl2000": "TL 2000 Tyxal+",
 }
 
+_TYWELL_CONTROL_TYPES = {
+    "re2020ControlBoiler",
+    "re2020ControlPassive",
+}
+
+_TYWELL_CONTROL_MODELS = {
+    "tywell 2050",
+    "tywell control",
+}
+
+_TYWELL_CONTROL_TUTORIALS = {
+    "tywell_control",
+    "tywell_control_2050",
+}
+
+_TYWELL_CONTROL_SENSOR_ATTRIBUTES = {
+    "hygroIn",
+    "isReference",
+    "shutterCmd",
+    "synchroRadio",
+}
+
+
+def is_physical_tywell_control_profile(
+    tutorial_id: str | None,
+    device_type: str | None,
+    metadata: dict[str, Any] | None = None,
+    data: dict[str, Any] | None = None,
+) -> bool:
+    """Return whether descriptors identify a physical Tywell wall controller.
+
+    A controller may be advertised as either a passive endpoint or an unlinked
+    boiler endpoint depending on how it is associated with the heating system.
+    Prefer Delta Dore's explicit tutorial identifier and retain the established
+    capability fallback for older configurations.
+    """
+    if device_type not in _TYWELL_CONTROL_TYPES:
+        return False
+
+    if device_type == "re2020ControlPassive":
+        return True
+
+    tutorial = str(tutorial_id or "").strip().casefold()
+    if tutorial in _TYWELL_CONTROL_TUTORIALS:
+        return True
+
+    product_name = str((data or {}).get("productName", "")).strip().casefold()
+    if product_name in _TYWELL_CONTROL_MODELS:
+        return True
+
+    attributes = set(metadata or {}) | set(data or {})
+    return bool(attributes & _TYWELL_CONTROL_SENSOR_ATTRIBUTES)
+
 
 def is_binary_tyxia_receiver_profile(metadata: dict[str, Any] | None) -> bool:
     """Return whether metadata identifies a fixed-output TYXIA receiver."""
@@ -266,6 +319,16 @@ class TydomDevice:
     def registry_device_name(self) -> str:
         """Return the physical device name used by Home Assistant."""
         return str(getattr(self, "_registry_device_name", self._name))
+
+    @property
+    def is_physical_tywell_control(self) -> bool:
+        """Return whether this endpoint represents a Tywell wall controller."""
+        return is_physical_tywell_control_profile(
+            None,
+            self._type,
+            self._metadata,
+            self.__dict__,
+        )
 
     def group_with_registry_device(self, device_id: str, device_name: str) -> None:
         """Group this protocol endpoint with another physical HA device."""

--- a/tests/test_area_thermostats.py
+++ b/tests/test_area_thermostats.py
@@ -625,6 +625,36 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         self.assertEqual(weather.registry_device_name, "Tywell Ctrl RdC")
         self.assertEqual(weather.device_id, "30_40")
 
+    async def test_weather_uses_unlinked_tywell_boiler_identity(self) -> None:
+        """An unlinked controller still owns its weather companion endpoint."""
+        handler_module.device_name.update(
+            {
+                "10_20": "Tywell Ctrl RdC",
+                "30_40": "Produit 1",
+            }
+        )
+        handler_module.device_type.update(
+            {
+                "10_20": "re2020ControlBoiler",
+                "30_40": "weather",
+            }
+        )
+        handler_module.device_tutorial_id["10_20"] = "tywell_control"
+
+        weather = await MessageHandler.get_device(
+            self.client,
+            "weather",
+            "30_40",
+            "40",
+            "Produit 1",
+            "30",
+            {},
+        )
+
+        self.assertIsInstance(weather, TydomWeather)
+        self.assertEqual(weather.registry_device_id, "10_20")
+        self.assertEqual(weather.registry_device_name, "Tywell Ctrl RdC")
+
     async def test_weather_endpoint_stays_separate_when_controller_is_ambiguous(
         self,
     ) -> None:

--- a/tests/test_device_models.py
+++ b/tests/test_device_models.py
@@ -67,6 +67,9 @@ is_trv_1_profile = devices_module.is_trv_1_profile
 is_tymoov_profile = devices_module.is_tymoov_profile
 is_tybox_1137_profile = devices_module.is_tybox_1137_profile
 is_tyxia_dimmer_profile = devices_module.is_tyxia_dimmer_profile
+is_physical_tywell_control_profile = (
+    devices_module.is_physical_tywell_control_profile
+)
 resolve_device_model = devices_module.resolve_device_model
 MessageHandler = handler_module.MessageHandler
 
@@ -116,6 +119,29 @@ class TestDeviceModels(TestCase):
                 self.assertEqual(
                     resolve_device_model(tutorial_id, "unknown"), expected_model
                 )
+
+    def test_physical_tywell_control_profiles(self) -> None:
+        """Both linked and unlinked controller forms retain one identity."""
+        self.assertTrue(
+            is_physical_tywell_control_profile(
+                "tywell_control",
+                "re2020ControlBoiler",
+            )
+        )
+        self.assertTrue(
+            is_physical_tywell_control_profile(
+                None,
+                "re2020ControlPassive",
+                {"hygroIn": {"permission": "r"}},
+            )
+        )
+        self.assertFalse(
+            is_physical_tywell_control_profile(
+                None,
+                "boiler",
+                {"heatSetpoint": {"permission": "rw"}},
+            )
+        )
 
     def test_family_tutorials_do_not_become_models(self) -> None:
         """Family-only tutorial identifiers retain the existing fallback."""


### PR DESCRIPTION
## Summary

PR #349 added area-backed climate support for Tywell Control, including support for a linked `re2020ControlBoiler`. However, identifying the physical controller for companion entities used separate, narrower logic which only recognised `re2020ControlPassive`.

Delta Dore exposes weather, TWC shutter scenarios and the physical Tywell Control as independent objects, each with its own identifier. Unless the integration explicitly connects them, Home Assistant therefore creates:

1. the physical Tywell Control containing its sensors and, when linked, its climate;
2. a separate device containing the weather entities;
3. a virtual Tywell Control containing `TWC_UP`, `TWC_DOWN` and `TWC_STOP`.

The issue occurs even when the controller is linked and its climate is working correctly. Removing the thermal association also showed that the same physical controller can remain exposed as an unlinked `re2020ControlBoiler`, rather than changing to `re2020ControlPassive`.

## Cause

The climate and grouping paths used different definitions of a Tywell Control:

- the climate path already supported a linked `re2020ControlBoiler`;
- weather grouping searched only for `re2020ControlPassive`;
- the TWC scene fallback also searched only for `re2020ControlPassive`.

TWC scenes generally target the shutter group rather than the controller endpoint itself, while the weather endpoint has its own independent identifier. Neither can reliably derive the physical controller without this fallback.

Consequently, a Tywell Control exposed as `re2020ControlBoiler` was valid for climate support but invisible to the companion-entity grouping logic.

## Changes

- Add one shared, capability-driven helper for identifying a physical Tywell Control.
- Recognise both supported representations:
  - `re2020ControlPassive`;
  - `re2020ControlBoiler`.
- Prefer Delta Dore's explicit `tywell_control` and `tywell_control_2050` tutorial identifiers.
- Retain product-name and capability fallbacks for configurations with incomplete descriptors.
- Reuse the same identification logic for:
  - unlinked-controller handling;
  - weather grouping;
  - TWC scene grouping.
- Keep an unlinked controller sensor-only rather than exposing a misleading climate entity.
- Preserve the ambiguity safeguard: when several controllers are plausible, the integration does not guess.
- Avoid hard-coded endpoint IDs or installation-specific names.

## Result

A physical Tywell Control now retains one consistent Home Assistant device:

- when linked, its climate, weather, physical sensors and TWC scenes are grouped together;
- when unlinked, its sensors, weather and TWC scenes remain grouped together, without creating a climate;
- restoring the thermal association recreates the climate under the same physical controller.

This complements PR #349 rather than replacing its area-backed climate implementation.

## Automated testing

Added coverage confirming that:

- an explicit `tywell_control` tutorial identifies an unlinked `re2020ControlBoiler` as a physical controller;
- a passive Tywell Control remains recognised;
- an ordinary boiler is not misidentified as a Tywell Control;
- weather uses the unlinked physical controller's registry identity;
- weather remains separate when several controllers make the association ambiguous;
- existing linked, unlinked and area-backed thermostat behaviour remains unchanged.

Validation completed successfully:

- Ruff checks pass;
- Ruff formatting passes;
- 149 automated tests and 34 subtests pass.

## Hardware testing

Tested on a live Tywell Pro installation containing:

- two TYPASS ATL heating endpoints;
- one physical Tywell Control;
- one separate Delta Dore weather endpoint;
- `TWC_UP`, `TWC_DOWN` and `TWC_STOP` scenarios.

### Linked configuration

The issue was initially observed whilst the physical controller was linked to a thermal area and already exposing a working climate entity. Weather and the TWC scenes nevertheless appeared on two additional Home Assistant devices.

This confirmed that working `re2020ControlBoiler` climate support did not imply that companion entities could identify the same physical controller.

### Unlinked configuration

The thermal association was removed and Home Assistant restarted. Delta Dore continued exposing the physical controller as:

```text
type: re2020ControlBoiler
tutorial_id: tywell_control
area link: absent
```

Confirmed that:

- the controller remained available as a sensor-only device;
- no misleading climate entity was created;
- weather was grouped with the physical controller;
- all three TWC scenes were grouped with the physical controller;
- no virtual duplicate Tywell Control was required.

### Association restored

The controller was then linked again. Delta Dore exposed:

```text
type: re2020ControlBoiler
tutorial_id: tywell_control
link.type: area
link.subtype: thermicCtrl
```

After a full Home Assistant restart, confirmed that:

- the Tywell climate entity was recreated;
- weather remained under the physical `Tywell Ctrl RdC`;
- `TWC_UP`, `TWC_DOWN` and `TWC_STOP` remained under it;
- physical controller sensors remained on the same device;
- the separate upstairs TYPASS ATL climate remained unaffected;
- no duplicate virtual Tywell devices appeared;
- no Delta Dore setup or runtime errors occurred.

An existing Home Assistant entity-ID reservation initially added a numerical suffix to the recreated climate. Renaming the active entity restored its preferred name without deletion and did not affect its stable unique ID or device association.
