### PR TITLE
Fix pilot-wire detection for RF 6600 zones exposing "authorization" instead of "hvacMode"

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2459,7 +2459,7 @@ class HaClimate(ClimateEntity, HAEntity):
             metadata is not None and "thermicLevel" in metadata
         )
         has_pilot_wire_command = hasattr(self._device, "hvacMode") or hasattr(
-            seft._device, "authorization"
+            self._device, "authorization"
         )
         self._is_filpilote = (
             has_pilot_wire_command

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -2458,8 +2458,11 @@ class HaClimate(ClimateEntity, HAEntity):
         has_thermic_level = hasattr(self._device, "thermicLevel") or (
             metadata is not None and "thermicLevel" in metadata
         )
+        has_pilot_wire_command = hasattr(self._device, "hvacMode") or hasattr(
+            seft._device, "authorization"
+        )
         self._is_filpilote = (
-            hasattr(self._device, "hvacMode")
+            has_pilot_wire_command
             and has_thermic_level
             and not has_setpoint_meta
             and not has_cool_enum_meta


### PR DESCRIPTION
Closes #395

## Problem

Following #328 and #334, pilot-wire detection in `ha_entities.py` still fails
on some RF 6600 FP (X3D) zones, because the discriminator only checks for a
`hvacMode` attribute:

```python
self._is_filpilote = (
    hasattr(self._device, "hvacMode")
    and has_thermic_level
    and not has_setpoint_meta
    and not has_cool_enum_meta
)
```

On this hardware, `hvacMode` never appears as a live attribute. Here is what
`/devices/meta` and `/devices/data` actually report for one of these zones:

**Metadata (`/devices/meta`):**
```json
{"name":"authorization","type":"string","permission":"r","validity":"STATUS_POLLING","enum_values":["STOP","HEATING"]},
{"name":"comfortMode","type":"string","permission":"w","validity":"INFINITE","enum_values":["STOP","HEATING"]},
{"name":"thermicLevel","type":"string","permission":"rw","validity":"DATA_POLLING","enum_values":["ECO","COMFORT","STOP","ANTI_FROST", ...]}
```

**Live data (`/devices/data`):**
```json
{"name":"authorization","value":"HEATING"},
{"name":"thermicLevel","value":"ANTI_FROST"},
{"name":"overrideThermicLevel","value":null},
{"name":"localMode","value":"NORMAL"},
{"name":"useMode","value":"SCHED"},
...
```

`comfortMode` is declared `"permission":"w"` (write-only), so it never appears
as a live device attribute (`hasattr(self._device, "comfortMode")` is always
`False`). On this zone, the readable on/off command register is called
**`authorization`**, not `hvacMode` or `comfortMode`. As a result the
`hasattr(self._device, "hvacMode")` check is never true, and the zone falls
back to the generic climate branch (raw `NORMAL`/`ECO`/`COMFORT` presets),
the same broken behaviour #328 and #334 were meant to fix.

`tydom_devices.py` already treats `authorization` as one of the recognized
device attributes (`for attribute in ("authorization", "comfortMode", "hvacMode",
"thermicLevel")`, line 626), so `self._device.authorization` is populated and
available — the discriminator just wasn't checking it.

## Fix

Widen the discriminator to also accept `authorization` as a valid pilot-wire
command register, factored into a named intermediate for readability:

```python
has_pilot_wire_command = hasattr(self._device, "hvacMode") or hasattr(
    self._device, "authorization"
)
self._is_filpilote = (
    has_pilot_wire_command
    and has_thermic_level
    and not has_setpoint_meta
    and not has_cool_enum_meta
)
```

Real thermostats remain unaffected: they carry `setpoint` metadata, which
still disqualifies them (`has_setpoint_meta`).

## Testing

Applied and tested live (HACS install, HAOS, core-2026.8.1) on two RF 6600 FP
zones (`widget_behavior.tutorial_id: 6_RecepteurRF_serie6000_1`). After a full
restart:

- `hvac_modes` → `[off, heat]` (was `[off, auto, heat]`)
- `preset_modes` → `[comfort, eco, away, none]` (was raw `NORMAL`/`ECO`/`COMFORT`)
- Presets track `thermicLevel` correctly both ways

Refs #291, #328, #334, #395.