### PR TITLE
Defer TYDOM group updates until entity registration

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5663,7 +5663,12 @@ class HAGroupEntity(HAEntity):
 
     def _handle_member_update(self) -> None:
         """Refresh the native group after a member update."""
-        self.async_write_ha_state()
+        if self._state_updates_ready():
+            self.async_write_ha_state()
+
+    def _state_updates_ready(self) -> bool:
+        """Return whether Home Assistant has fully registered this entity."""
+        return self.hass is not None and getattr(self, "entity_id", None) is not None
 
     def get_sensors(self) -> list:
         """Do not expose internal group membership as sensors."""
@@ -5710,9 +5715,10 @@ class HAGroupEntity(HAEntity):
 
     def refresh_members(self) -> None:
         """Attach members discovered after the group and refresh its HA state."""
+        if not self._state_updates_ready():
+            return
         self._register_member_callbacks()
-        if getattr(self, "entity_id", None) is not None:
-            self._handle_member_update()
+        self._handle_member_update()
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -6011,6 +6017,8 @@ class HALightGroup(LightEntity, HAGroupEntity):
 
     def _handle_member_update(self) -> None:
         """Reconcile an assumed group state with reported member states."""
+        if not self._state_updates_ready():
+            return
         if self._assumed_is_on is not None:
             members = self._member_devices()
             states = self._reported_member_states()
@@ -6135,6 +6143,8 @@ class HACoverGroup(CoverEntity, HAGroupEntity):
 
     def _handle_member_update(self) -> None:
         """Reconcile an assumed group state with reported member positions."""
+        if not self._state_updates_ready():
+            return
         if self._assumed_is_closed is not None:
             members = self._member_devices()
             states = self._reported_member_closed_states()

--- a/tests/test_native_group_entities.py
+++ b/tests/test_native_group_entities.py
@@ -169,7 +169,9 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
             stored_devices[member.device_id] = member
         group = GroupDevice(usage, member_ids)
         hass = SimpleNamespace(hub=SimpleNamespace(devices=stored_devices))
-        return entity_class(group, hass)
+        entity = entity_class(group, hass)
+        entity.entity_id = f"{usage}.all_{usage}s"
+        return entity
 
     async def test_light_group_aggregates_state_and_deduplicates_commands(self) -> None:
         """Report any light on and command each physical member only once."""
@@ -187,7 +189,9 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
         self.assertFalse(entity.is_on)
         entity._clear_assumed_state()
 
-    async def test_light_group_keeps_requested_state_until_members_converge(self) -> None:
+    async def test_light_group_keeps_requested_state_until_members_converge(
+        self,
+    ) -> None:
         """Avoid presenting a stale light state while TYDOM polls each member."""
         first = MemberDevice("1", level=100)
         second = MemberDevice("2", level=100)
@@ -307,6 +311,33 @@ class NativeGroupEntityTests(IsolatedAsyncioTestCase):
         second.register_callback.assert_called_once_with(entity._handle_member_update)
         entity.async_write_ha_state.assert_called_once_with()
         self.assertFalse(entity.is_on)
+
+    def test_group_defers_refresh_until_home_assistant_registration(self) -> None:
+        """Ignore protocol refreshes while Home Assistant is adding the entity."""
+        member = MemberDevice("1", level=0)
+        entity = self._entity(HALightGroup, "light", [member])
+        entity.entity_id = "light.all_lights"
+        entity.hass = None
+        entity.async_write_ha_state = MagicMock()
+
+        entity.refresh_members()
+        entity._handle_member_update()
+
+        member.register_callback.assert_not_called()
+        entity.async_write_ha_state.assert_not_called()
+
+    def test_group_refresh_registration_is_idempotent(self) -> None:
+        """Register each member callback once across repeated refreshes."""
+        member = MemberDevice("1", level=0)
+        entity = self._entity(HALightGroup, "light", [member])
+        entity.entity_id = "light.all_lights"
+        entity.async_write_ha_state = MagicMock()
+
+        entity.refresh_members()
+        entity.refresh_members()
+
+        member.register_callback.assert_called_once_with(entity._handle_member_update)
+        self.assertEqual(entity.async_write_ha_state.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Native TYDOM groups can receive a membership refresh while Home Assistant is still registering their entities. Calling `async_write_ha_state()` at that point raises `RuntimeError: Attribute hass is None`, interrupts integration setup and leaves all entities unavailable.

This change defers group callback registration and state writes until Home Assistant has assigned both `hass` and an `entity_id` to the group entity.

## Changes

- Ignore early group membership refreshes until the entity is fully registered.
- Protect the shared group update callback from premature state writes.
- Apply the same guard to the specialised light and cover group callbacks.
- Keep callback registration idempotent across subsequent refreshes.
- Add regression tests for early initialisation and repeated refreshes.

## Testing

Automated validation:

- Ruff check passes for both modified files.
- Ruff formatting check passes for both modified files.
- All 11 native-group regression tests pass.
- The complete test suite passes: 156 tests and 34 subtests.

Hardware validation was completed by @patoche94 with a Tywell Pro running Home Assistant Core 2026.8.1:

1. The reporter reproduced the failure after upgrading to v0.29, with every integration entity becoming unavailable and the startup log showing `Attribute hass is None` during a TYDOM group refresh.
2. The reporter restored v0.29, replaced only `custom_components/deltadore_tydom/ha_entities.py` with the patched file and restarted Home Assistant.
3. The integration then loaded successfully and all equipment and entities were available again.

The successful result is recorded in issue #397 and in the [HACF testing thread](https://forum.hacf.fr/t/integration-delta-dore-tydom-par-cyrilp/64810/117).

Fixes #397