### PR TITLE
Identify Profalux Zigbee shutters and ignore empty endpoints

### DIFF
--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1326,6 +1326,26 @@ class MessageHandler:
                     has_error = endpoint.get("error", 0) != 0
                     has_data = "data" in endpoint and len(endpoint.get("data", [])) > 0
 
+                    # Some Zigbee gateways advertise a second, non-functional
+                    # endpoint for each physical cover.  A successful endpoint
+                    # with neither state nor capabilities cannot create a useful
+                    # Home Assistant entity.  Keep endpoints with metadata so a
+                    # temporarily silent or offline device is still discovered.
+                    if (
+                        not has_error
+                        and not has_data
+                        and not device_metadata.get(unique_id)
+                        and not endpoint.get("link")
+                    ):
+                        LOGGER.debug(
+                            "Ignoring empty endpoint placeholder "
+                            "(device_id=%s, endpoint_id=%s, name=%s)",
+                            device_id,
+                            endpoint_id,
+                            name_of_id,
+                        )
+                        continue
+
                     if has_error:
                         LOGGER.warning(
                             "Endpoint avec erreur (création quand même) : "

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -218,6 +218,12 @@ def resolve_device_model(
     named product range are accepted. Broad capability profiles retain Home
     Assistant's existing fallback instead of being presented as device models.
     """
+    if usage in {"awning", "klineShutter", "shutter", "swingShutter"}:
+        manufacturer = str((data or {}).get("manufacturer", "")).strip()
+        model_identifier = str((data or {}).get("modelIdentifier", "")).strip()
+        if manufacturer.casefold() == "profalux" and model_identifier:
+            return f"Profalux {model_identifier}"
+
     tutorial = str(tutorial_id or "").strip().casefold()
     if not tutorial:
         if usage == "shutter" and is_tymoov_profile(data):

--- a/tests/test_device_models.py
+++ b/tests/test_device_models.py
@@ -293,6 +293,35 @@ class TestDeviceModels(TestCase):
         metadata.pop("invertOutput")
         self.assertFalse(is_tybox_1137_profile(metadata))
 
+    def test_reported_profalux_zigbee_model(self) -> None:
+        """Profalux covers use the manufacturer and model reported by Zigbee."""
+        for model_identifier in ("MOT-C1Z06F", "MOT-C1Z10F"):
+            with self.subTest(model_identifier=model_identifier):
+                self.assertEqual(
+                    resolve_device_model(
+                        "profalux_stella",
+                        "shutter",
+                        data={
+                            "manufacturer": "Profalux",
+                            "modelIdentifier": model_identifier,
+                        },
+                    ),
+                    f"Profalux {model_identifier}",
+                )
+
+    def test_unrelated_zigbee_descriptor_is_not_used_as_a_model(self) -> None:
+        """Do not turn arbitrary Zigbee descriptors into cover models."""
+        self.assertIsNone(
+            resolve_device_model(
+                "profalux_stella",
+                "shutter",
+                data={
+                    "manufacturer": "Other manufacturer",
+                    "modelIdentifier": "MOT-C1Z06F",
+                },
+            )
+        )
+
 
 class TestDeviceModelApplication(IsolatedAsyncioTestCase):
     """Exercise model application when protocol devices are created."""
@@ -304,6 +333,7 @@ class TestDeviceModelApplication(IsolatedAsyncioTestCase):
         handler_module.device_metadata.clear()
         handler_module.device_tutorial_id.clear()
         handler_module.endpoint_config.clear()
+        self.handler = MessageHandler(MagicMock(), b"")
 
     async def test_resolved_model_is_added_to_device_data(self) -> None:
         """A descriptor-derived model is exposed through productName."""
@@ -366,6 +396,95 @@ class TestDeviceModelApplication(IsolatedAsyncioTestCase):
             )
             self.assertIsNotNone(device)
             self.assertEqual(device.productName, "TYXIA 2600")
+
+    async def test_empty_endpoint_placeholder_is_not_created(self) -> None:
+        """Ignore successful endpoints that expose no state or capabilities."""
+        real_uid = "20_10"
+        placeholder_uid = "11_10"
+        handler_module.device_name.update(
+            {
+                real_uid: "Bedroom shutter",
+                placeholder_uid: "Product 1",
+            }
+        )
+        handler_module.device_type.update(
+            {
+                real_uid: "shutter",
+                placeholder_uid: "shutter",
+            }
+        )
+        handler_module.device_tutorial_id.update(
+            {
+                real_uid: "profalux_stella",
+                placeholder_uid: "profalux_stella",
+            }
+        )
+        handler_module.device_metadata.update(
+            {
+                real_uid: {"position": {"permission": "rw", "unit": "%"}},
+                placeholder_uid: {},
+            }
+        )
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": 10,
+                    "endpoints": [
+                        {
+                            "id": 20,
+                            "error": 0,
+                            "data": [
+                                {
+                                    "name": "manufacturer",
+                                    "value": "Profalux",
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "modelIdentifier",
+                                    "value": "MOT-C1Z06F",
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "position",
+                                    "value": 42,
+                                    "validity": "upToDate",
+                                },
+                            ],
+                        },
+                        {"id": 11, "error": 0, "data": []},
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].device_name, "Bedroom shutter")
+        self.assertEqual(devices[0].productName, "Profalux MOT-C1Z06F")
+
+    async def test_silent_endpoint_with_capabilities_is_preserved(self) -> None:
+        """Keep a temporarily silent endpoint when its capabilities are known."""
+        uid = "20_10"
+        handler_module.device_name[uid] = "Offline shutter"
+        handler_module.device_type[uid] = "shutter"
+        handler_module.device_tutorial_id[uid] = "profalux_stella"
+        handler_module.device_metadata[uid] = {
+            "position": {"permission": "rw", "unit": "%"}
+        }
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": 10,
+                    "endpoints": [{"id": 20, "error": 0, "data": []}],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].device_name, "Offline shutter")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This extends the descriptor-driven model identification introduced in #378 for shutters paired through the Zigbee gateway built into Tydom Pro and Tywell Pro gateways.

The diagnostic capture attached to #397 contains 20 configured Profalux endpoints for 10 physical shutters:

- six shutters report `manufacturer=Profalux` and `modelIdentifier=MOT-C1Z06F`;
- four shutters report `manufacturer=Profalux` and `modelIdentifier=MOT-C1Z10F`;
- each physical shutter is accompanied by an empty `Produit X` endpoint with neither data nor metadata.

Home Assistant currently gives the real shutters a generic Delta Dore model and creates the empty endpoints as additional devices, even though they expose no state or capability.

## Changes

- Derive the model of Profalux covers from the Zigbee `manufacturer` and `modelIdentifier` values reported by the device.
- Expose the observed models as `Profalux MOT-C1Z06F` and `Profalux MOT-C1Z10F` without relying on device IDs or inferred endpoint pairings.
- Ignore a successfully queried, unlinked endpoint when it supplies neither state data nor metadata.
- Preserve endpoints which are temporarily silent but still expose metadata, linked area endpoints and endpoints reporting an error.

The placeholder rule is capability-driven: it does not depend on the French `Produit X` name, a Profalux-specific endpoint number or the numerical distance between the duplicate and the working shutter.

## Evidence

The #397 capture shows that every working shutter exposes `position`, a writable `positionCmd` with `UP`, `DOWN`, `STOP` and `FAVORIT1`, and its Zigbee manufacturer/model descriptors. The ten companion endpoints contain both `data: []` and `metadata: []` and therefore cannot provide a Home Assistant entity.

## Testing

- Added model-resolution tests for both observed Profalux identifiers.
- Added discovery coverage proving that the working shutter is created and receives its reported model while the empty companion endpoint is omitted.
- Added regression coverage proving that a silent endpoint with known capabilities is retained.
- Existing linked Tywell area endpoints remain covered by the complete test suite.
- 150 automated tests pass.
- Ruff checks and formatting pass for `custom_components`.

Hardware validation was completed by @patoche94 on the Tywell Pro installation reported in #397 using the combined test branch:

- all expected TYDOM equipment remained available after a complete Home Assistant restart;
- all ten genuine Profalux shutters were present and functional with their reported models;
- the ten empty `Produit X` endpoints were no longer supplied by the integration, while their previous registry entries correctly became unavailable;
- the sanitised startup evidence confirms that ten empty placeholders were ignored and that the retained shutters reported `MOT-C1Z06F` or `MOT-C1Z10F`.

The obsolete unavailable registry entries can be removed by the user through the device-removal support introduced in #357.

Related to #397
