### PR TITLE
Keep percentage units for TYDOM battery levels

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -463,6 +463,12 @@ class GenericSensor(SensorEntity):
         - Uses stable identifiers from the device API
         - Combines base unique_id with entity-specific identifier for multi-entity devices
         """
+        if device_class == SensorDeviceClass.BATTERY:
+            # Home Assistant battery sensors always represent a percentage.
+            # Some TYDOM devices report ``unit: NA`` for their discrete battery
+            # scale even though the value is converted to a percentage below.
+            unit_of_measurement = PERCENTAGE
+
         self._device = device
         # unique_id format: {device_id}_{entity_name}
         # device_id is stable and unique (endpoint_id + "_" + device_id from Tydom API)
@@ -555,6 +561,9 @@ class GenericSensor(SensorEntity):
         Uses unit from metadata if available, otherwise falls back to
         the unit set during initialization.
         """
+        if self._attr_device_class == SensorDeviceClass.BATTERY:
+            return PERCENTAGE
+
         # First try to get unit from metadata
         if (
             self._device._metadata is not None

--- a/tests/test_cover_position_sensor.py
+++ b/tests/test_cover_position_sensor.py
@@ -52,10 +52,13 @@ def _load_generic_sensor_class():
     namespace = {
         "DOMAIN": "deltadore_tydom",
         "EntityCategory": EntityCategory,
+        "PERCENTAGE": "%",
         "SensorDeviceClass": SensorDeviceClass,
         "SensorEntity": SensorEntity,
         "SensorEntityDescription": SensorEntityDescription,
-        "ranged_value_to_percentage": lambda _range, value: value,
+        "ranged_value_to_percentage": lambda value_range, value: round(
+            (value - value_range[0]) * 100 / (value_range[1] - value_range[0])
+        ),
         "suppress": suppress,
     }
     exec(compile(isolated_module, source_path, "exec"), namespace)
@@ -91,6 +94,29 @@ class CoverPositionSensorTests(TestCase):
         )
 
         self.assertEqual(self._sensor(device).native_value, 64)
+
+    def test_battery_ignores_tydom_na_unit(self) -> None:
+        """Keep the percentage unit for a discrete TYDOM battery level."""
+        device = SimpleNamespace(
+            device_id="tywell_control_1",
+            battLevel=2,
+            _metadata={
+                "battLevel": {"min": 0, "max": 2, "step": 1, "unit": "NA"}
+            },
+        )
+
+        sensor = GenericSensor(
+            device,
+            "battery",
+            "measurement",
+            "battLevel",
+            "battLevel",
+            None,
+        )
+
+        self.assertEqual(sensor.native_value, 100)
+        self.assertEqual(sensor.entity_description.native_unit_of_measurement, "%")
+        self.assertEqual(sensor.native_unit_of_measurement, "%")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The diagnostic log attached to #397 shows Home Assistant warning about the unit of `sensor.thermostat_sejour_battlevel`.

The sensor value itself is already correct: TYDOM reports a discrete `battLevel` from `0` to `2`, which the integration converts to `0%`, `50%` or `100%`. Patoche94 confirmed that a reported value of `2` is displayed as `100%`.

However, the TYDOM metadata declares `unit: NA`. The climate entity gives the resulting generic sensor the Home Assistant battery device class but no initial unit, leaving Home Assistant to see a battery measurement without its required percentage unit during entity registration.

## Changes

- Give every generic Home Assistant battery sensor the native `%` unit when its entity description is created.
- Keep `%` as the runtime unit for battery sensors instead of allowing a TYDOM no-unit marker to replace it.
- Leave the existing range-to-percentage conversion unchanged.
- Leave unit handling for every non-battery sensor unchanged.

## Testing

- Added a regression test reproducing `battLevel=2` with metadata `min=0`, `max=2` and `unit=NA`.
- Confirmed that the resulting state is `100` and both the entity description and runtime unit are `%`.
- 147 automated tests pass.
- Ruff checks and formatting pass for `custom_components`.

Hardware validation was completed by @patoche94 on the Tywell Pro installation reported in #397 using the combined test branch. After a complete Home Assistant restart:

- `sensor.thermostat_sejour_battlevel` still displayed `100%` for the TYDOM value `battLevel=2`;
- the complete startup log contained no Home Assistant unit warning for `battLevel`;
- all expected TYDOM equipment remained available, with no regression observed.

Only this sanitised result is included here; the raw debug log is not reproduced because it contains installation-specific identifiers.

Related to #397
