### PR TITLE
Expose cooling consumption as cumulative energy

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -1727,6 +1727,7 @@ class HAEnergy(SensorEntity, HAEntity):
         "energyInstantDhwI": SensorDeviceClass.CURRENT,
         "energyIndexTi1": SensorDeviceClass.ENERGY,
         "energyTotIndexWatt": SensorDeviceClass.ENERGY,
+        "energyIndexCoolWatt": SensorDeviceClass.ENERGY,
         "energyIndexHeatWatt": SensorDeviceClass.ENERGY,
         "energyIndexECSWatt": SensorDeviceClass.ENERGY,
         "energyIndexHeatGas": SensorDeviceClass.ENERGY,
@@ -1744,6 +1745,7 @@ class HAEnergy(SensorEntity, HAEntity):
         # Total increasing for energy counters
         "energyIndexTi1": SensorStateClass.TOTAL_INCREASING,
         "energyTotIndexWatt": SensorStateClass.TOTAL_INCREASING,
+        "energyIndexCoolWatt": SensorStateClass.TOTAL_INCREASING,
         "energyIndexECSWatt": SensorStateClass.TOTAL_INCREASING,
         "energyIndexHeatWatt": SensorStateClass.TOTAL_INCREASING,
         "energyIndexHeatGas": SensorStateClass.TOTAL_INCREASING,
@@ -1812,6 +1814,7 @@ class HAEnergy(SensorEntity, HAEntity):
         "energyInstantDhwI": UnitOfElectricCurrent.AMPERE,
         "energyIndexTi1": UnitOfEnergy.WATT_HOUR,
         "energyTotIndexWatt": UnitOfEnergy.WATT_HOUR,
+        "energyIndexCoolWatt": UnitOfEnergy.WATT_HOUR,
         "energyIndexHeatWatt": UnitOfEnergy.WATT_HOUR,
         "energyIndexECSWatt": UnitOfEnergy.WATT_HOUR,
         "energyIndexHeatGas": UnitOfEnergy.WATT_HOUR,

--- a/tests/test_energy_sensor_metadata.py
+++ b/tests/test_energy_sensor_metadata.py
@@ -1,0 +1,64 @@
+"""Regression tests for cumulative TYDOM energy sensor metadata."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest import TestCase
+
+
+def _energy_mapping(name: str) -> dict[str, str]:
+    """Return one HAEnergy class mapping without importing Home Assistant."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    energy_class = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "HAEnergy"
+    )
+    assignment = next(
+        node
+        for node in energy_class.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        )
+    )
+    assert isinstance(assignment.value, ast.Dict)
+    return {
+        ast.literal_eval(key): ast.unparse(value)
+        for key, value in zip(
+            assignment.value.keys, assignment.value.values, strict=True
+        )
+    }
+
+
+class EnergySensorMetadataTests(TestCase):
+    """Ensure every cumulative heat-pump index is Energy-compatible."""
+
+    def test_cooling_index_matches_heating_and_dhw_metadata(self) -> None:
+        """Expose the cooling counter directly to the Energy dashboard."""
+        self.assertEqual(
+            _energy_mapping("sensor_classes")["energyIndexCoolWatt"],
+            "SensorDeviceClass.ENERGY",
+        )
+        self.assertEqual(
+            _energy_mapping("state_classes")["energyIndexCoolWatt"],
+            "SensorStateClass.TOTAL_INCREASING",
+        )
+        self.assertEqual(
+            _energy_mapping("units")["energyIndexCoolWatt"],
+            "UnitOfEnergy.WATT_HOUR",
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Summary

The hardware log attached to #397 exposes three cumulative heat-pump energy indexes on the same endpoint:

- `energyIndexCoolWatt` for cooling;
- `energyIndexHeatWatt` for heating;
- `energyIndexECSWatt` for domestic hot water.

TYDOM describes all three as numeric, read-only counters with `METER_SUPERVISION` validity and the native `Wh` unit. The integration already assigns the correct Home Assistant energy metadata to the heating and domestic-hot-water indexes, but the cooling index was omitted. Consequently, the native cooling sensor cannot be selected directly in the Home Assistant Energy dashboard.

## Changes

- Assign `SensorDeviceClass.ENERGY` to `energyIndexCoolWatt`.
- Assign `SensorStateClass.TOTAL_INCREASING` to the cumulative cooling counter.
- Preserve its native `Wh` unit through `UnitOfEnergy.WATT_HOUR`.
- Leave every other energy measurement and conversion unchanged.

The correction is capability-based and applies to any TYDOM endpoint exposing `energyIndexCoolWatt`; it does not depend on a particular heat-pump model or device identifier.

## Testing

- Added a regression test confirming the device class, state class and native unit of the cooling index.
- All 165 automated tests pass.
- Ruff checks and formatting pass for `custom_components` and the new regression test.
- `git diff --check` passes.

Hardware validation was completed by @patoche94 on the Tywell Pro installation reported in #397:

- the native `energyIndexCoolWatt` sensor became directly selectable in the Home Assistant Energy dashboard;
- this was not possible before the correction and previously required a template sensor;
- the next value refresh was still pending at the time of confirmation, which is expected because the cumulative counter follows the TYDOM equipment's own reporting schedule.

This confirms the Home Assistant energy metadata and dashboard compatibility on the reported hardware.

Related to #397