### PR TITLE
Preserve valid data from endpoints reporting errors

### DIFF
--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1325,6 +1325,12 @@ class MessageHandler:
                     # Check for errors or missing data, but still try to create device
                     has_error = endpoint.get("error", 0) != 0
                     has_data = "data" in endpoint and len(endpoint.get("data", [])) > 0
+                    valid_data = [
+                        elem
+                        for elem in endpoint.get("data", [])
+                        if elem.get("validity") == "upToDate"
+                    ]
+                    has_valid_data = bool(valid_data)
 
                     # Some Zigbee gateways advertise a second, non-functional
                     # endpoint for each physical cover.  A successful endpoint
@@ -1355,7 +1361,7 @@ class MessageHandler:
                             endpoint.get("error"),
                         )
 
-                    if not has_data:
+                    if not has_valid_data:
                         LOGGER.warning(
                             "Endpoint sans données valides (création avec état par défaut) : "
                             "device_id=%s, endpoint_id=%s, name=%s",
@@ -1402,15 +1408,13 @@ class MessageHandler:
                                 reference_uid
                             ] = reference
 
-                        # Only process data if available and valid
-                        if has_data and not has_error:
-                            for elem in endpoint["data"]:
+                        # Endpoint-level errors can accompany usable values. Trust
+                        # each field's validity instead of discarding the full payload.
+                        if has_valid_data:
+                            for elem in valid_data:
                                 element_name = elem["name"]
                                 element_value = elem["value"]
-                                element_validity = elem["validity"]
-
-                                if element_validity == "upToDate":
-                                    data[element_name] = element_value
+                                data[element_name] = element_value
 
                         if (
                             area_id is not None
@@ -1435,7 +1439,7 @@ class MessageHandler:
                                 "device_id": device_id,
                                 "endpoint_id": endpoint_id,
                             }
-                            if has_data and not has_error:
+                            if has_valid_data:
                                 LOGGER.info(
                                     "Device update (id=%s, endpoint=%s, name=%s, type=%s)",
                                     device_id,

--- a/tests/test_device_models.py
+++ b/tests/test_device_models.py
@@ -486,6 +486,60 @@ class TestDeviceModelApplication(IsolatedAsyncioTestCase):
         self.assertEqual(len(devices), 1)
         self.assertEqual(devices[0].device_name, "Offline shutter")
 
+    async def test_valid_values_survive_endpoint_error(self) -> None:
+        """Keep individually valid values when TYDOM flags the endpoint."""
+        uid = "20_10"
+        handler_module.device_name[uid] = "Typass ATL"
+        handler_module.device_type[uid] = "boiler"
+        handler_module.device_metadata[uid] = {
+            "authorization": {"enum_values": ["STOP", "HEATING"]},
+            "heatSetpoint": {"permission": "rw", "unit": "degC"},
+            "ambientTemperature": {"permission": "r", "unit": "degC"},
+        }
+
+        devices = await self.handler.parse_devices_data(
+            [
+                {
+                    "id": 10,
+                    "endpoints": [
+                        {
+                            "id": 20,
+                            "error": 1,
+                            "data": [
+                                {
+                                    "name": "authorization",
+                                    "value": "HEATING",
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "heatSetpoint",
+                                    "value": 19.0,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "ambientTemperature",
+                                    "value": 29.73,
+                                    "validity": "upToDate",
+                                },
+                                {
+                                    "name": "overrideSetpoint",
+                                    "value": 21.0,
+                                    "validity": "expired",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].authorization, "HEATING")
+        self.assertEqual(devices[0].heatSetpoint, 19.0)
+        self.assertEqual(devices[0].ambientTemperature, 29.73)
+        self.assertFalse(hasattr(devices[0], "overrideSetpoint"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Some TYDOM endpoints return a non-zero endpoint-level error while still providing individual values marked as upToDate.

The current parser discards the entire endpoint payload whenever error is non-zero. This can cause valid heating values such as authorization, heatSetpoint, and ambientTemperature to be lost, leaving the associated climate entity with its default or unavailable state.

## Changes

- Continue logging the endpoint-level error.
- Process individual values whose validity is upToDate.
- Continue ignoring expired or otherwise invalid values.
- Report the device as updated when at least one valid value was processed.
- Add a regression test based on an errored heating endpoint.

## Rationale

The exact meaning of TYDOM endpoint error code 1 is not publicly documented. Observed responses can nevertheless contain both error: 1 and current field values marked validity: upToDate.

Because validity is supplied for each individual value, it provides a more granular indication of whether that value is usable. The endpoint warning is retained so genuine communication problems remain visible.

## Testing

- Added a test confirming that upToDate values survive error: 1.
- Confirmed that an expired value from the same response is ignored.
- Full upstream-based suite: 174 passed and 36 subtests passed.
- Ruff lint and formatting checks passed.
- Hassfest and HACS validation passed on the combined test branch.