### PR TITLE
Allow direct TYXAL alarm profile transitions

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1250,26 +1250,71 @@ class TydomAlarm(TydomDevice):
             return True
         return False
 
-    def get_alarm_mode_from_zones(self) -> str | None:
-        """Identify the configured alarm mode from the active zones."""
+    @staticmethod
+    def _parse_alarm_zones(value: Any) -> set[int]:
+        """Return the configured comma-separated alarm zones."""
+        if not value:
+            return set()
+        return {int(zone.strip()) for zone in str(value).split(",") if zone.strip()}
 
-        def parse_zones(value) -> set[int]:
-            if not value:
-                return set()
-
-            return {int(zone.strip()) for zone in str(value).split(",") if zone.strip()}
-
-        active_zones = {
+    def _active_alarm_zones(self) -> set[int]:
+        """Return the zones currently reported as armed by the central unit."""
+        if getattr(self, "alarmMode", None) == "OFF":
+            return set()
+        return {
             zone
             for zone in range(1, 9)
             if getattr(self, f"part{zone}State", "OFF") == "ON"
             or getattr(self, f"zone{zone}State", "OFF") == "ON"
         }
 
+    async def _set_alarm_profile(self, code: str | None, configured_zones: Any) -> None:
+        """Transition to one configured profile without globally disarming."""
+        target_zones = self._parse_alarm_zones(configured_zones)
+        legacy = self.is_legacy_alarm()
+
+        # An empty profile retains the existing global alarmCmd behaviour. It
+        # means "all zones" on installations which do not configure explicit
+        # Away/Home/Night zone lists, rather than an empty desired zone set.
+        if not target_zones:
+            await self._tydom_client.put_alarm_cdata(
+                self._id, self._endpoint, code, "ON", configured_zones, legacy
+            )
+            return
+
+        active_zones = self._active_alarm_zones()
+        zones_to_enable = target_zones - active_zones
+        zones_to_disable = active_zones - target_zones
+
+        # Extend protection before removing surplus coverage so zones shared
+        # by both profiles remain armed throughout the transition.
+        if zones_to_enable:
+            await self._tydom_client.put_alarm_cdata(
+                self._id,
+                self._endpoint,
+                code,
+                "ON",
+                ",".join(str(zone) for zone in sorted(zones_to_enable)),
+                legacy,
+            )
+        if zones_to_disable:
+            await self._tydom_client.put_alarm_cdata(
+                self._id,
+                self._endpoint,
+                code,
+                "OFF",
+                ",".join(str(zone) for zone in sorted(zones_to_disable)),
+                legacy,
+            )
+
+    def get_alarm_mode_from_zones(self) -> str | None:
+        """Identify the configured alarm mode from the active zones."""
+        active_zones = self._active_alarm_zones()
+
         configured_modes = (
-            ("night", parse_zones(self._tydom_client._zone_night)),
-            ("home", parse_zones(self._tydom_client._zone_home)),
-            ("away", parse_zones(self._tydom_client._zone_away)),
+            ("night", self._parse_alarm_zones(self._tydom_client._zone_night)),
+            ("home", self._parse_alarm_zones(self._tydom_client._zone_home)),
+            ("away", self._parse_alarm_zones(self._tydom_client._zone_away)),
         )
 
         for mode, configured_zones in configured_modes:
@@ -1287,38 +1332,17 @@ class TydomAlarm(TydomDevice):
 
     async def alarm_arm_away(self, code=None) -> None:
         """Arm away alarm."""
-        await self._tydom_client.put_alarm_cdata(
-            self._id,
-            self._endpoint,
-            code,
-            "ON",
-            self._tydom_client._zone_away,
-            self.is_legacy_alarm(),
-        )
+        await self._set_alarm_profile(code, self._tydom_client._zone_away)
         # self._tydom_client.add_poll_device_url_1s(f"/devices/{self._id}/endpoints/{self._endpoint}/cdata")
 
     async def alarm_arm_home(self, code=None) -> None:
         """Arm home alarm."""
-        await self._tydom_client.put_alarm_cdata(
-            self._id,
-            self._endpoint,
-            code,
-            "ON",
-            self._tydom_client._zone_home,
-            self.is_legacy_alarm(),
-        )
+        await self._set_alarm_profile(code, self._tydom_client._zone_home)
         # self._tydom_client.add_poll_device_url_1s(f"/devices/{self._id}/endpoints/{self._endpoint}/cdata")
 
     async def alarm_arm_night(self, code=None) -> None:
         """Arm night alarm."""
-        await self._tydom_client.put_alarm_cdata(
-            self._id,
-            self._endpoint,
-            code,
-            "ON",
-            self._tydom_client._zone_night,
-            self.is_legacy_alarm(),
-        )
+        await self._set_alarm_profile(code, self._tydom_client._zone_night)
 
     async def alarm_trigger(self, code=None) -> None:
         """Trigger the alarm.

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -112,6 +112,117 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertFalse(binary_light.supports_brightness)
         self.assertTrue(dimmable_light.supports_brightness)
 
+    @staticmethod
+    def _profile_alarm(data: dict[str, str]) -> tuple[object, MagicMock]:
+        """Return an alarm with configurable profiles and live zone states."""
+        client = MagicMock()
+        client._zone_home = "3"
+        client._zone_night = "1,3"
+        client._zone_away = "1,2,3"
+        client.put_alarm_cdata = AsyncMock()
+        alarm = TydomAlarm(
+            client, "10_20", "20", "Alarm", "alarm", "10", {}, data
+        )
+        return alarm, client
+
+    async def test_alarm_profile_reduction_disables_only_surplus_zones(self) -> None:
+        """Away to Night must remove zone 2 without a global disarm."""
+        alarm, client = self._profile_alarm(
+            {"zone1State": "ON", "zone2State": "ON", "zone3State": "ON"}
+        )
+
+        await alarm.alarm_arm_night("123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "OFF", "2", False
+        )
+
+    async def test_alarm_profile_additions_precede_removals(self) -> None:
+        """A profile replacement must extend protection before reducing it."""
+        alarm, client = self._profile_alarm(
+            {"zone1State": "ON", "zone2State": "ON", "zone3State": "OFF"}
+        )
+        client._zone_home = "2,3"
+
+        await alarm.alarm_arm_home("123456")
+
+        self.assertEqual(
+            client.put_alarm_cdata.await_args_list,
+            [
+                call("20", "10", "123456", "ON", "3", False),
+                call("20", "10", "123456", "OFF", "1", False),
+            ],
+        )
+
+    async def test_alarm_profile_from_disarmed_enables_target_zones(self) -> None:
+        """Arming from OFF must enable the complete configured profile."""
+        alarm, client = self._profile_alarm(
+            {"zone1State": "OFF", "zone2State": "OFF", "zone3State": "OFF"}
+        )
+
+        await alarm.alarm_arm_home("123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "ON", "3", False
+        )
+
+    async def test_disarmed_mode_ignores_stale_zone_states(self) -> None:
+        """Explicit OFF mode must override zone values left over from arming."""
+        alarm, client = self._profile_alarm(
+            {"alarmMode": "OFF", "zone1State": "ON", "zone3State": "ON"}
+        )
+
+        await alarm.alarm_arm_home("123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "ON", "3", False
+        )
+
+    async def test_empty_alarm_profile_retains_global_arm_command(self) -> None:
+        """An unconfigured zone list must keep the established global command."""
+        alarm, client = self._profile_alarm({"zone1State": "OFF"})
+        client._zone_away = ""
+
+        await alarm.alarm_arm_away("123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "ON", "", False
+        )
+
+    async def test_alarm_profile_uses_updated_integration_configuration(self) -> None:
+        """Profile calculations must use current integration option values."""
+        alarm, client = self._profile_alarm(
+            {"zone1State": "ON", "zone2State": "OFF"}
+        )
+        client._zone_home = "2"
+
+        await alarm.alarm_arm_home("123456")
+
+        self.assertEqual(
+            client.put_alarm_cdata.await_args_list,
+            [
+                call("20", "10", "123456", "ON", "2", False),
+                call("20", "10", "123456", "OFF", "1", False),
+            ],
+        )
+
+    async def test_legacy_alarm_profiles_use_part_commands(self) -> None:
+        """Legacy alarm transitions must retain the part-command dispatcher."""
+        alarm, client = self._profile_alarm(
+            {"part1State": "ON", "part2State": "ON", "part3State": "OFF"}
+        )
+        client._zone_night = "2,3"
+
+        await alarm.alarm_arm_night("123456")
+
+        self.assertEqual(
+            client.put_alarm_cdata.await_args_list,
+            [
+                call("20", "10", "123456", "ON", "3", True),
+                call("20", "10", "123456", "OFF", "1", True),
+            ],
+        )
+
     async def test_alarm_inventory_merges_labels_and_technical_data(self) -> None:
         """Inventory responses should be useful without exposing other labels."""
         client = MagicMock()


### PR DESCRIPTION
Fixes #407.

## Summary

Treat the configured Home, Night and Away alarm profiles as desired final zone sets, allowing an already armed TYXAL system to move directly between profiles without a global disarm.

## Problem

The integration previously sent `ON` for every zone in the requested profile. This could extend coverage, but it could not reduce it. For example, moving from Away `[1,2,3]` to Night `[1,3]` sent `ON` for zones 1 and 3, leaving zone 2 armed.

The only workaround was a global disarm followed by rearming in the desired mode, temporarily leaving all zones unprotected.

## Changes

- Read the live `zone1State`…`zone8State` values, or legacy `part1State`…`part8State` values.
- Read the requested Home, Night or Away zone set from the integration's current configuration.
- Send `ON` only for missing target zones.
- Send `OFF` only for active zones which are not part of the target profile.
- Enable missing protection before removing surplus zones.
- Preserve the existing global arm command when a profile has no explicit zone list.
- Treat an explicit `alarmMode: OFF` as disarmed even if stale zone attributes remain.
- Retain the legacy `partCmd` dispatcher for older alarm systems.

No zone numbers or profile definitions are hard-coded. Changing the integration's configured zone lists automatically changes the calculated transitions.

## Safety

Profile changes never call the global `alarmCmd=OFF`. Zones shared by the current and target profiles remain armed throughout the transition.

## Automated testing

Coverage includes:

- reducing Away `[1,2,3]` to Night `[1,3]` by disabling only zone 2;
- enabling missing zones before disabling surplus zones;
- arming a complete profile from the disarmed state;
- ignoring stale zone states when `alarmMode` explicitly reports `OFF`;
- retaining global arming for an empty configured zone list;
- using profile values changed through the integration configuration;
- preserving legacy part-based alarm commands.

Validation completed:

- 180 automated tests and 36 subtests pass;
- Ruff checks pass;
- Ruff formatting passes for the changed integration file;
- `git diff --check` passes.

## Hardware validation

Successfully tested by the reporter on a real TYXAL installation using the combined test branch.

The following direct transitions produced the expected live zone states in both Home Assistant and the official TYDOM application:

- Away → Night: only the surplus Upstairs zone was disabled;
- Night → Away: the missing Upstairs zone was enabled;
- Away → Home: only the target Basement zone remained armed;
- Home → Night: the missing Ground-floor zone was enabled while the Basement remained armed.

Away, Night and Home were also tested successfully from the disarmed state. The reporter then changed the Home profile from three zones to two through the integration options; the next arm operation immediately respected the updated configuration.

Sanitised log evidence confirmed acknowledged `zoneCmd` operations and the corresponding `marcheZone`, `arretZone` and `marcheTotale` events for the requested transitions.
