### PR TITLE
Fix TYDOM2 alarm acknowledgement transport

### DIFF
--- a/custom_components/deltadore_tydom/alarm_control_panel.py
+++ b/custom_components/deltadore_tydom/alarm_control_panel.py
@@ -21,6 +21,7 @@ SERVICE_CONFIGURE_ALARM_PRODUCT = "configure_alarm_product"
 SERVICE_RENAME_ALARM_ZONE = "rename_alarm_zone"
 SERVICE_ENTER_ALARM_MAINTENANCE = "enter_alarm_maintenance"
 SERVICE_EXIT_ALARM_MAINTENANCE = "exit_alarm_maintenance"
+SERVICE_FORCE_ARM = "force_arm"
 
 ALARM_CODE_SCHEMA = vol.All(
     cv.string,
@@ -113,4 +114,13 @@ async def async_setup_entry(
             vol.Required("name"): vol.All(cv.string, str.strip, vol.Length(max=64)),
         },
         "async_rename_alarm_zone",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_FORCE_ARM,
+        {
+            vol.Required("code"): ALARM_CODE_SCHEMA,
+            vol.Required("mode"): vol.In(("away", "home", "night")),
+        },
+        "async_force_arm",
     )

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -127,6 +127,7 @@ _BINARY_TRUE_VALUES = frozenset({"1", "on", "true", "yes"})
 _BINARY_FALSE_VALUES = frozenset({"0", "off", "false", "no"})
 _PROBLEM_ATTRIBUTE_MARKERS = ("defect", "empty", "intrusion")
 _BINARY_OPEN_STATES = frozenset({"LOCKED", "UNLOCKED"})
+_AUTOMATIC_ALARM_HISTORY_TIMEOUT = 10.0
 
 
 def normalize_binary_state(value: Any, *, allow_numeric: bool = False) -> bool | None:
@@ -6468,6 +6469,7 @@ class HAAlarmPendingEventsSensor(SensorEntity, HAEntity):
         self._attr_unique_id = f"{device.device_id}_pending_alarm_events"
         self._last_unacked_state = bool(getattr(device, "unackedEvent", False))
         self._refresh_task = None
+        self._automatic_history_supported = True
 
     @property
     def native_value(self) -> int | None:
@@ -6532,6 +6534,8 @@ class HAAlarmPendingEventsSensor(SensorEntity, HAEntity):
 
     def _schedule_refresh(self) -> None:
         """Schedule one history request without delaying entity setup."""
+        if not self._automatic_history_supported:
+            return
         if self._refresh_task is None or self._refresh_task.done():
             self._refresh_task = self.hass.async_create_task(
                 self._async_refresh_events(),
@@ -6541,11 +6545,21 @@ class HAAlarmPendingEventsSensor(SensorEntity, HAEntity):
     async def _async_refresh_events(self) -> None:
         """Fetch the bounded list advertised by the TYXAL history endpoint."""
         try:
-            await self._device.get_events("UNACKED_EVENTS")
+            await self._device.get_events(
+                "UNACKED_EVENTS",
+                timeout=_AUTOMATIC_ALARM_HISTORY_TIMEOUT,
+                log_timeout=False,
+            )
         except Exception:
-            LOGGER.exception(
-                "Unable to refresh unacknowledged events for %s",
+            # Some TYDOM2 gateways expose ``unackedEvent`` but never answer
+            # the optional detailed-history request. Probe once per load, then
+            # retain the pushed boolean as the authoritative state.
+            self._automatic_history_supported = False
+            LOGGER.debug(
+                "Detailed unacknowledged-event history is unavailable for %s; "
+                "automatic refresh disabled until the integration is reloaded",
                 self._device.device_id,
+                exc_info=True,
             )
 
 

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -109,6 +109,7 @@ from .tydom.tydom_devices import (
     TydomMoment,
     TydomRemoteControl,
     TydomInterrupter,
+    TydomAlarmCommandError,
     get_twc_scene_action,
 )
 
@@ -3518,23 +3519,48 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
 
     async def async_alarm_disarm(self, code=None) -> None:
         """Send disarm command."""
-        await self._device.alarm_disarm(code)
+        await self._run_alarm_command(self._device.alarm_disarm(code), "disarming")
 
     async def async_alarm_arm_away(self, code=None) -> None:
         """Send arm away command."""
-        await self._device.alarm_arm_away(code)
+        await self._run_alarm_command(self._device.alarm_arm_away(code), "arming")
 
     async def async_alarm_arm_home(self, code=None) -> None:
         """Send arm home command."""
-        await self._device.alarm_arm_home(code)
+        await self._run_alarm_command(self._device.alarm_arm_home(code), "arming")
 
     async def async_alarm_arm_night(self, code=None) -> None:
         """Send arm night command."""
-        await self._device.alarm_arm_night(code)
+        await self._run_alarm_command(self._device.alarm_arm_night(code), "arming")
 
     async def async_alarm_trigger(self, code=None) -> None:
         """Send alarm trigger command."""
-        await self._device.alarm_trigger(code)
+        await self._run_alarm_command(self._device.alarm_trigger(code), "triggering")
+
+    async def _run_alarm_command(self, command, operation: str) -> None:
+        """Run an alarm command and expose a negative gateway result in HA."""
+        try:
+            await command
+        except TydomAlarmCommandError as err:
+            if err.result == "DENIED":
+                raise HomeAssistantError(
+                    f"The alarm system refused {operation}. Check the reported "
+                    "defects before trying again."
+                ) from err
+            raise HomeAssistantError(
+                f"The alarm system rejected {operation} ({err.result})."
+            ) from err
+
+    async def async_force_arm(self, code: str, mode: str) -> None:
+        """Force arming only after an explicit Home Assistant action."""
+        try:
+            await self._device.force_arm(mode, code)
+        except ValueError as err:
+            raise HomeAssistantError(str(err)) from err
+        except TydomAlarmCommandError as err:
+            raise HomeAssistantError(
+                f"The alarm system rejected forced arming ({err.result})."
+            ) from err
 
     async def async_acknowledge_events(self, code=None) -> None:
         """Acknowledge alarm events."""

--- a/custom_components/deltadore_tydom/services.yaml
+++ b/custom_components/deltadore_tydom/services.yaml
@@ -5,6 +5,34 @@ acknowledge_events:
     entity:
       integration: deltadore_tydom
       domain: alarm_control_panel
+force_arm:
+  name: Force arm alarm
+  description: Explicitly force the selected alarm mode despite defects that caused normal arming to be refused. Use only after checking those defects.
+  target:
+    entity:
+      integration: deltadore_tydom
+      domain: alarm_control_panel
+  fields:
+    code:
+      name: TYXAL user code
+      description: User code authorised to arm the alarm.
+      required: true
+      selector:
+        text:
+          type: password
+    mode:
+      name: Arming mode
+      description: Configured Home Assistant alarm mode to force.
+      required: true
+      selector:
+        select:
+          options:
+            - label: Away
+              value: away
+            - label: Home
+              value: home
+            - label: Night
+              value: night
 get_events:
   name: Get alarm events
   description: Retrieve alarm events from the system. Returns a list of events based on the selected filter.

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -157,6 +157,14 @@
             "name": "Acknowledge defect events",
             "description": "Acknowledge all defect alarm events."
         },
+        "force_arm": {
+            "name": "Force arm alarm",
+            "description": "Explicitly force an alarm mode despite defects that caused normal arming to be refused.",
+            "fields": {
+                "code": {"name": "TYXAL user code", "description": "User code authorised to arm the alarm."},
+                "mode": {"name": "Arming mode", "description": "Configured Home Assistant alarm mode to force."}
+            }
+        },
         "get_events": {
             "name": "Get alarm events",
             "description": "Get alarm events",

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -158,6 +158,14 @@
             "name": "Acquitter les événements de défaut",
             "description": "Acquitter tous les événements d'alarme de défaut."
         },
+        "force_arm": {
+            "name": "Forcer la mise en marche de l'alarme",
+            "description": "Forcer explicitement un mode d'alarme malgré les défauts ayant entraîné le refus de la mise en marche normale.",
+            "fields": {
+                "code": {"name": "Code utilisateur TYXAL", "description": "Code utilisateur autorisé à mettre l'alarme en marche."},
+                "mode": {"name": "Mode de mise en marche", "description": "Mode d'alarme Home Assistant configuré à forcer."}
+            }
+        },
         "get_events": {
             "name": "Obtenir les événements d'alarme",
             "description": "Obtenir les événements d'alarme",

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -419,6 +419,9 @@ class MessageHandler:
         self._cdata_replies: list[Reply] = []
         self._end_reply_events: dict[str, asyncio.Event] = {}
         self._reply_errors: dict[str, str] = {}
+        self._alarm_command_waiters: dict[
+            tuple[str, str, str], list[asyncio.Future[dict[str, Any]]]
+        ] = {}
         self._area_devices: dict[str, dict[str, AreaDeviceReference]] = {}
         self._area_data: dict[str, dict[str, Any]] = {}
         self._area_metadata: dict[str, dict] = {}
@@ -479,6 +482,49 @@ class MessageHandler:
     def get_reply_error(self, transaction_id: str) -> str | None:
         """Return and forget a protocol error for one pending request."""
         return self._reply_errors.pop(transaction_id, None)
+
+    def create_alarm_command_waiter(
+        self, device_id: str, endpoint_id: str, command: str
+    ) -> asyncio.Future[dict[str, Any]]:
+        """Wait for an asynchronous alarm command result broadcast by TYDOM."""
+        key = (str(device_id), str(endpoint_id), command)
+        waiter = asyncio.get_running_loop().create_future()
+        self._alarm_command_waiters.setdefault(key, []).append(waiter)
+        return waiter
+
+    def remove_alarm_command_waiter(
+        self,
+        device_id: str,
+        endpoint_id: str,
+        command: str,
+        waiter: asyncio.Future[dict[str, Any]],
+    ) -> None:
+        """Remove one alarm command waiter after completion or timeout."""
+        key = (str(device_id), str(endpoint_id), command)
+        waiters = self._alarm_command_waiters.get(key)
+        if not waiters:
+            return
+        with contextlib.suppress(ValueError):
+            waiters.remove(waiter)
+        if not waiters:
+            self._alarm_command_waiters.pop(key, None)
+
+    def _resolve_alarm_command_waiter(
+        self, device_id: str, endpoint_id: str, element: dict[str, Any]
+    ) -> None:
+        """Deliver a Transac-Id 0 alarm result to the command that sent it."""
+        command = element.get("name")
+        if not command or (element.get("values") or {}).get("result") is None:
+            return
+        key = (str(device_id), str(endpoint_id), command)
+        waiters = self._alarm_command_waiters.get(key)
+        while waiters:
+            waiter = waiters.pop(0)
+            if not waiter.done():
+                waiter.set_result(element)
+                break
+        if not waiters:
+            self._alarm_command_waiters.pop(key, None)
 
     def _complete_empty_cdata_reply(self, transaction_id: str) -> None:
         """Complete an EOR-only reply unless late TYXAL data completed it first."""
@@ -1603,10 +1649,18 @@ class MessageHandler:
                         data = {}
 
                         for elem in endpoint["cdata"]:
+                            if type_of_id == "alarm":
+                                self._resolve_alarm_command_waiter(
+                                    device_id, endpoint_id, elem
+                                )
+
                             if type_of_id == "conso":
                                 data.update(_parse_energy_cdata_element(elem))
 
-                            elif type_of_id == "alarm" and transaction_id is not None:
+                            elif type_of_id == "alarm" and transaction_id not in (
+                                None,
+                                "0",
+                            ):
                                 reply = None
                                 for r in self._cdata_replies:
                                     if r["transaction_id"] == transaction_id:

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -138,6 +138,7 @@ device_name = {}
 device_endpoint = {}
 device_type = {}
 device_metadata = {}
+device_command_metadata = {}
 device_tutorial_id = {}
 interrupter_endpoint_config = {}
 interrupter_info = {}
@@ -962,6 +963,7 @@ class MessageHandler:
                     endpoint,
                     device_metadata.get(uid),
                     data,
+                    command_metadata=device_command_metadata.get(uid),
                 )
             case "weather":
                 weather_device = TydomWeather(
@@ -1184,8 +1186,15 @@ class MessageHandler:
         LOGGER.debug("parse_cmeta_data : %s", parsed)
         for i in parsed:
             for endpoint in i["endpoints"]:
-                if len(endpoint["cmetadata"]) > 0:
-                    for elem in endpoint["cmetadata"]:
+                command_metadata = endpoint.get("cmetadata", [])
+                unique_id = f"{endpoint['id']}_{i['id']}"
+                device_command_metadata[unique_id] = {
+                    elem["name"]: elem
+                    for elem in command_metadata
+                    if isinstance(elem, dict) and elem.get("name")
+                }
+                if len(command_metadata) > 0:
+                    for elem in command_metadata:
                         if elem["name"] == "energyIndex":
                             for params in elem["parameters"]:
                                 if params["name"] == "dest":

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -37,7 +37,7 @@ from .const import (
     DELTADORE_AUTH_URL,
     MEDIATION_URL,
 )
-from .MessageHandler import MessageHandler
+from .MessageHandler import MessageHandler, TydomAlarmCommandError
 
 if TYPE_CHECKING:
     from .tydom_devices import TydomDevice
@@ -1516,55 +1516,43 @@ class TydomClient:
         else:
             pin = alarm_pin
 
-        try:
-            if zone_id is None or zone_id == "":
-                cmd = "alarmCmd"
-                body = json.dumps({"value": str(value), "pwd": str(pin)})
-            else:
-                if legacy_zones:
-                    cmd = "partCmd"
-                    body = json.dumps({"value": str(value), "part": str(zone_id)})
-                else:
-                    cmd = "zoneCmd"
-                    zones = [
-                        int(zone.strip())
-                        for zone in str(zone_id).split(",")
-                        if zone.strip()
-                    ]
-                    body = json.dumps(
-                        {"value": str(value), "pwd": str(pin), "zones": zones}
-                    )
+        if zone_id is None or zone_id == "":
+            cmd = "alarmCmd"
+            body = {"value": str(value), "pwd": str(pin)}
+        elif legacy_zones:
+            cmd = "partCmd"
+            body = {"value": str(value), "part": str(zone_id)}
+        else:
+            cmd = "zoneCmd"
+            zones = [
+                int(zone.strip()) for zone in str(zone_id).split(",") if zone.strip()
+            ]
+            body = {"value": str(value), "pwd": str(pin), "zones": zones}
 
-            safe_device_id = quote(str(device_id), safe="")
-            safe_endpoint_id = quote(str(endpoint_id), safe="")
-            safe_cmd = quote(str(cmd), safe="")
-            str_request = (
-                f"PUT /devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata?name={safe_cmd} HTTP/1.1\r\nContent-Length: "
-                + str(len(body))
-                + "\r\nContent-Type: application/json; charset=UTF-8\r\nTransac-Id: 0\r\n\r\n"
-                + body
-                + "\r\n\r\n"
+        safe_device_id = quote(str(device_id), safe="")
+        safe_endpoint_id = quote(str(endpoint_id), safe="")
+        safe_cmd = quote(cmd, safe="")
+        replies = await self.get_reply_to_request(
+            "PUT",
+            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata?name={safe_cmd}",
+            body=body,
+        )
+
+        result = next(
+            (
+                str(reply.get("values", {}).get("result"))
+                for reply in replies or []
+                if reply.get("name") == cmd
+                and reply.get("values", {}).get("result") is not None
+            ),
+            None,
+        )
+        if result is None:
+            raise TydomClientApiClientCommunicationError(
+                f"No command result received for {cmd}"
             )
-
-            a_bytes = self._cmd_prefix + bytes(str_request, "ascii")
-            LOGGER.debug("Sending message to tydom (%s)", "PUT cdata")
-
-            try:
-                if not file_mode:
-                    await self.send_bytes(a_bytes)
-                    return 0
-            except BaseException:
-                LOGGER.error("put_alarm_cdata ERROR !", exc_info=True)
-                # Masquer les informations sensibles dans les bytes loggés
-                a_bytes_str = (
-                    a_bytes.decode("utf-8", errors="replace")
-                    if isinstance(a_bytes, bytes)
-                    else str(a_bytes)
-                )
-                sanitized_bytes = sanitize_log_message(a_bytes_str, self._password)
-                LOGGER.error("Request bytes: %s", sanitized_bytes)
-        except BaseException:
-            LOGGER.error("put_alarm_cdata ERROR !", exc_info=True)
+        if result != "ACK":
+            raise TydomAlarmCommandError(cmd, result)
 
     async def put_ackevents_cdata(self, device_id, endpoint_id=None, alarm_pin=None):
         """Acknowledge alarm events using the command supported by the gateway.

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -37,7 +37,8 @@ from .const import (
     DELTADORE_AUTH_URL,
     MEDIATION_URL,
 )
-from .MessageHandler import MessageHandler, TydomAlarmCommandError
+from .MessageHandler import MessageHandler
+from .tydom_devices import TydomAlarmCommandError
 
 if TYPE_CHECKING:
     from .tydom_devices import TydomDevice
@@ -1529,28 +1530,39 @@ class TydomClient:
             ]
             body = {"value": str(value), "pwd": str(pin), "zones": zones}
 
+        body_json = json.dumps(body)
         safe_device_id = quote(str(device_id), safe="")
         safe_endpoint_id = quote(str(endpoint_id), safe="")
         safe_cmd = quote(cmd, safe="")
-        replies = await self.get_reply_to_request(
-            "PUT",
-            f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata?name={safe_cmd}",
-            body=body,
+        request = (
+            f"PUT /devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+            f"?name={safe_cmd} HTTP/1.1\r\nContent-Length: {len(body_json)}"
+            "\r\nContent-Type: application/json; charset=UTF-8"
+            "\r\nTransac-Id: 0\r\n\r\n"
+            f"{body_json}\r\n\r\n"
         )
-
-        result = next(
-            (
-                str(reply.get("values", {}).get("result"))
-                for reply in replies or []
-                if reply.get("name") == cmd
-                and reply.get("values", {}).get("result") is not None
-            ),
-            None,
+        waiter = self._message_handler.create_alarm_command_waiter(
+            str(device_id), str(endpoint_id), cmd
         )
-        if result is None:
-            raise TydomClientApiClientCommunicationError(
-                f"No command result received for {cmd}"
+        try:
+            if not file_mode:
+                await self.send_bytes(self._cmd_prefix + request.encode("ascii"))
+            try:
+                async with async_timeout.timeout(5):
+                    reply = await waiter
+            except TimeoutError:
+                # Older gateways may execute alarm commands without publishing
+                # a command result. Preserve that established fire-and-forget
+                # behaviour rather than turning a successful command into an
+                # apparent Home Assistant failure.
+                LOGGER.debug("No asynchronous result received for %s", cmd)
+                return
+        finally:
+            self._message_handler.remove_alarm_command_waiter(
+                str(device_id), str(endpoint_id), cmd, waiter
             )
+
+        result = str(reply.get("values", {}).get("result"))
         if result != "ACK":
             raise TydomAlarmCommandError(cmd, result)
 

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -854,6 +854,7 @@ class TydomClient:
         body: dict | bytes | None = None,
         headers: dict | None = None,
         timeout: float = TIMEOUT_NORMAL_REQUEST,
+        log_timeout: bool = True,
     ) -> list[dict] | None:
         """Send request and wait for its reply with timeout handling.
 
@@ -863,6 +864,7 @@ class TydomClient:
             body: Request body
             headers: Request headers
             timeout: Timeout in seconds (default: 30.0)
+            log_timeout: Log an expected timeout as a warning when true.
 
         Returns:
             List of reply events or None
@@ -900,7 +902,8 @@ class TydomClient:
             async with async_timeout.timeout(timeout):
                 await event.wait()
         except TimeoutError:
-            LOGGER.warning(
+            log_method = LOGGER.warning if log_timeout else LOGGER.debug
+            log_method(
                 "Timeout waiting for reply to %s %s (transaction_id: %s, timeout: %.1fs)",
                 method,
                 safe_url,
@@ -1626,6 +1629,9 @@ class TydomClient:
         event_type: str | None = None,
         indexStart: int = 0,
         nbElement: int = 10,
+        *,
+        timeout: float = TIMEOUT_LONG_REQUEST,
+        log_timeout: bool = True,
     ) -> list[dict] | None:
         """Get historical events."""
         # GET /devices/xxxx/endpoints/xxxx/cdata?name=histo&type=ALL&indexStart=0&nbElem=10
@@ -1637,7 +1643,9 @@ class TydomClient:
         # The box streams the events one message at a time (about 2 seconds
         # apart), so the reply wait needs the long timeout; the default one
         # (10 s) cuts the stream off after a few events.
-        return await self.get_reply_to_request("GET", url, timeout=TIMEOUT_LONG_REQUEST)
+        return await self.get_reply_to_request(
+            "GET", url, timeout=timeout, log_timeout=log_timeout
+        )
 
     @staticmethod
     def _first_cdata_value(messages: list[dict] | None) -> dict | None:

--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -1581,19 +1581,41 @@ class TydomClient:
         pin = alarm_pin or self._alarm_pin
 
         if pin:
+            # TYDOM2 publishes the command outcome asynchronously with the
+            # reserved transaction id 0, just like arm commands.  Waiting for
+            # a transaction-correlated HTTP reply causes a 30-second timeout.
+            body = json.dumps({"pwd": str(pin)})
+            request = (
+                f"PUT /devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
+                "?name=ackEventCmd HTTP/1.1\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Content-Type: application/json; charset=UTF-8\r\n"
+                "Transac-Id: 0\r\n\r\n"
+                f"{body}\r\n\r\n"
+            )
+            waiter = self._message_handler.create_alarm_command_waiter(
+                str(device_id), str(endpoint_id), "ackEventCmd"
+            )
             try:
-                await self.get_reply_to_request(
-                    "PUT",
-                    f"/devices/{safe_device_id}/endpoints/{safe_endpoint_id}/cdata"
-                    "?name=ackEventCmd",
-                    body={"pwd": str(pin)},
+                await self.send_bytes(self._cmd_prefix + request.encode("ascii"))
+                try:
+                    async with async_timeout.timeout(5):
+                        reply = await waiter
+                except TimeoutError:
+                    # Older gateways may not publish a result.  Do not send
+                    # the /data fallback: its empty 200 is only transport ACK
+                    # and does not prove that the central unit executed it.
+                    LOGGER.debug("No asynchronous result received for ackEventCmd")
+                    return
+            finally:
+                self._message_handler.remove_alarm_command_waiter(
+                    str(device_id), str(endpoint_id), "ackEventCmd", waiter
                 )
-                return
-            except TydomClientApiClientCommunicationError:
-                LOGGER.debug(
-                    "Authenticated TYXAL acknowledgement was rejected; "
-                    "trying the data-channel form"
-                )
+
+            result = str(reply.get("values", {}).get("result"))
+            if result != "ACK":
+                raise TydomAlarmCommandError("ackEventCmd", result)
+            return
 
         await self.put_devices_data(device_id, endpoint_id, "ackEventCmd", "ACK")
 

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1383,9 +1383,12 @@ class TydomAlarm(TydomDevice):
         )
 
     async def acknowledge_events(self, code=None) -> None:
-        """Acknowledge alarm events and refresh the authoritative event list."""
+        """Acknowledge alarm events without blocking on unsupported history."""
         await self._tydom_client.put_ackevents_cdata(self._id, self._endpoint, code)
-        await self.get_events("UNACKED_EVENTS")
+        # The central unit publishes ``unackedEvent`` after a successful
+        # acknowledgement.  Some TYDOM2 gateways never answer the optional
+        # history endpoint; querying it here turned a completed action into a
+        # 60-second Home Assistant failure.
 
     _KEPT_KEYS: ClassVar = {
         "": {"name", "date", "zones", "accessCode", "product"},

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -260,6 +260,16 @@ class DeviceCallback(Protocol):
         """Call the callback."""
 
 
+class TydomAlarmCommandError(Exception):
+    """Exception raised when a TYDOM alarm command returns a negative result."""
+
+    def __init__(self, command: str, result: str) -> None:
+        """Store the rejected command and gateway result."""
+        self.command = command
+        self.result = result
+        super().__init__(f"TYDOM rejected {command} with result {result}")
+
+
 # Import TydomGroup at the end to avoid circular import
 
 
@@ -1230,10 +1240,29 @@ class TydomLight(TydomDevice):
 class TydomAlarm(TydomDevice):
     """represents an alarm."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+        self, *args, command_metadata: dict[str, Any] | None = None, **kwargs
+    ) -> None:
         """Initialise an alarm and its dashboard event cache."""
         super().__init__(*args, **kwargs)
         self._pending_events: list[dict[str, Any]] | None = None
+        self._command_metadata = command_metadata or {}
+
+    def _alarm_command_name(self, zone_id: str | None) -> str:
+        """Return the command used by this alarm and zone selection."""
+        if zone_id in (None, ""):
+            return "alarmCmd"
+        return "partCmd" if self.is_legacy_alarm() else "zoneCmd"
+
+    def _supports_alarm_command_value(self, command: str, value: str) -> bool:
+        """Return whether cmetadata explicitly advertises a command value."""
+        metadata = self._command_metadata.get(command)
+        if not isinstance(metadata, dict) or "w" not in metadata.get("permission", ""):
+            return False
+        for parameter in metadata.get("parameters", []):
+            if parameter.get("name") == "value":
+                return value in parameter.get("enum_values", [])
+        return False
 
     @property
     def pending_events(self) -> list[dict[str, Any]] | None:
@@ -1317,6 +1346,30 @@ class TydomAlarm(TydomDevice):
             code,
             "ON",
             self._tydom_client._zone_night,
+            self.is_legacy_alarm(),
+        )
+
+    async def force_arm(self, mode: str, code: str) -> None:
+        """Explicitly force arming in one configured Home Assistant mode."""
+        zones_by_mode = {
+            "away": self._tydom_client._zone_away,
+            "home": self._tydom_client._zone_home,
+            "night": self._tydom_client._zone_night,
+        }
+        if mode not in zones_by_mode:
+            raise ValueError(f"Unsupported force-arm mode: {mode}")
+
+        zone_id = zones_by_mode[mode]
+        command = self._alarm_command_name(zone_id)
+        if not self._supports_alarm_command_value(command, "FORCED_ON"):
+            raise ValueError(f"The gateway does not advertise FORCED_ON for {command}")
+
+        await self._tydom_client.put_alarm_cdata(
+            self._id,
+            self._endpoint,
+            code,
+            "FORCED_ON",
+            zone_id,
             self.is_legacy_alarm(),
         )
 

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1412,13 +1412,22 @@ class TydomAlarm(TydomDevice):
         else:
             return event
 
-    async def get_events(self, event_type: str | None) -> list[dict[str, Any]]:
+    async def get_events(
+        self,
+        event_type: str | None,
+        *,
+        timeout: float | None = None,
+        log_timeout: bool = True,
+    ) -> list[dict[str, Any]]:
         """Get alarm events."""
         if self._endpoint is None:
             LOGGER.error("Cannot get events: endpoint is None for device %s", self._id)
             return []
+        kwargs: dict[str, Any] = {"log_timeout": log_timeout}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
         events = await self._tydom_client.get_historic_cdata(
-            self._id, self._endpoint, event_type
+            self._id, self._endpoint, event_type, **kwargs
         )
 
         LOGGER.debug("Raw messages: %s", events)

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -157,6 +157,39 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
             ],
         )
 
+    async def test_transac_zero_alarm_result_resolves_command_waiter(self) -> None:
+        """TYDOM alarm broadcasts must complete the matching pending command."""
+        handler = MessageHandler(MagicMock(), b"")
+        handler_module.device_name["10_20"] = "Alarm"
+        handler_module.device_type["10_20"] = "alarm"
+        waiter = handler.create_alarm_command_waiter("20", "10", "zoneCmd")
+
+        await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "cdata": [
+                                {
+                                    "name": "zoneCmd",
+                                    "values": {
+                                        "result": "DENIED",
+                                        "authent": "USER",
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "0",
+        )
+
+        self.assertEqual((await waiter)["values"]["result"], "DENIED")
+
     async def test_force_arm_uses_advertised_zone_command(self) -> None:
         """Modern alarms may force only a command advertised by cmetadata."""
         alarm, client = _alarm_with_command("zoneCmd", ["ON", "OFF", "FORCED_ON"])

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -77,6 +77,38 @@ for name, original in _original_modules.items():
         sys.modules[name] = original
 
 
+def _alarm_with_command(
+    command: str,
+    values: list[str],
+    *,
+    away_zones: str = "1,3",
+    legacy: bool = False,
+) -> tuple[object, MagicMock]:
+    """Return an alarm advertising one writable cdata command."""
+    client = MagicMock()
+    client._zone_away = away_zones
+    client._zone_home = "1"
+    client._zone_night = "2"
+    client.put_alarm_cdata = AsyncMock()
+    alarm = TydomAlarm(
+        client,
+        "10_20",
+        "20",
+        "Alarm",
+        "alarm",
+        "10",
+        {},
+        {"part1State": "OFF"} if legacy else {},
+        command_metadata={
+            command: {
+                "permission": "w",
+                "parameters": [{"name": "value", "enum_values": values}],
+            }
+        },
+    )
+    return alarm, client
+
+
 class ProtocolResponseTests(IsolatedAsyncioTestCase):
     """Exercise response acknowledgements and light refresh polling."""
 
@@ -84,6 +116,89 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         """Reset protocol state shared between tests."""
         handler_module.device_name.clear()
         handler_module.device_type.clear()
+        handler_module.device_command_metadata.clear()
+
+    async def test_alarm_command_metadata_is_retained_by_endpoint(self) -> None:
+        """Command capabilities must remain available to alarm entities."""
+        handler = MessageHandler(MagicMock(), b"")
+
+        await handler.parse_cmeta_data(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "cmetadata": [
+                                {
+                                    "name": "zoneCmd",
+                                    "permission": "w",
+                                    "parameters": [
+                                        {
+                                            "name": "value",
+                                            "type": "string",
+                                            "enum_values": ["ON", "OFF", "FORCED_ON"],
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            None,
+        )
+
+        self.assertIn(
+            "FORCED_ON",
+            handler_module.device_command_metadata["10_20"]["zoneCmd"]["parameters"][0][
+                "enum_values"
+            ],
+        )
+
+    async def test_force_arm_uses_advertised_zone_command(self) -> None:
+        """Modern alarms may force only a command advertised by cmetadata."""
+        alarm, client = _alarm_with_command("zoneCmd", ["ON", "OFF", "FORCED_ON"])
+
+        await alarm.force_arm("away", "123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "FORCED_ON", "1,3", False
+        )
+
+    async def test_force_arm_rejects_unadvertised_command(self) -> None:
+        """Force arming must not guess support when FORCED_ON is absent."""
+        alarm, client = _alarm_with_command("zoneCmd", ["ON", "OFF"])
+
+        with self.assertRaisesRegex(ValueError, "does not advertise FORCED_ON"):
+            await alarm.force_arm("away", "123456")
+
+        client.put_alarm_cdata.assert_not_awaited()
+
+    async def test_force_arm_uses_advertised_global_command(self) -> None:
+        """An empty configured zone selection must use the global alarm command."""
+        alarm, client = _alarm_with_command(
+            "alarmCmd", ["ON", "OFF", "FORCED_ON"], away_zones=""
+        )
+
+        await alarm.force_arm("away", "123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "FORCED_ON", "", False
+        )
+
+    async def test_force_arm_uses_advertised_legacy_part_command(self) -> None:
+        """Legacy alarms must retain their per-part command path."""
+        alarm, client = _alarm_with_command(
+            "partCmd", ["OFF", "ON", "FORCED_ON"], legacy=True
+        )
+
+        await alarm.force_arm("away", "123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "FORCED_ON", "1,3", True
+        )
 
     def test_light_brightness_requires_intermediate_levels(self) -> None:
         """Binary level metadata must not advertise variable brightness."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -383,11 +383,10 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         self.assertEqual(alarm.pending_events, result)
         callback.assert_called_once_with()
 
-    async def test_acknowledgement_refreshes_cached_alarm_events(self) -> None:
-        """Acknowledgement must replace optimistic state with gateway history."""
+    async def test_acknowledgement_does_not_block_on_gateway_history(self) -> None:
+        """Acknowledgement must not issue an unsupported 60-second history read."""
         client = MagicMock()
         client.put_ackevents_cdata = AsyncMock()
-        client.get_historic_cdata = AsyncMock(return_value=[])
         alarm = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
         alarm._pending_events = [{"name": "INTRUSION"}]
         callback = MagicMock()
@@ -396,11 +395,9 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         await alarm.acknowledge_events()
 
         client.put_ackevents_cdata.assert_awaited_once_with("20", "10", None)
-        client.get_historic_cdata.assert_awaited_once_with(
-            "20", "10", "UNACKED_EVENTS"
-        )
-        self.assertEqual(alarm.pending_events, [])
-        callback.assert_called_once_with()
+        client.get_historic_cdata.assert_not_called()
+        self.assertEqual(alarm.pending_events, [{"name": "INTRUSION"}])
+        callback.assert_not_called()
 
     async def test_ignored_acknowledgement_keeps_pending_alarm_events(self) -> None:
         """A transport acknowledgement must not hide an uncleared gateway event."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -363,7 +363,9 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         callback = MagicMock()
         alarm.register_callback(callback)
 
-        result = await alarm.get_events("UNACKED_EVENTS")
+        result = await alarm.get_events(
+            "UNACKED_EVENTS", timeout=10.0, log_timeout=False
+        )
 
         self.assertEqual(
             result,
@@ -381,6 +383,13 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
             ],
         )
         self.assertEqual(alarm.pending_events, result)
+        client.get_historic_cdata.assert_awaited_once_with(
+            "20",
+            "10",
+            "UNACKED_EVENTS",
+            log_timeout=False,
+            timeout=10.0,
+        )
         callback.assert_called_once_with()
 
     async def test_acknowledgement_does_not_block_on_gateway_history(self) -> None:
@@ -420,10 +429,8 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
 
         await alarm.acknowledge_events()
 
-        self.assertEqual(
-            alarm.pending_events,
-            [{"name": "alarmIntrusion", "date": "2026-08-05T09:59:00"}],
-        )
+        self.assertEqual(alarm.pending_events, [{"name": "alarmIntrusion"}])
+        client.get_historic_cdata.assert_not_called()
 
     async def test_empty_success_response_is_treated_as_acknowledgement(self) -> None:
         """An empty successful response must not be reported as an unknown message."""

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -30,6 +30,15 @@ class _WebSocketResponse:
     """Stand-in used only to evaluate runtime annotations."""
 
 
+class _AlarmCommandError(Exception):
+    """Stand-in retaining the command result inspected by the tests."""
+
+    def __init__(self, command: str, result: str) -> None:
+        """Store the simulated command result."""
+        self.command = command
+        self.result = result
+
+
 for package_name in (
     "custom_components",
     "custom_components.deltadore_tydom",
@@ -79,6 +88,7 @@ _module(
 _module(
     "custom_components.deltadore_tydom.tydom.MessageHandler",
     MessageHandler=MagicMock(),
+    TydomAlarmCommandError=_AlarmCommandError,
 )
 
 module_name = "custom_components.deltadore_tydom.tydom.tydom_client"
@@ -99,6 +109,7 @@ TydomClient = client_module.TydomClient
 TydomClientApiClientCommunicationError = (
     client_module.TydomClientApiClientCommunicationError
 )
+TydomAlarmCommandError = client_module.TydomAlarmCommandError
 sanitize_log_message = client_module.sanitize_log_message
 
 for name, original in _original_modules.items():
@@ -170,6 +181,43 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
                 call("20", "10", "123456", "ON", "1", True),
                 call("20", "10", "123456", "ON", "3", True),
             ],
+        )
+
+    async def test_alarm_command_waits_for_acknowledged_result(self) -> None:
+        """Alarm commands must use a tracked request and require an ACK result."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(
+            return_value=[
+                {"name": "alarmCmd", "values": {"result": "ACK", "authent": "USER"}}
+            ]
+        )
+
+        await client._put_alarm_cdata("20", "10", "123456", "ON")
+
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=alarmCmd",
+            body={"value": "ON", "pwd": "123456"},
+        )
+
+    async def test_denied_zone_alarm_command_raises(self) -> None:
+        """A gateway DENIED result must reach the Home Assistant action."""
+        client = self._client()
+        client.get_reply_to_request = AsyncMock(
+            return_value=[
+                {"name": "zoneCmd", "values": {"result": "DENIED", "authent": "USER"}}
+            ]
+        )
+
+        with self.assertRaises(TydomAlarmCommandError) as context:
+            await client._put_alarm_cdata("20", "10", "123456", "ON", "1,3")
+
+        self.assertEqual(context.exception.command, "zoneCmd")
+        self.assertEqual(context.exception.result, "DENIED")
+        client.get_reply_to_request.assert_awaited_once_with(
+            "PUT",
+            "/devices/20/endpoints/10/cdata?name=zoneCmd",
+            body={"value": "ON", "pwd": "123456", "zones": [1, 3]},
         )
 
     async def test_alarm_inventory_uses_supported_label_command(self) -> None:

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -88,6 +88,9 @@ _module(
 _module(
     "custom_components.deltadore_tydom.tydom.MessageHandler",
     MessageHandler=MagicMock(),
+)
+_module(
+    "custom_components.deltadore_tydom.tydom.tydom_devices",
     TydomAlarmCommandError=_AlarmCommandError,
 )
 
@@ -184,41 +187,41 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         )
 
     async def test_alarm_command_waits_for_acknowledged_result(self) -> None:
-        """Alarm commands must use a tracked request and require an ACK result."""
+        """Alarm commands must correlate their Transac-Id 0 cdata result."""
         client = self._client()
-        client.get_reply_to_request = AsyncMock(
-            return_value=[
-                {"name": "alarmCmd", "values": {"result": "ACK", "authent": "USER"}}
-            ]
+        waiter = asyncio.get_running_loop().create_future()
+        waiter.set_result(
+            {"name": "alarmCmd", "values": {"result": "ACK", "authent": "USER"}}
         )
+        client._message_handler.create_alarm_command_waiter.return_value = waiter
+        client.send_bytes = AsyncMock()
 
         await client._put_alarm_cdata("20", "10", "123456", "ON")
 
-        client.get_reply_to_request.assert_awaited_once_with(
-            "PUT",
-            "/devices/20/endpoints/10/cdata?name=alarmCmd",
-            body={"value": "ON", "pwd": "123456"},
-        )
+        request = client.send_bytes.await_args.args[0].decode("ascii")
+        self.assertIn("PUT /devices/20/endpoints/10/cdata?name=alarmCmd", request)
+        self.assertIn("Transac-Id: 0", request)
+        self.assertIn('{"value": "ON", "pwd": "123456"}', request)
 
     async def test_denied_zone_alarm_command_raises(self) -> None:
         """A gateway DENIED result must reach the Home Assistant action."""
         client = self._client()
-        client.get_reply_to_request = AsyncMock(
-            return_value=[
-                {"name": "zoneCmd", "values": {"result": "DENIED", "authent": "USER"}}
-            ]
+        waiter = asyncio.get_running_loop().create_future()
+        waiter.set_result(
+            {"name": "zoneCmd", "values": {"result": "DENIED", "authent": "USER"}}
         )
+        client._message_handler.create_alarm_command_waiter.return_value = waiter
+        client.send_bytes = AsyncMock()
 
         with self.assertRaises(TydomAlarmCommandError) as context:
             await client._put_alarm_cdata("20", "10", "123456", "ON", "1,3")
 
         self.assertEqual(context.exception.command, "zoneCmd")
         self.assertEqual(context.exception.result, "DENIED")
-        client.get_reply_to_request.assert_awaited_once_with(
-            "PUT",
-            "/devices/20/endpoints/10/cdata?name=zoneCmd",
-            body={"value": "ON", "pwd": "123456", "zones": [1, 3]},
-        )
+        request = client.send_bytes.await_args.args[0].decode("ascii")
+        self.assertIn("PUT /devices/20/endpoints/10/cdata?name=zoneCmd", request)
+        self.assertIn("Transac-Id: 0", request)
+        self.assertIn('"zones": [1, 3]', request)
 
     async def test_alarm_inventory_uses_supported_label_command(self) -> None:
         """Inventory must not depend on optional unsupported productInfo data."""

--- a/tests/test_tydom_client_connection.py
+++ b/tests/test_tydom_client_connection.py
@@ -346,33 +346,35 @@ class TestManagedConnection(IsolatedAsyncioTestCase):
         )
 
     async def test_alarm_acknowledgement_prefers_authenticated_cdata(self) -> None:
-        """A configured code must use the controlled command advertised by TYXAL."""
+        """A configured code uses the asynchronous TYXAL command result."""
         client = self._client()
-        client.get_reply_to_request = AsyncMock(return_value=[])
+        waiter = asyncio.get_running_loop().create_future()
+        waiter.set_result({"name": "ackEventCmd", "values": {"result": "ACK"}})
+        client._message_handler.create_alarm_command_waiter.return_value = waiter
+        client.send_bytes = AsyncMock()
         client.put_devices_data = AsyncMock()
 
         await client.put_ackevents_cdata("20", "10", "123456")
 
-        client.get_reply_to_request.assert_awaited_once_with(
-            "PUT",
-            "/devices/20/endpoints/10/cdata?name=ackEventCmd",
-            body={"pwd": "123456"},
-        )
+        request = client.send_bytes.await_args.args[0].decode("ascii")
+        self.assertIn("PUT /devices/20/endpoints/10/cdata?name=ackEventCmd", request)
+        self.assertIn("Transac-Id: 0", request)
+        self.assertIn('{"pwd": "123456"}', request)
         client.put_devices_data.assert_not_awaited()
 
-    async def test_alarm_acknowledgement_falls_back_to_data_channel(self) -> None:
-        """Firmware rejecting authenticated cdata must retain the proven fallback."""
+    async def test_alarm_acknowledgement_rejects_denied_result(self) -> None:
+        """A negative asynchronous result must reach the service caller."""
         client = self._client()
-        client.get_reply_to_request = AsyncMock(
-            side_effect=TydomClientApiClientCommunicationError("HTTP 500")
+        waiter = asyncio.get_running_loop().create_future()
+        waiter.set_result(
+            {"name": "ackEventCmd", "values": {"result": "DENIED"}}
         )
-        client.put_devices_data = AsyncMock()
+        client._message_handler.create_alarm_command_waiter.return_value = waiter
+        client.send_bytes = AsyncMock()
 
-        await client.put_ackevents_cdata("20", "10", "123456")
+        with self.assertRaises(TydomAlarmCommandError):
+            await client.put_ackevents_cdata("20", "10", "123456")
 
-        client.put_devices_data.assert_awaited_once_with(
-            "20", "10", "ackEventCmd", "ACK"
-        )
 
     async def test_alarm_remote_configuration_lock_uses_official_command(self) -> None:
         """Remote TYXAL configuration must be explicitly locked and unlocked."""


### PR DESCRIPTION
Fixes #410.

Depends on #414: this branch is based on the validated asynchronous alarm-command correlation, so the diff will shrink automatically once #414 is merged.

## Changes

- Send the authenticated `ackEventCmd` using the gateway-reserved `Transac-Id: 0` transport.
- Wait up to five seconds for the asynchronous `ACK` or negative result published on `/devices/cdata`.
- Surface a negative result instead of treating an empty `/data` HTTP 200 response as proof of execution.
- Retain fire-and-forget compatibility when an older gateway publishes no result.
- Do not issue a blocking `UNACKED_EVENTS` history read after acknowledgement. The pushed `unackedEvent` value remains the authoritative confirmation.
- Probe automatic detailed event history only once per integration load, with a ten-second timeout. If the gateway does not support it, disable further automatic attempts for that session instead of producing repeated 60-second warnings.
- Keep explicit history service calls unchanged for gateways which support the complete streamed response.

## Hardware validation

Validated successfully by the reporter on a TYDOM2, SDK `03.21.43`, connected to a TYXAL+ CS8000:

- an unacknowledged fault was present and the alarm was disarmed;
- the Home Assistant acknowledgement button removed the fault immediately from the official TYDOM application;
- `unackedEvent` changed to `false` in Home Assistant;
- the transport acknowledgement, asynchronous `ackEventCmd: ACK` result and `EOR` completed in approximately 430 ms;
- no 30-second or 60-second timeout occurred during acknowledgement;
- a later full refresh confirmed stable `alarmMode: OFF`, `alarmState: OFF` and inactive zones.

The reporter then performed a clean reinstall and final retest using the combined test branch. Both a full Home Assistant restart and an integration reload completed without any Delta Dore timeout warning or error, and no repeated `UNACKED_EVENTS` requests were observed. A second acknowledgement again removed the fault from the official TYDOM application and kept `unackedEvent` at `false` in Home Assistant. The only reported warnings were Home Assistant's generic custom-integration notice and its debug log-rate warning.

Sanitised evidence is available in #410.

## Automated tests

Targeted coverage includes:

- asynchronous acknowledgement success;
- negative command results;
- absence of a post-action history request;
- forwarding of the bounded automatic-history timeout;
- retention of pending state until the gateway confirms it has cleared.

Validation: 49 targeted unit tests pass.
