### PR TITLE
Expose who changed the TYXAL alarm state

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3434,6 +3434,13 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         "outTemperature": SensorStateClass.MEASUREMENT,
     }
 
+    _ACTOR_HISTORY_STATES = {
+        AlarmControlPanelState.DISARMED,
+        AlarmControlPanelState.ARMED_AWAY,
+        AlarmControlPanelState.ARMED_HOME,
+        AlarmControlPanelState.ARMED_NIGHT,
+    }
+
     def __init__(self, device: TydomAlarm, hass) -> None:
         """Initialize the sensor."""
         self.hass = hass
@@ -3443,7 +3450,11 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         self._attr_name = None  # primary entity inherits device name
         self._attr_code_format = CodeFormat.NUMBER
         self._attr_code_arm_required = True
+        self._attr_changed_by = None
         self._registered_sensors = []
+        self._last_alarm_state = self.alarm_state
+        self._last_alarm_event_sequence = self._device.alarm_event_sequence
+        self._pending_alarm_actor: tuple[str, str] | None = None
 
         self._attr_supported_features = (
             self._attr_supported_features
@@ -3456,15 +3467,67 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
         await super().async_added_to_hass()
-        self._device.register_callback(self.async_write_ha_state)
+        self._device.register_callback(self._handle_alarm_update)
         self._device._ha_device = self
 
     async def async_will_remove_from_hass(self) -> None:
         """Remove the push callback registered in async_added_to_hass."""
-        self._device.remove_callback(self.async_write_ha_state)
+        self._device.remove_callback(self._handle_alarm_update)
         if hasattr(self._device, "_ha_device") and self._device._ha_device is self:
             self._device._ha_device = None
         await super().async_will_remove_from_hass()
+
+    def _handle_alarm_update(self) -> None:
+        """Publish alarm pushes and associate spontaneous actors with transitions."""
+        current_state = self.alarm_state
+        previous_state = self._last_alarm_state
+        self._last_alarm_state = current_state
+        event_sequence = self._device.alarm_event_sequence
+        has_new_actor = event_sequence != self._last_alarm_event_sequence
+        actor = self._device.latest_alarm_actor if has_new_actor else None
+        actor_target = self._device.latest_alarm_event_target if has_new_actor else None
+        self._last_alarm_event_sequence = event_sequence
+
+        state_changed = (
+            current_state != previous_state
+            and current_state in self._ACTOR_HISTORY_STATES
+        )
+        if state_changed:
+            self._attr_changed_by = None
+            if actor and self._actor_target_matches_state(actor_target, current_state):
+                self._attr_changed_by = actor
+                self._pending_alarm_actor = None
+            elif self._pending_alarm_actor and self._actor_target_matches_state(
+                self._pending_alarm_actor[0], current_state
+            ):
+                self._attr_changed_by = self._pending_alarm_actor[1]
+                self._pending_alarm_actor = None
+            else:
+                self._pending_alarm_actor = None
+        elif actor and actor_target:
+            if self._actor_target_matches_state(actor_target, current_state):
+                self._attr_changed_by = actor
+            else:
+                # TYDOM may publish eventAlarm just before alarmMode changes.
+                self._pending_alarm_actor = (actor_target, actor)
+
+        self.async_write_ha_state()
+
+    @staticmethod
+    def _actor_target_matches_state(target, state) -> bool:
+        """Return whether an actor event describes the current HA alarm state."""
+        if target == "disarmed":
+            return state == AlarmControlPanelState.DISARMED
+        return target == "armed" and state in {
+            AlarmControlPanelState.ARMED_AWAY,
+            AlarmControlPanelState.ARMED_HOME,
+            AlarmControlPanelState.ARMED_NIGHT,
+        }
+
+    @property
+    def changed_by(self) -> str | None:
+        """Return the actor resolved for the latest alarm transition."""
+        return self._attr_changed_by
 
     @property
     def alarm_state(self) -> AlarmControlPanelState:

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1657,6 +1657,12 @@ class MessageHandler:
                                 self._resolve_alarm_command_waiter(
                                     device_id, endpoint_id, elem
                                 )
+                                values = elem.get("values") or {}
+                                event = values.get("event")
+                                if elem.get("name") == "eventAlarm" and isinstance(
+                                    event, dict
+                                ):
+                                    data["eventAlarm"] = event
 
                             if type_of_id == "conso":
                                 data.update(_parse_energy_cdata_element(elem))
@@ -1742,7 +1748,7 @@ class MessageHandler:
                                     type_of_id,
                                 )
 
-                        if type_of_id == "conso" and data:
+                        if type_of_id in {"alarm", "conso"} and data:
                             device = await MessageHandler.get_device(
                                 self.tydom_client,
                                 type_of_id,

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1247,6 +1247,9 @@ class TydomAlarm(TydomDevice):
         super().__init__(*args, **kwargs)
         self._pending_events: list[dict[str, Any]] | None = None
         self._command_metadata = command_metadata or {}
+        self._alarm_event_sequence = 0
+        self._latest_alarm_actor: str | None = None
+        self._latest_alarm_event_target: str | None = None
 
     def _alarm_command_name(self, zone_id: str | None) -> str:
         """Return the command used by this alarm and zone selection."""
@@ -1272,6 +1275,62 @@ class TydomAlarm(TydomDevice):
     def clear_pending_events(self) -> None:
         """Clear the local event cache after acknowledgement or a clear state."""
         self._pending_events = []
+
+    @staticmethod
+    def _actor_from_alarm_event(event: dict[str, Any]) -> str | None:
+        """Return the named actor carried by a spontaneous alarm event."""
+        access_code = event.get("accessCode") or {}
+        actor = str(access_code.get("nameCustom") or "").strip()
+        if actor:
+            return actor
+
+        product = event.get("product") or {}
+        actor = str(product.get("nameCustom") or "").strip()
+        if actor:
+            return actor
+
+        standard_name = str(product.get("nameStd") or "").strip()
+        product_number = product.get("number")
+        if standard_name and product_number is not None:
+            return f"{standard_name} {product_number}"
+        return standard_name or str(product.get("typeLong") or "").strip() or None
+
+    @staticmethod
+    def _alarm_event_target(event: dict[str, Any]) -> str | None:
+        """Return the state family reached by a completed alarm event."""
+        name = str(event.get("name") or "").strip().casefold()
+        if name == "arret":
+            return "disarmed"
+        if name.startswith("marche"):
+            return "armed"
+        return None
+
+    @property
+    def alarm_event_sequence(self) -> int:
+        """Return a sequence incremented for each named arm/disarm event."""
+        return self._alarm_event_sequence
+
+    @property
+    def latest_alarm_actor(self) -> str | None:
+        """Return the actor from the newest spontaneous arm/disarm event."""
+        return self._latest_alarm_actor
+
+    @property
+    def latest_alarm_event_target(self) -> str | None:
+        """Return whether the newest actor event armed or disarmed the alarm."""
+        return self._latest_alarm_event_target
+
+    async def update_device(self, device) -> None:
+        """Capture spontaneous alarm actors before publishing the update."""
+        event = getattr(device, "eventAlarm", None)
+        target = self._alarm_event_target(event) if isinstance(event, dict) else None
+        if target:
+            actor = self._actor_from_alarm_event(event)
+            if actor:
+                self._latest_alarm_actor = actor
+                self._latest_alarm_event_target = target
+                self._alarm_event_sequence += 1
+        await super().update_device(device)
 
     def is_legacy_alarm(self) -> bool:
         """Check if alarm is legacy."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -233,6 +233,127 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
             "20", "10", "123456", "FORCED_ON", "1,3", True
         )
 
+    async def test_spontaneous_alarm_event_is_forwarded_as_device_update(self) -> None:
+        """A pushed eventAlarm must reach the stored alarm device."""
+        handler = MessageHandler(MagicMock(), b"")
+        handler_module.device_name["10_20"] = "Alarm"
+        handler_module.device_type["10_20"] = "alarm"
+
+        devices = await handler.parse_devices_cdata(
+            [
+                {
+                    "id": 20,
+                    "endpoints": [
+                        {
+                            "id": 10,
+                            "error": 0,
+                            "cdata": [
+                                {
+                                    "name": "eventAlarm",
+                                    "parameters": {},
+                                    "values": {
+                                        "event": {
+                                            "name": "marcheTotale",
+                                            "product": {
+                                                "nameCustom": "TL 2000 Sandra",
+                                                "typeLong": "TL 2000",
+                                            },
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+            "0",
+        )
+
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].eventAlarm["name"], "marcheTotale")
+
+    async def test_alarm_actor_prefers_named_access_code(self) -> None:
+        """A spontaneous named user code must take precedence over product data."""
+        client = MagicMock()
+        stored = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+        incoming = TydomAlarm(
+            client,
+            "10_20",
+            "20",
+            "Alarm",
+            "alarm",
+            "10",
+            {},
+            {
+                "eventAlarm": {
+                    "name": "arret",
+                    "accessCode": {"nameCustom": "Sandra"},
+                    "product": {"nameCustom": "TYDOM application"},
+                }
+            },
+        )
+
+        await stored.update_device(incoming)
+
+        self.assertEqual(stored.latest_alarm_actor, "Sandra")
+        self.assertEqual(stored.latest_alarm_event_target, "disarmed")
+        self.assertEqual(stored.alarm_event_sequence, 1)
+
+    async def test_alarm_actor_uses_named_remote(self) -> None:
+        """A spontaneous named physical remote must populate the alarm actor."""
+        client = MagicMock()
+        stored = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+        incoming = TydomAlarm(
+            client,
+            "10_20",
+            "20",
+            "Alarm",
+            "alarm",
+            "10",
+            {},
+            {
+                "eventAlarm": {
+                    "name": "marcheTotale",
+                    "product": {
+                        "nameCustom": "TL 2000 Sandra",
+                        "typeLong": "TL 2000",
+                    },
+                }
+            },
+        )
+
+        await stored.update_device(incoming)
+
+        self.assertEqual(stored.latest_alarm_actor, "TL 2000 Sandra")
+        self.assertEqual(stored.latest_alarm_event_target, "armed")
+        self.assertEqual(stored.alarm_event_sequence, 1)
+
+    async def test_non_state_alarm_event_does_not_replace_actor(self) -> None:
+        """Intrusion and diagnostic events must not become changed_by actors."""
+        client = MagicMock()
+        stored = TydomAlarm(client, "10_20", "20", "Alarm", "alarm", "10", {}, {})
+        incoming = TydomAlarm(
+            client,
+            "10_20",
+            "20",
+            "Alarm",
+            "alarm",
+            "10",
+            {},
+            {
+                "eventAlarm": {
+                    "name": "intrusion",
+                    "product": {"nameCustom": "Living room detector"},
+                }
+            },
+        )
+
+        await stored.update_device(incoming)
+
+        self.assertIsNone(stored.latest_alarm_actor)
+        self.assertIsNone(stored.latest_alarm_event_target)
+        self.assertEqual(stored.alarm_event_sequence, 0)
+
     def test_light_brightness_requires_intermediate_levels(self) -> None:
         """Binary level metadata must not advertise variable brightness."""
         client = MagicMock()


### PR DESCRIPTION
Fixes #408.

## Summary

Populate Home Assistant's standard `changed_by` alarm attribute directly from the spontaneous `eventAlarm` messages published by TYDOM, without requesting alarm history.

## Problem

Regular `alarmMode` and `alarmState` pushes do not identify the person, code or physical remote responsible for a transition, so `changed_by` remains empty.

The first implementation requested the newest `ON_OFF` history entry after each transition. Hardware testing showed that the reported TYDOM2 never answers `histo` reads, regardless of the filter, causing repeated 60-second timeouts while `changed_by` remained `null`.

The reporter's sanitised debug log revealed the appropriate source: TYDOM spontaneously publishes `eventAlarm` on `/devices/cdata` at the same time as each transition. It already contains either:

- `accessCode.nameCustom` for a named user code; or
- `product.nameCustom` and product metadata for a physical remote or keyfob.

## Changes

- Forward spontaneous `eventAlarm` objects through the existing alarm device update path.
- Extract named user codes first, followed by named products and standard product fallbacks.
- Accept only completed arm/disarm events (`marche...` and `arret`) so intrusion and diagnostic events cannot overwrite `changed_by`.
- Correlate the actor with the resulting armed or disarmed state whether `eventAlarm` arrives just before or just after `alarmMode`.
- Clear a previous actor when a new transition has no matching actor event.
- Perform no extra network request and introduce no delay or history timeout.

The implementation is driven by the event payload rather than a hard-coded gateway, central unit or remote model.

## Evidence

The reporter's TYDOM2, SDK `03.21.43`, publishes both supported actor forms immediately:

- a TL 2000 transition contains `eventAlarm.event.product.nameCustom`;
- a keypad transition contains `eventAlarm.event.accessCode.nameCustom`.

The official TYDOM application displays the same actor names. Sanitised captures and logs are available in #408.

## Automated tests

Coverage confirms that:

- a spontaneous `eventAlarm` becomes an alarm device update;
- a named access code takes precedence over product information;
- a named TL 2000 remote is retained as the actor;
- arm and disarm events are assigned to the correct state family;
- unrelated intrusion events are ignored.

The complete suite passes: 169 tests.

## Hardware validation requested

The revised implementation should be tested on the reported TYDOM2 using:

1. one arm and one disarm operation with the named TL 2000 remote;
2. one arm and one disarm operation with a named user code;
3. verification that `changed_by` contains the expected actor after every transition;
4. confirmation that no `histo&type=ON_OFF` request or associated timeout is triggered automatically.

The combined test branch is:

https://github.com/Sleinous/hass-deltadore-tydom-component/tree/test/seb91260-tydom2-alarm
