### PR TITLE
Reduce repeated Calybox endpoint warnings

### DIFF
--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -60,6 +60,9 @@ if TYPE_CHECKING:
 _MAX_REPLIES_SIZE = 5
 """Maximal number of replies to keep track of."""
 
+_ENDPOINT_WARNING_MILESTONES = {1, 10, 100, 1000}
+"""Per-session endpoint issue counts which remain visible as warnings."""
+
 _HISTO_END_INDEX = 255
 """Index value (0xFF) of the sentinel element closing an histo reply stream.
 
@@ -425,6 +428,36 @@ class MessageHandler:
         self._area_devices: dict[str, dict[str, AreaDeviceReference]] = {}
         self._area_data: dict[str, dict[str, Any]] = {}
         self._area_metadata: dict[str, dict] = {}
+        self._endpoint_issue_counts: dict[tuple[Any, Any, str, Any], int] = {}
+
+    def _record_endpoint_issue(
+        self,
+        device_id: Any,
+        endpoint_id: Any,
+        issue: str,
+        detail: Any,
+        name: str,
+    ) -> None:
+        """Rate-limit a repeated endpoint problem while retaining diagnostics."""
+        key = (device_id, endpoint_id, issue, detail)
+        occurrences = self._endpoint_issue_counts.get(key, 0) + 1
+        self._endpoint_issue_counts[key] = occurrences
+
+        log = (
+            LOGGER.warning
+            if occurrences in _ENDPOINT_WARNING_MILESTONES
+            else LOGGER.debug
+        )
+        log(
+            "TYDOM endpoint %s: device_id=%s, endpoint_id=%s, name=%s, "
+            "detail=%s, occurrences=%s; retaining the previous state",
+            issue,
+            device_id,
+            endpoint_id,
+            name,
+            detail,
+            occurrences,
+        )
 
     def get_reply(self, transaction_id: str) -> Reply | None:
         """
@@ -1395,6 +1428,7 @@ class MessageHandler:
                     if (
                         not has_error
                         and not has_data
+                        and type_of_id != "conso"
                         and not device_metadata.get(unique_id)
                         and not endpoint.get("link")
                     ):
@@ -1408,20 +1442,37 @@ class MessageHandler:
                         continue
 
                     if has_error:
-                        LOGGER.warning(
-                            "Endpoint avec erreur (création quand même) : "
-                            "device_id=%s, endpoint_id=%s, error=%s",
+                        self._record_endpoint_issue(
                             device_id,
                             endpoint_id,
+                            "reported an error",
                             endpoint.get("error"),
+                            name_of_id,
                         )
-
-                    if not has_valid_data:
-                        LOGGER.warning(
-                            "Endpoint sans données valides (création avec état par défaut) : "
-                            "device_id=%s, endpoint_id=%s, name=%s",
+                    elif not has_data and type_of_id != "conso":
+                        self._record_endpoint_issue(
                             device_id,
                             endpoint_id,
+                            "returned no regular data",
+                            None,
+                            name_of_id,
+                        )
+                    elif not has_data:
+                        # Calybox/Tywatt consumption endpoints expose their values
+                        # through /devices/cdata rather than /devices/data.
+                        LOGGER.debug(
+                            "Ignoring expected empty regular data for cdata endpoint "
+                            "(device_id=%s, endpoint_id=%s, name=%s)",
+                            device_id,
+                            endpoint_id,
+                            name_of_id,
+                        )
+                    elif not has_valid_data:
+                        self._record_endpoint_issue(
+                            device_id,
+                            endpoint_id,
+                            "returned no up-to-date data",
+                            None,
                             name_of_id,
                         )
 
@@ -1503,8 +1554,9 @@ class MessageHandler:
                                     type_of_id,
                                 )
                             else:
-                                LOGGER.info(
-                                    "Device créé sans données (id=%s, endpoint=%s, name=%s, type=%s)",
+                                LOGGER.debug(
+                                    "Device created without fresh data "
+                                    "(id=%s, endpoint=%s, name=%s, type=%s)",
                                     device_id,
                                     endpoint_id,
                                     name_of_id,

--- a/tests/test_endpoint_logging.py
+++ b/tests/test_endpoint_logging.py
@@ -1,0 +1,163 @@
+"""Tests for expected and repeated TYDOM endpoint responses."""
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock
+
+
+_MISSING = object()
+_original_modules: dict[str, object] = {}
+
+
+def _module(name: str, **attributes) -> types.ModuleType:
+    """Install a minimal module needed to load protocol code in isolation."""
+    _original_modules.setdefault(name, sys.modules.get(name, _MISSING))
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    sys.modules[name] = module
+    return module
+
+
+for package_name in (
+    "custom_components",
+    "custom_components.deltadore_tydom",
+    "custom_components.deltadore_tydom.tydom",
+):
+    package = _module(package_name)
+    package.__path__ = []
+
+logger = MagicMock()
+_module(
+    "custom_components.deltadore_tydom.const",
+    LOGGER=logger,
+    validate_value_with_metadata=MagicMock(return_value=(True, None)),
+)
+
+root = Path(__file__).parents[1]
+tydom_path = root / "custom_components" / "deltadore_tydom" / "tydom"
+
+devices_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.tydom.tydom_devices",
+    tydom_path / "tydom_devices.py",
+)
+assert devices_spec is not None and devices_spec.loader is not None
+devices_module = importlib.util.module_from_spec(devices_spec)
+_original_modules.setdefault(
+    devices_spec.name, sys.modules.get(devices_spec.name, _MISSING)
+)
+sys.modules[devices_spec.name] = devices_module
+devices_spec.loader.exec_module(devices_module)
+
+handler_spec = importlib.util.spec_from_file_location(
+    "custom_components.deltadore_tydom.tydom.MessageHandler",
+    tydom_path / "MessageHandler.py",
+)
+assert handler_spec is not None and handler_spec.loader is not None
+handler_module = importlib.util.module_from_spec(handler_spec)
+_original_modules.setdefault(
+    handler_spec.name, sys.modules.get(handler_spec.name, _MISSING)
+)
+sys.modules[handler_spec.name] = handler_module
+handler_spec.loader.exec_module(handler_module)
+
+MessageHandler = handler_module.MessageHandler
+
+for name, original in _original_modules.items():
+    if original is _MISSING:
+        sys.modules.pop(name, None)
+    else:
+        sys.modules[name] = original
+
+
+class EndpointLoggingTests(IsolatedAsyncioTestCase):
+    """Exercise captured Calybox response shapes and warning throttling."""
+
+    def setUp(self) -> None:
+        """Reset protocol registries and logging."""
+        logger.reset_mock()
+        handler_module.device_name.clear()
+        handler_module.device_type.clear()
+        handler_module.device_metadata.clear()
+        self.handler = MessageHandler(MagicMock(), b"")
+
+    @staticmethod
+    def _response(error: int = 0, data: list[dict] | None = None) -> list[dict]:
+        """Build one endpoint response."""
+        return [
+            {
+                "id": 20,
+                "endpoints": [
+                    {
+                        "id": 10,
+                        "error": error,
+                        "data": [] if data is None else data,
+                    }
+                ],
+            }
+        ]
+
+    async def test_cdata_consumption_endpoint_does_not_warn(self) -> None:
+        """An empty Calybox consumption endpoint is an expected response."""
+        uid = "10_20"
+        handler_module.device_name[uid] = "Consumption"
+        handler_module.device_type[uid] = "conso"
+
+        devices = await self.handler.parse_devices_data(self._response(), None)
+
+        logger.warning.assert_not_called()
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(devices[0].device_name, "Consumption")
+
+    async def test_repeated_empty_heating_endpoint_is_rate_limited(self) -> None:
+        """A temporarily silent heating zone must not flood HA warnings."""
+        uid = "10_20"
+        handler_module.device_name[uid] = "Bedrooms"
+        handler_module.device_type[uid] = "boiler"
+        handler_module.device_metadata[uid] = {
+            "thermicLevel": {"permission": "rw"}
+        }
+
+        for _ in range(12):
+            await self.handler.parse_devices_data(self._response(), None)
+
+        warning_counts = [call.args[-1] for call in logger.warning.call_args_list]
+        self.assertEqual(warning_counts, [1, 10])
+
+    async def test_error_does_not_emit_a_second_missing_data_warning(self) -> None:
+        """One errored response represents one issue, not two warnings."""
+        uid = "10_20"
+        handler_module.device_name[uid] = "Bedrooms"
+        handler_module.device_type[uid] = "boiler"
+        handler_module.device_metadata[uid] = {
+            "thermicLevel": {"permission": "rw"}
+        }
+
+        await self.handler.parse_devices_data(self._response(error=5), None)
+
+        logger.warning.assert_called_once()
+        self.assertEqual(logger.warning.call_args.args[1], "reported an error")
+        self.assertEqual(logger.warning.call_args.args[-2], 5)
+
+    async def test_different_error_codes_remain_visible(self) -> None:
+        """A new gateway error code starts its own diagnostic series."""
+        uid = "10_20"
+        handler_module.device_name[uid] = "Bedrooms"
+        handler_module.device_type[uid] = "boiler"
+        handler_module.device_metadata[uid] = {
+            "thermicLevel": {"permission": "rw"}
+        }
+
+        await self.handler.parse_devices_data(self._response(error=1), None)
+        await self.handler.parse_devices_data(self._response(error=5), None)
+
+        self.assertEqual(logger.warning.call_count, 2)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
Fixes #403.

## Summary

Handle expected empty Calybox consumption responses without warning and rate-limit repeated endpoint errors or missing-data responses while retaining useful diagnostics.

## Capture findings

The reporter's capture confirms that the Calybox 1020 WT exposes three endpoints under the same device:

- two heating zones using regular `/devices/data` values;
- one `conso` endpoint named `Consommation`.

The consumption endpoint legitimately returns an empty `data` array from `/devices/data`. Its `/devices/cmeta` entry instead advertises `energyHisto`, with the supported electricity destinations. Treating the empty regular response as an invalid endpoint therefore produces a misleading warning.

The heating endpoints normally return complete state data, but the gateway can occasionally return no values or endpoint error codes `1` and `5`. These responses should remain diagnosable without creating hundreds of identical Home Assistant repairs/log entries.

## Changes

- Preserve empty `conso` endpoints during initial discovery so that their later `cdata` values can populate the energy entities.
- Treat an empty regular-data response from a consumption endpoint as expected debug information.
- Report an errored endpoint only once per response instead of also reporting a second missing-data warning.
- Rate-limit each repeated endpoint issue and error code per integration session:
  - occurrences 1, 10, 100 and 1,000 remain warnings;
  - intermediate repetitions are retained at debug level.
- Keep distinct error codes visible through independent counters.
- Retain the previously known entity state when a response contains no fresh usable value.
- Move routine per-device update messages from info to debug level.

This does not hide unsupported devices or new error codes. The first occurrence always remains visible as a warning, with its device, endpoint, name, error detail and occurrence count.

## Automated testing

Added capture-based coverage for:

- an empty Calybox consumption endpoint;
- repeated empty heating-zone responses;
- an errored response producing only one warning;
- distinct gateway error codes remaining independently visible.

The complete suite passes: 169 tests.

## Hardware validation

Validated by the reporter on the Calybox 1020 WT:

- the repeated endpoint warnings have stopped;
- `Consommation` and its energy values returned after the normal refresh delay;
- the fix is confirmed ready to merge.
