### PR TITLE
Use advertised transport for legacy alarm commands

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1292,9 +1292,10 @@ class TydomAlarm(TydomDevice):
             return False
 
         command = self._metadata.get("alarmCmd")
-        if not isinstance(command, dict) or "w" not in str(
-            command.get("permission", "")
-        ).lower():
+        if (
+            not isinstance(command, dict)
+            or "w" not in str(command.get("permission", "")).lower()
+        ):
             return False
 
         values = command.get("enum_values")

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1286,6 +1286,45 @@ class TydomAlarm(TydomDevice):
             return set()
         return {int(zone.strip()) for zone in str(value).split(",") if zone.strip()}
 
+    def _supports_regular_alarm_command(self, value: str) -> bool:
+        """Return whether a legacy alarm advertises a regular alarmCmd write."""
+        if not self.is_legacy_alarm() or not isinstance(self._metadata, dict):
+            return False
+
+        command = self._metadata.get("alarmCmd")
+        if not isinstance(command, dict) or "w" not in str(
+            command.get("permission", "")
+        ).lower():
+            return False
+
+        values = command.get("enum_values")
+        return not isinstance(values, list) or value in values
+
+    async def _send_alarm_mode(
+        self,
+        value: str,
+        code: str | None,
+        zones: str | None,
+    ) -> None:
+        """Select regular data or cdata from the alarm's advertised capability."""
+        if zones in (None, "") and self._supports_regular_alarm_command(value):
+            await self._tydom_client.put_devices_data(
+                self._id,
+                self._endpoint,
+                "alarmCmd",
+                value,
+            )
+            return
+
+        await self._tydom_client.put_alarm_cdata(
+            self._id,
+            self._endpoint,
+            code,
+            value,
+            zones,
+            self.is_legacy_alarm(),
+        )
+
     def _active_alarm_zones(self) -> set[int]:
         """Return the zones currently reported as armed by the central unit."""
         if getattr(self, "alarmMode", None) == "OFF":
@@ -1306,9 +1345,7 @@ class TydomAlarm(TydomDevice):
         # means "all zones" on installations which do not configure explicit
         # Away/Home/Night zone lists, rather than an empty desired zone set.
         if not target_zones:
-            await self._tydom_client.put_alarm_cdata(
-                self._id, self._endpoint, code, "ON", configured_zones, legacy
-            )
+            await self._send_alarm_mode("ON", code, configured_zones)
             return
 
         active_zones = self._active_alarm_zones()
@@ -1354,9 +1391,7 @@ class TydomAlarm(TydomDevice):
 
     async def alarm_disarm(self, code) -> None:
         """Disarm alarm."""
-        await self._tydom_client.put_alarm_cdata(
-            self._id, self._endpoint, code, "OFF", None, self.is_legacy_alarm()
-        )
+        await self._send_alarm_mode("OFF", code, None)
         # self._tydom_client.add_poll_device_url_1s(f"/devices/{self._id}/endpoints/{self._endpoint}/cdata")
 
     async def alarm_arm_away(self, code=None) -> None:
@@ -1402,9 +1437,7 @@ class TydomAlarm(TydomDevice):
 
         This will trigger a SOS alarm for 90 seconds.
         """
-        await self._tydom_client.put_alarm_cdata(
-            self._id, self._endpoint, code, "PANIC", None, self.is_legacy_alarm()
-        )
+        await self._send_alarm_mode("PANIC", code, None)
 
     async def acknowledge_events(self, code=None) -> None:
         """Acknowledge alarm events without blocking on unsupported history."""

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -371,6 +371,89 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
             ],
         )
 
+    @staticmethod
+    def _legacy_alarm() -> tuple[TydomAlarm, MagicMock]:
+        """Return a CSX-style alarm advertising regular global commands."""
+        client = MagicMock()
+        client.put_devices_data = AsyncMock()
+        client.put_alarm_cdata = AsyncMock()
+        client._zone_away = ""
+        client._zone_home = "2"
+        client._zone_night = "1"
+        alarm = TydomAlarm(
+            client,
+            "10_20",
+            "20",
+            "Legacy alarm",
+            "alarm",
+            "10",
+            {
+                "alarmCmd": {
+                    "permission": "w",
+                    "enum_values": ["OFF", "ON", "FORCED_ON"],
+                },
+                "part1State": {"permission": "r"},
+            },
+            {"alarmMode": "OFF", "part1State": "OFF"},
+        )
+        return alarm, client
+
+    async def test_legacy_global_disarm_uses_regular_data(self) -> None:
+        """CSX-style alarmCmd must use its advertised regular data endpoint."""
+        alarm, client = self._legacy_alarm()
+
+        await alarm.alarm_disarm("unused-code")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "20", "10", "alarmCmd", "OFF"
+        )
+        client.put_alarm_cdata.assert_not_awaited()
+
+    async def test_legacy_global_arm_uses_regular_data(self) -> None:
+        """A global legacy arm must not be sent to unsupported cdata."""
+        alarm, client = self._legacy_alarm()
+
+        await alarm.alarm_arm_away("unused-code")
+
+        client.put_devices_data.assert_awaited_once_with(
+            "20", "10", "alarmCmd", "ON"
+        )
+        client.put_alarm_cdata.assert_not_awaited()
+
+    async def test_legacy_partial_arm_retains_cdata_part_command(self) -> None:
+        """Configured CSX parts must retain the existing cdata dispatcher."""
+        alarm, client = self._legacy_alarm()
+
+        await alarm.alarm_arm_home("unused-code")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "unused-code", "ON", "2", True
+        )
+        client.put_devices_data.assert_not_awaited()
+
+    async def test_modern_alarm_retains_cdata_global_command(self) -> None:
+        """Modern zone-based alarms must retain authenticated cdata writes."""
+        client = MagicMock()
+        client.put_devices_data = AsyncMock()
+        client.put_alarm_cdata = AsyncMock()
+        alarm = TydomAlarm(
+            client,
+            "10_20",
+            "20",
+            "Modern alarm",
+            "alarm",
+            "10",
+            {"alarmCmd": {"permission": "w", "enum_values": ["OFF", "ON"]}},
+            {"alarmMode": "ON", "zone1State": "ON"},
+        )
+
+        await alarm.alarm_disarm("123456")
+
+        client.put_alarm_cdata.assert_awaited_once_with(
+            "20", "10", "123456", "OFF", None, False
+        )
+        client.put_devices_data.assert_not_awaited()
+
     async def test_alarm_inventory_merges_labels_and_technical_data(self) -> None:
         """Inventory responses should be useful without exposing other labels."""
         client = MagicMock()


### PR DESCRIPTION
Fixes #421.

## Summary

Select the alarm command transport from the capabilities reported by the gateway so that legacy CSX-style alarms can arm and disarm through their supported regular-data command while modern TYXAL alarms retain authenticated `cdata` commands.

## Problem

The CSX40 in #421 is discovered correctly and reports live state changes. Its acknowledgement command also succeeds through `/devices/data`. However, global arm and disarm operations are always sent to `/cdata`, which the reported gateway rejects immediately with HTTP 500.

Earlier CSX40 captures show the reason:

- `/devices/meta` advertises writable `alarmCmd` values `OFF`, `ON` and `FORCED_ON`;
- `/devices/cmeta` advertises `partCmd` and `histo`, but not `alarmCmd`.

The integration was therefore using the modern TYXAL transport for a command which this legacy alarm explicitly exposes through the regular endpoint.

## Changes

- Detect a legacy part-based alarm through its existing `partNState` capabilities.
- Verify that its regular metadata advertises a writable `alarmCmd` and supports the requested value.
- Send global `ON` and `OFF` operations through `/devices/data` when those conditions are met.
- Retain the existing `partCmd` `cdata` transport for configured partial Home and Night profiles.
- Retain authenticated `alarmCmd`/`zoneCmd` `cdata` handling for modern zone-based TYXAL/CS8000 systems.
- Leave unsupported values, such as a command absent from the advertised enumeration, on the existing path rather than assuming support.

No product name or CSX40 identifier is hard-coded. Other legacy alarms exposing the same capability layout benefit from the same selection.

## Relation to previous CSX40 work

PR #360 fixed the legacy dispatcher so that a global disarm operation was no longer discarded before any request was sent. This PR addresses the separate transport problem now visible in #421: the request is sent, but to an unsupported `cdata` endpoint.

## Automated testing

Added regression coverage confirming that:

- legacy global disarm uses regular `alarmCmd=OFF`;
- legacy global arm uses regular `alarmCmd=ON`;
- a configured legacy partial profile still uses `partCmd` through `cdata`;
- a modern zone-based alarm still uses its existing authenticated `cdata` command.

The complete suite passes: 169 tests.

## Hardware validation

Validated successfully by the reporter on the affected CSX40 installation:

- Arm Away sends `alarmCmd=ON` through `PUT /devices/data` and receives HTTP 200;
- the gateway then publishes `alarmMode=ON`, confirming the real state change;
- disarm sends `alarmCmd=OFF` through the same transport and receives HTTP 200;
- the gateway then publishes `alarmMode=OFF`;
- both operations work from Home Assistant and the previous HTTP 500 is absent.

The supplied log was sanitised by the reporter. Home and Night partial profiles were not reported as used; their unchanged `partCmd` path is covered by regression tests.
