### PR TITLE
Expose the source type of TYXAL alarm state changes

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3451,10 +3451,11 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         self._attr_code_format = CodeFormat.NUMBER
         self._attr_code_arm_required = True
         self._attr_changed_by = None
+        self._changed_by_type: str | None = None
         self._registered_sensors = []
         self._last_alarm_state = self.alarm_state
         self._last_alarm_event_sequence = self._device.alarm_event_sequence
-        self._pending_alarm_actor: tuple[str, str] | None = None
+        self._pending_alarm_actor: tuple[str, str, str] | None = None
 
         self._attr_supported_features = (
             self._attr_supported_features
@@ -3485,6 +3486,7 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         event_sequence = self._device.alarm_event_sequence
         has_new_actor = event_sequence != self._last_alarm_event_sequence
         actor = self._device.latest_alarm_actor if has_new_actor else None
+        actor_type = self._device.latest_alarm_actor_type if has_new_actor else None
         actor_target = self._device.latest_alarm_event_target if has_new_actor else None
         self._last_alarm_event_sequence = event_sequence
 
@@ -3494,22 +3496,30 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
         )
         if state_changed:
             self._attr_changed_by = None
-            if actor and self._actor_target_matches_state(actor_target, current_state):
+            self._changed_by_type = None
+            if (
+                actor
+                and actor_type
+                and self._actor_target_matches_state(actor_target, current_state)
+            ):
                 self._attr_changed_by = actor
+                self._changed_by_type = actor_type
                 self._pending_alarm_actor = None
             elif self._pending_alarm_actor and self._actor_target_matches_state(
                 self._pending_alarm_actor[0], current_state
             ):
                 self._attr_changed_by = self._pending_alarm_actor[1]
+                self._changed_by_type = self._pending_alarm_actor[2]
                 self._pending_alarm_actor = None
             else:
                 self._pending_alarm_actor = None
-        elif actor and actor_target:
+        elif actor and actor_type and actor_target:
             if self._actor_target_matches_state(actor_target, current_state):
                 self._attr_changed_by = actor
+                self._changed_by_type = actor_type
             else:
                 # TYDOM may publish eventAlarm just before alarmMode changes.
-                self._pending_alarm_actor = (actor_target, actor)
+                self._pending_alarm_actor = (actor_target, actor, actor_type)
 
         self.async_write_ha_state()
 
@@ -3528,6 +3538,13 @@ class HaAlarm(AlarmControlPanelEntity, HAEntity):
     def changed_by(self) -> str | None:
         """Return the actor resolved for the latest alarm transition."""
         return self._attr_changed_by
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the source type for the actor that changed alarm state."""
+        if self._changed_by_type is None:
+            return {}
+        return {"changed_by_type": self._changed_by_type}
 
     @property
     def alarm_state(self) -> AlarmControlPanelState:

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -1249,6 +1249,7 @@ class TydomAlarm(TydomDevice):
         self._command_metadata = command_metadata or {}
         self._alarm_event_sequence = 0
         self._latest_alarm_actor: str | None = None
+        self._latest_alarm_actor_type: str | None = None
         self._latest_alarm_event_target: str | None = None
 
     def _alarm_command_name(self, zone_id: str | None) -> str:
@@ -1277,23 +1278,26 @@ class TydomAlarm(TydomDevice):
         self._pending_events = []
 
     @staticmethod
-    def _actor_from_alarm_event(event: dict[str, Any]) -> str | None:
-        """Return the named actor carried by a spontaneous alarm event."""
+    def _actor_from_alarm_event(
+        event: dict[str, Any],
+    ) -> tuple[str, str] | None:
+        """Return the named actor and source carried by an alarm event."""
         access_code = event.get("accessCode") or {}
         actor = str(access_code.get("nameCustom") or "").strip()
         if actor:
-            return actor
+            return actor, "access_code"
 
         product = event.get("product") or {}
         actor = str(product.get("nameCustom") or "").strip()
         if actor:
-            return actor
+            return actor, "product"
 
         standard_name = str(product.get("nameStd") or "").strip()
         product_number = product.get("number")
         if standard_name and product_number is not None:
-            return f"{standard_name} {product_number}"
-        return standard_name or str(product.get("typeLong") or "").strip() or None
+            return f"{standard_name} {product_number}", "product"
+        actor = standard_name or str(product.get("typeLong") or "").strip()
+        return (actor, "product") if actor else None
 
     @staticmethod
     def _alarm_event_target(event: dict[str, Any]) -> str | None:
@@ -1316,6 +1320,11 @@ class TydomAlarm(TydomDevice):
         return self._latest_alarm_actor
 
     @property
+    def latest_alarm_actor_type(self) -> str | None:
+        """Return the source type from the newest alarm actor event."""
+        return self._latest_alarm_actor_type
+
+    @property
     def latest_alarm_event_target(self) -> str | None:
         """Return whether the newest actor event armed or disarmed the alarm."""
         return self._latest_alarm_event_target
@@ -1325,9 +1334,9 @@ class TydomAlarm(TydomDevice):
         event = getattr(device, "eventAlarm", None)
         target = self._alarm_event_target(event) if isinstance(event, dict) else None
         if target:
-            actor = self._actor_from_alarm_event(event)
-            if actor:
-                self._latest_alarm_actor = actor
+            actor_details = self._actor_from_alarm_event(event)
+            if actor_details:
+                self._latest_alarm_actor, self._latest_alarm_actor_type = actor_details
                 self._latest_alarm_event_target = target
                 self._alarm_event_sequence += 1
         await super().update_device(device)

--- a/tests/test_protocol_responses.py
+++ b/tests/test_protocol_responses.py
@@ -296,6 +296,7 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         await stored.update_device(incoming)
 
         self.assertEqual(stored.latest_alarm_actor, "Sandra")
+        self.assertEqual(stored.latest_alarm_actor_type, "access_code")
         self.assertEqual(stored.latest_alarm_event_target, "disarmed")
         self.assertEqual(stored.alarm_event_sequence, 1)
 
@@ -325,6 +326,7 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         await stored.update_device(incoming)
 
         self.assertEqual(stored.latest_alarm_actor, "TL 2000 Sandra")
+        self.assertEqual(stored.latest_alarm_actor_type, "product")
         self.assertEqual(stored.latest_alarm_event_target, "armed")
         self.assertEqual(stored.alarm_event_sequence, 1)
 
@@ -351,6 +353,7 @@ class ProtocolResponseTests(IsolatedAsyncioTestCase):
         await stored.update_device(incoming)
 
         self.assertIsNone(stored.latest_alarm_actor)
+        self.assertIsNone(stored.latest_alarm_actor_type)
         self.assertIsNone(stored.latest_alarm_event_target)
         self.assertEqual(stored.alarm_event_sequence, 0)
 


### PR DESCRIPTION
## Summary

Add `changed_by_type` to the TYXAL alarm entity alongside the standard Home Assistant `changed_by` attribute.

The value is stable and is derived from the spontaneous `eventAlarm` payload:

- `access_code` when the actor comes from `accessCode.nameCustom`;
- `product` when it comes from `product.nameCustom`, `nameStd`, or `typeLong`.

This retains `changed_by` as the actor’s name while allowing dashboards and automations to distinguish a named code from a named remote, badge, or other TYDOM product.

## Scope

This deliberately follows the actor resolution introduced by #419. The two changes remain separate: #419 provides the standard `changed_by` attribute, while this PR adds only the complementary source type.

Closes #424.

## Testing

Automated validation:

- Protocol tests cover `access_code`, `product`, and ignored non-state events.
- Ruff passes.
- All 191 repository tests pass after rebasing onto `main`.

Hardware validation was completed by @seb91260 on a TYDOM2 gateway using the combined test branch:

| Action | `changed_by` | `changed_by_type` |
| --- | --- | --- |
| Arm with named TL 2000 remote | Sébastien | `product` |
| Disarm with named TL 2000 remote | Sébastien | `product` |
| Arm with named user code | Sébastien | `access_code` |
| Disarm with named user code | Sébastien | `access_code` |

The four values matched the expected actor and source type after a full Home Assistant restart.