### PR TITLE
Document v0.30 and v0.31 user-facing capabilities

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -67,7 +67,8 @@ Plateforme | Description
   commandes météo ou volets associées sur le même appareil physique, quelle
   que soit la disposition des points de terminaison annoncée par TYDOM.
 - Expose les modes et zones d'alarme, l'historique et l'acquittement des
-  événements, les opérations de maintenance à distance confirmées et les
+  événements, l'auteur de la dernière transition d'état, les opérations de
+  maintenance à distance et d'armement forcé confirmées, ainsi que les
   événements d'automatisation natifs des interrupteurs et télécommandes
   compatibles.
 
@@ -83,7 +84,7 @@ Catégorie | Matériel ou configuration confirmés | Prise en charge dans Home A
 -- | -- | --
 Alarme et sécurité | TYXAL+, CS8000, CSX40 et détecteurs de fumée DFR TYXAL+ | Pilotage de l'alarme, modes par zone, diagnostics, état de détection de fumée, historique et acquittement des événements, ainsi que la gestion à distance des produits et zones compatibles.
 Chauffage et régulation | Tybox 5101 avec Typass ATL, Tywell Control, Tywell 2050, TYXIA 1137, Calybox et RF 6600 FP | Régulation par zone, températures, consignes de chauffage et de refroidissement, modes de fonctionnement, humidité, batterie et commandes de chauffage ou de fil pilote annoncées par l'appareil.
-Suivi énergétique | TYWATT 1000, TYWATT 2000 et TYWATT 5400 avec EMIC | Mesures de puissance, courant et énergie, y compris les canaux de chauffage et d'eau chaude sanitaire lorsqu'ils sont annoncés.
+Suivi énergétique | TYWATT 1000, TYWATT 2000 et TYWATT 5400 avec EMIC | Mesures de puissance, courant et énergie, y compris les canaux de chauffage, d'eau chaude sanitaire et de refroidissement lorsqu'ils sont annoncés.
 Portails et portes de garage | Récepteurs à contact sec TYXIA 4620 | Boutons impulsionnels reproduisant la séquence ouverture/arrêt/fermeture du récepteur, sans prétendre connaître une position qui n'est pas remontée.
 Éclairage et commutation | Récepteurs TYXIA 4910 à sortie fixe et TYXIA 4940 à variation configurés dans l'usage `Autres` de TYDOM, TYXIA 6610, Delta Dore Easy Plug et équipements X3D compatibles | Éclairages, luminosité, interrupteurs et prises selon les capacités annoncées par le point de terminaison.
 Ouvertures et protections solaires | Volets roulants TYMOOV et Well'com, installations BSO, volets Zigbee Profalux `MOT-C1Z06F` et `MOT-C1Z10F`, bannes TYXIA 5731, ouvrants K-Line DVI et portes K-Line POD | Volets natifs avec montée, descente, arrêt et position lorsqu'ils sont annoncés ; les commandes et positions des bannes sont converties selon la sémantique ouverture/fermeture de Home Assistant ; l'état d'ouverture ou de contact est exposé lorsqu'un retour est fourni.
@@ -282,6 +283,8 @@ TYXAL+ utiles dans Home Assistant :
 - `deltadore_tydom.get_events` renvoie l'historique et permet de le filtrer sur
   les alarmes, les activations/désactivations ou les événements non acquittés ;
 - `deltadore_tydom.acknowledge_events` acquitte les événements en attente ;
+- `deltadore_tydom.force_arm` arme explicitement un mode Absent, Présent ou
+  Nuit configuré lorsqu'un armement normal a été refusé en raison de défauts ;
 - `deltadore_tydom.get_alarm_products` répertorie les produits et zones
   configurés ;
 - `deltadore_tydom.enter_alarm_maintenance` déverrouille la configuration à
@@ -304,16 +307,26 @@ installateur n'est utilisé que pour la requête et est masqué dans les journau
 La suppression de produits, les codes d'accès, les réglages téléphoniques et la
 configuration des sirènes ne sont pas exposés.
 
+`force_arm` ne remplace pas les commandes d'alarme habituelles de Home
+Assistant. Utilisez-le uniquement après avoir vérifié les défauts signalés et
+déterminé qu'un armement forcé est approprié.
+
 L'appareil d'alarme TYXAL fournit également un bouton **Acquitter les
 événements** utilisable directement dans un tableau de bord, sans appel de
 service ni automatisation.
 
+Lorsque TYDOM transmet l'auteur d'une transition d'alarme, l'entité d'alarme
+expose `changed_by`, contenant le nom du code utilisateur ou du produit, ainsi
+que `changed_by_type`, dont la valeur est `access_code` ou `product`. Ces
+attributs décrivent la dernière transition d'armement ou de désarmement reçue.
+
 ## Limites connues
 
-- Les récepteurs de portail et de porte de garage TYXIA 4620 fournissent une
-  commande impulsionnelle, mais aucun retour de position ou de direction. Home
-  Assistant expose donc un bouton sans état et ne peut pas déterminer si
-  l'impulsion suivante ouvrira, arrêtera ou fermera la motorisation.
+- Les configurations de portail et de porte de garage TYXIA 4620 à contact sec
+  fournissent une commande impulsionnelle, mais aucun retour de position ou de
+  direction. Home Assistant expose donc un bouton sans état et ne peut pas
+  déterminer si l'impulsion suivante ouvrira, arrêtera ou fermera la
+  motorisation.
 - Le volet Tywell natif rejoue les scénarios `TWC_UP`, `TWC_DOWN` et
   `TWC_STOP` créés par TYDOM. Les volets concernés doivent donc être configurés
   dans l'application officielle, et la position globale n'est disponible que

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Platform | Description
 - Keep Tywell wall-controller sensors, area-backed climate control and
   companion weather or shutter controls attached to the same physical device
   across the different endpoint layouts advertised by TYDOM.
-- Expose alarm modes and zones, event history and acknowledgement, supported
-  remote maintenance operations, and native automation events from compatible
-  wall switches and remote controls.
+- Expose alarm modes and zones, event history and acknowledgement, the actor
+  behind the latest alarm state change, supported remote maintenance and
+  forced-arming operations, and native automation events from compatible wall
+  switches and remote controls.
 
 ### Tested hardware
 
@@ -78,7 +79,7 @@ Category | Confirmed hardware or configuration | Home Assistant support
 -- | -- | --
 Alarm and safety | TYXAL+, CS8000, CSX40 and DFR TYXAL+ smoke detectors | Alarm control, zone modes, diagnostics, smoke state, event history, acknowledgement and supported remote product/zone management.
 Climate and heating | Tybox 5101 with Typass ATL, Tywell Control, Tywell 2050, TYXIA 1137, Calybox and RF 6600 FP | Area-backed climate control, temperatures, heating and cooling setpoints, operating modes, humidity, battery and capability-driven heating or pilot-wire commands where advertised.
-Energy monitoring | TYWATT 1000, TYWATT 2000 and TYWATT 5400 with EMIC | Power, current and energy measurements, including heating and domestic hot water channels where advertised.
+Energy monitoring | TYWATT 1000, TYWATT 2000 and TYWATT 5400 with EMIC | Power, current and energy measurements, including heating, domestic hot water and cooling channels where advertised.
 Gates and garage doors | TYXIA 4620 dry-contact receivers | Stateless toggle buttons matching the receiver's open/stop/close pulse sequence, without claiming unavailable position feedback.
 Lighting and switching | TYXIA 4910 fixed-output and TYXIA 4940 dimming receivers configured under TYDOM's `Others` usage, TYXIA 6610, Delta Dore Easy Plug and compatible X3D equipment | Lights, brightness, switches and plugs according to the capabilities reported by the endpoint.
 Openings and covers | TYMOOV and Well'com roller shutters, BSO installations, Profalux `MOT-C1Z06F` and `MOT-C1Z10F` Zigbee shutters, TYXIA 5731 awnings, K-Line DVI openings and K-Line POD doors | Native covers with up, down, stop and position control where advertised; awning commands and positions are translated into Home Assistant open/close semantics; opening/contact state is exposed when feedback is supplied.
@@ -261,6 +262,8 @@ useful in Home Assistant:
 - `deltadore_tydom.get_events` returns alarm history and can filter it to alarm,
   activation/deactivation or unacknowledged events;
 - `deltadore_tydom.acknowledge_events` acknowledges pending alarm events;
+- `deltadore_tydom.force_arm` explicitly arms a configured Away, Home or Night
+  mode when normal arming was refused because of defects;
 - `deltadore_tydom.get_alarm_products` lists configured products and zones;
 - `deltadore_tydom.enter_alarm_maintenance` unlocks remote configuration and
   puts a disarmed CS8000 into maintenance mode;
@@ -281,15 +284,24 @@ finished. The installer code is used only for the request and is redacted from
 logs. Product deletion, access codes, telephone settings and siren
 configuration are not exposed.
 
+`force_arm` does not replace the normal Home Assistant alarm controls. Use it
+only after checking the reported defects and deciding that forced arming is
+appropriate.
+
 The TYXAL alarm device also provides an **Acknowledge events** button for
 convenient dashboard use without requiring a service call or automation.
 
+When TYDOM reports the actor for an alarm transition, the alarm entity exposes
+`changed_by` with the user-code or product name and `changed_by_type` with
+either `access_code` or `product`. These attributes describe the latest
+reported arm or disarm transition.
+
 ## Known limitations
 
-- TYXIA 4620 gate and garage receivers provide an impulse command but no
-  position or direction feedback. Home Assistant therefore exposes a stateless
-  toggle button and cannot determine whether the next pulse will open, stop or
-  close the motor.
+- Dry-contact TYXIA 4620 gate and garage configurations provide an impulse
+  command but no position or direction feedback. Home Assistant therefore
+  exposes a stateless toggle button and cannot determine whether the next pulse
+  will open, stop or close the motor.
 - The native Tywell shutter cover replays the `TWC_UP`, `TWC_DOWN` and
   `TWC_STOP` scenarios created by TYDOM. Its shutter membership must therefore
   be configured in the official application, and aggregate position is only


### PR DESCRIPTION
## Summary

Updates the English and French READMEs to reflect the user-facing behaviour delivered in v0.30 and v0.31.

## Changes

- Documents the TYXAL force_arm service and its safety constraint.
- Documents the changed_by and changed_by_type attributes on supported alarm state transitions.
- Includes TYWATT cooling-energy channels in the tested-hardware table.
- Clarifies that the no-feedback limitation applies to dry-contact TYXIA 4620 configurations, without making an unsupported claim about other TYXIA 4620-compatible equipment.

## Validation

- Markdown diff check passes.
- English and French documentation were updated together.