### PR TITLE
Expose feedback-capable gate state

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3157,7 +3157,9 @@ class HaGate(CoverEntity, HAEntity):
         self._attr_unique_id = f"{self._device.device_id}_cover"
         self._attr_name = None  # primary entity inherits device name
         self._registered_sensors = []
-        self._attr_supported_features = _level_command_cover_features(device)
+        self._attr_supported_features = _level_command_cover_features(
+            device, allow_position=True
+        )
 
     async def async_added_to_hass(self) -> None:
         """Refresh on every device push (see HACover for the MRO rationale)."""
@@ -3192,7 +3194,7 @@ class HaGate(CoverEntity, HAEntity):
 
         Some compatible gate motors report the same ``level`` feedback as a
         garage door, while ordinary dry-contact receivers expose no feedback at
-        all.  Older gate profiles can instead report ``openState``.
+        all. Older gate profiles can instead report ``openState``.
         """
         level = getattr(self._device, "level", None)
         if level is not None:
@@ -3220,6 +3222,10 @@ class HaGate(CoverEntity, HAEntity):
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the gate."""
         await self._device.stop()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Set the gate position when its endpoint allows it."""
+        await self._device.set_level(kwargs[ATTR_POSITION])
 
     async def async_toggle(self, **kwargs: Any) -> None:
         """Toggle the gate without deriving direction from an unknown state."""

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -3188,15 +3188,26 @@ class HaGate(CoverEntity, HAEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return if the window is closed."""
-        if hasattr(self._device, "openState"):
-            open_state = getattr(self._device, "openState", None)
+        """Return whether the gate is closed when feedback is available.
+
+        Some compatible gate motors report the same ``level`` feedback as a
+        garage door, while ordinary dry-contact receivers expose no feedback at
+        all.  Older gate profiles can instead report ``openState``.
+        """
+        level = getattr(self._device, "level", None)
+        if level is not None:
+            return level == 0
+
+        open_state = getattr(self._device, "openState", None)
+        if open_state is not None:
             return open_state == "LOCKED"
-        else:
-            LOGGER.warning(
-                "no attribute 'openState' for device %s", self._device.device_id
-            )
-            return None
+
+        return None
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the reported gate position when the endpoint provides it."""
+        return getattr(self._device, "level", None)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the gate."""

--- a/tests/test_gate_feedback.py
+++ b/tests/test_gate_feedback.py
@@ -1,0 +1,106 @@
+"""Regression tests for feedback-capable gate covers."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+
+def _load_gate_class():
+    """Load HaGate in isolation without importing Home Assistant."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "HaGate"
+    )
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            class_node,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class CoverEntity:
+        pass
+
+    class HAEntity:
+        pass
+
+    class CoverDeviceClass:
+        GATE = "gate"
+
+    class CoverEntityFeature(int):
+        pass
+
+    namespace = {
+        "Any": object,
+        "CoverDeviceClass": CoverDeviceClass,
+        "CoverEntity": CoverEntity,
+        "CoverEntityFeature": CoverEntityFeature,
+        "DeviceInfo": dict,
+        "HAEntity": HAEntity,
+        "LOGGER": MagicMock(),
+        "TydomGate": object,
+        "_level_command_cover_features": MagicMock(),
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["HaGate"]
+
+
+HaGate = _load_gate_class()
+
+
+class GateFeedbackTests(TestCase):
+    """Verify feedback is exposed only when a gate actually provides it."""
+
+    @staticmethod
+    def _gate(**attributes):
+        entity = HaGate.__new__(HaGate)
+        entity._device = SimpleNamespace(**attributes)
+        return entity
+
+    def test_level_feedback_exposes_position_and_closed_state(self) -> None:
+        """A feedback-capable gate follows the established garage convention."""
+        closed = self._gate(level=0)
+        partially_open = self._gate(level=65)
+
+        self.assertTrue(closed.is_closed)
+        self.assertEqual(closed.current_cover_position, 0)
+        self.assertFalse(partially_open.is_closed)
+        self.assertEqual(partially_open.current_cover_position, 65)
+
+    def test_open_state_feedback_remains_supported(self) -> None:
+        """Legacy openState feedback remains available without a level."""
+        gate = self._gate(openState="LOCKED")
+
+        self.assertTrue(gate.is_closed)
+        self.assertIsNone(gate.current_cover_position)
+
+    def test_gate_without_feedback_remains_stateless(self) -> None:
+        """Dry-contact receivers do not claim an unavailable state."""
+        gate = self._gate()
+
+        self.assertIsNone(gate.is_closed)
+        self.assertIsNone(gate.current_cover_position)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/tests/test_gate_feedback.py
+++ b/tests/test_gate_feedback.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 from types import SimpleNamespace
-from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
 
 
 def _load_gate_class():
@@ -49,6 +49,7 @@ def _load_gate_class():
         pass
 
     namespace = {
+        "ATTR_POSITION": "position",
         "Any": object,
         "CoverDeviceClass": CoverDeviceClass,
         "CoverEntity": CoverEntity,
@@ -66,7 +67,7 @@ def _load_gate_class():
 HaGate = _load_gate_class()
 
 
-class GateFeedbackTests(TestCase):
+class GateFeedbackTests(IsolatedAsyncioTestCase):
     """Verify feedback is exposed only when a gate actually provides it."""
 
     @staticmethod
@@ -98,6 +99,15 @@ class GateFeedbackTests(TestCase):
 
         self.assertIsNone(gate.is_closed)
         self.assertIsNone(gate.current_cover_position)
+
+    async def test_feedback_capable_gate_accepts_a_requested_position(self) -> None:
+        """A writable level is forwarded as a cover position request."""
+        set_level = AsyncMock()
+        gate = self._gate(set_level=set_level)
+
+        await gate.async_set_cover_position(position=100)
+
+        set_level.assert_awaited_once_with(100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This change makes gate state handling capability-driven:

- use the gateway-provided `level` feedback when it is available;
- expose `level` as the gate's current position and use `0` as closed;
- expose position control only when the endpoint declares a writable `level`;
- retain the legacy `openState` fallback;
- leave dry-contact gate receivers without `level` or `openState` state-less, rather than reporting a misleading state or logging a warning on every update.

### Reported hardware

The supplied capture is from a **Hörmann gate motor** paired through its compatible **X3D receiver** and added in Tydom using the **TYXIA 4620** gate profile. The integration does not identify it as Hörmann in code: the gateway exposes the generic TYXIA 4620 profile, so the behaviour is selected solely from its advertised capabilities.

That endpoint declares `level` as read/write, with a range of 0–100 and a step of 100. The capture confirms `levelCmd: ON` followed by `level: 100`, and `levelCmd: OFF` followed by `level: 0`.

## Testing

- Added regression coverage for level feedback, legacy `openState`, state-less dry-contact gates, and forwarding a requested position.
- `uv run --no-project --with pytest pytest` — 203 passed.
- Ruff and formatting checks pass for the changed files.
- Hardware validation is requested from the reporter using the test branch.

Fixes #427