### PR TITLE
Fix: authentification Digest en mode local (firmware 3.25.x and next)

### DIFF
--- a/custom_components/deltadore_tydom/tydom/tydom_client.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_client.py
@@ -349,6 +349,10 @@ class TydomClient:
                     '.*nonce="([a-zA-Z0-9+=]+)".*',
                     www_authenticate,
                 )
+                realm_matcher = re.match(
+                    r'.*realm="([^"]+)".*',
+                    www_authenticate,
+                )
                 response.close()
 
                 if re_matcher:
@@ -357,7 +361,10 @@ class TydomClient:
                     raise TydomClientApiClientError("Could't find auth nonce")
 
                 ws_headers = {
-                    "Authorization": self.build_digest_headers(re_matcher.group(1))
+                    "Authorization": self.build_digest_headers(
+                        re_matcher.group(1),
+                        realm_matcher.group(1) if realm_matcher else None,
+                    )
                 }
 
             connection = await session.ws_connect(
@@ -687,12 +694,12 @@ class TydomClient:
         """Handle a pong response and keep the pending ping counter non-negative."""
         self.pending_pings = max(0, self.pending_pings - 1)
 
-    def build_digest_headers(self, nonce):
+    def build_digest_headers(self, nonce, realm=None):
         """Build the headers of Digest Authentication."""
         digest_auth = HTTPDigestAuth(self._mac, self._password)
         chal = {}
         chal["nonce"] = nonce
-        chal["realm"] = (
+        chal["realm"] = realm or (
             "ServiceMedia" if self._remote_mode is True else "protected area"
         )
         chal["qop"] = "auth"


### PR DESCRIPTION
## Summary

On new Hub Tyxal+ (firmware 3.25.x) and next firmware release.

In local mode, the websocket connection to the Tydom gateway consistently failed with:
**aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected**
The gateway would close the connection without sending any HTTP response, right after the websocket upgrade request (containing the **Authorization header**) was sent.

## Root cause
In build_digest_headers(), the realm used to compute the Digest hash (H(A1) = MD5(username:realm:password)) was hardcoded.

The realm is hardcoded ("protected area", all lowercase), instead of being extracted from the server's response. However, the server returns:

`
WWW-Authenticate: Digest realm="Protected Area", qop="auth", nonce="...", opaque="..."
`

## Fix 

The realm is now extracted dynamically from the **WWW-Authenticate header**

## Testing

Tested with Tydom Home 
Tested with Hub Tyxal+


## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Ruff lint and formatting checks pass.
- [ ] Relevant automated tests have been added or updated and pass.
- [x] Hardware-dependent behaviour has been tested, or the reason it could not be tested is explained above.
- [ ] Logs and examples contain no credentials, PINs, tokens, MAC addresses or personal information.
- [ ] User-facing documentation is up to date; when the README changed, I updated both `README.md` and `README.fr.md`.
- [ ] The pull request links the issue it resolves, where applicable.
