### PR TITLE
Add Energy management  for Delta Dore Easy Plug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ config/*
 # Development documentation
 PR_DESCRIPTION.md
 /.vs
+
+
+# Add Python virtual env 
+.venv/

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5722,6 +5722,19 @@ class HASwitch(SwitchEntity, HAEntity):
     _attr_has_entity_name = True
     _attr_icon = "mdi:toggle-switch"
 
+    sensor_classes = {
+        "energyInstantTotElecP": SensorDeviceClass.POWER,
+        "energyTotIndexWatt": SensorDeviceClass.ENERGY,
+    }
+    state_classes = {
+        "energyInstantTotElecP": SensorStateClass.MEASUREMENT,
+        "energyTotIndexWatt": SensorStateClass.TOTAL_INCREASING,
+    }
+    units = {
+        "energyInstantTotElecP": UnitOfPower.WATT,
+        "energyTotIndexWatt": UnitOfEnergy.WATT_HOUR,
+    }    
+
     def __init__(self, device: TydomDevice, hass) -> None:
         """Initialize HASwitch."""
         self.hass = hass

--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -5733,7 +5733,7 @@ class HASwitch(SwitchEntity, HAEntity):
     units = {
         "energyInstantTotElecP": UnitOfPower.WATT,
         "energyTotIndexWatt": UnitOfEnergy.WATT_HOUR,
-    }    
+    }
 
     def __init__(self, device: TydomDevice, hass) -> None:
         """Initialize HASwitch."""

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1716,7 +1716,7 @@ class MessageHandler:
                                 ):
                                     data["eventAlarm"] = event
 
-                            if type_of_id == "conso":
+                            if type_of_id in {"conso", "plug"}:    
                                 data.update(_parse_energy_cdata_element(elem))
 
                             elif type_of_id == "alarm" and transaction_id not in (

--- a/custom_components/deltadore_tydom/tydom/MessageHandler.py
+++ b/custom_components/deltadore_tydom/tydom/MessageHandler.py
@@ -1716,7 +1716,7 @@ class MessageHandler:
                                 ):
                                     data["eventAlarm"] = event
 
-                            if type_of_id in {"conso", "plug"}:    
+                            if type_of_id in {"conso", "plug"}:
                                 data.update(_parse_energy_cdata_element(elem))
 
                             elif type_of_id == "alarm" and transaction_id not in (


### PR DESCRIPTION
## Summary
Add energy support for Delta Dore Easy Plug devices.

Easy Plug devices are exposed as `plug` endpoints, but their energy cdata was previously ignored. This change parses their energy readings and exposes:

- Instantaneous power: `energyInstantTotElecP` in watts
- Total energy: `energyTotIndexWatt` in watt-hours with `total_increasing` state class

This makes the Easy Plug compatible with Home Assistant’s Energy dashboard.

## Testing

- Tested manually on a real Delta Dore Easy Plug.
- Confirmed that the instantaneous power and cumulative energy sensors are created.
- Confirmed that the device can be added successfully to Home Assistant’s Energy dashboard.

## Checklist

- [x] The change is focused and does not include unrelated work.
- [x] Ruff lint and formatting checks pass.
- [ ] Relevant automated tests have been added or updated and pass.
- [ ] Hardware-dependent behaviour has been tested, or the reason it could not be tested is explained above.
- [ ] Logs and examples contain no credentials, PINs, tokens, MAC addresses or personal information.
- [ ] User-facing documentation is up to date; when the README changed, I updated both `README.md` and `README.fr.md`.
- [ ] The pull request links the issue it resolves, where applicable.