### PR TITLE
Fix Home Assistant device registry deprecations

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -220,6 +220,22 @@ def is_binary_attribute(
     )
 
 
+def _get_hub_for_tydom_device(hass: Any, device: Any):
+    """Return the hub that owns one device, even with several gateways."""
+    if hass is None:
+        return None
+    hubs = getattr(hass, "data", {}).get(DOMAIN, {})
+    device_client = getattr(device, "_tydom_client", None)
+    for hub in hubs.values():
+        if getattr(hub, "_tydom_client", None) is device_client:
+            return hub
+        if any(
+            candidate is device for candidate in getattr(hub, "devices", {}).values()
+        ):
+            return hub
+    return None
+
+
 class HAEntity:
     """Generic abstract HA entity."""
 
@@ -233,17 +249,8 @@ class HAEntity:
     hass: Any = None
 
     def _get_hub(self):
-        """Get the hub instance from hass data."""
-        if self.hass is None:
-            return None
-        if DOMAIN not in self.hass.data:
-            return None
-        # Get the first hub entry (assuming single hub per instance)
-        hubs = self.hass.data[DOMAIN]
-        if not hubs:
-            return None
-        # Return the first hub (entry_id is the key)
-        return next(iter(hubs.values()))
+        """Return the hub that owns this entity's TYDOM device."""
+        return _get_hub_for_tydom_device(self.hass, self._device)
 
     def _get_tydom_gateway_device_id(self) -> str | None:
         """Get the Tydom gateway device_id to use as via_device_id."""
@@ -263,7 +270,7 @@ class HAEntity:
         return None
 
     def _enrich_device_info(self, info: DeviceInfo) -> DeviceInfo:
-        """Enrich device info with via_device link to gateway.
+        """Enrich device info with a parent link to the gateway.
 
         Note: If area information becomes available from Tydom API
         (via /areas/data endpoint), we could add 'suggested_area' to DeviceInfo
@@ -274,7 +281,10 @@ class HAEntity:
         gateway_device_id = self._get_tydom_gateway_device_id()
         if gateway_device_id is not None and self._device is not None:
             if gateway_device_id != self._device.device_id:
-                info["via_device"] = (DOMAIN, gateway_device_id)
+                if gateway_registry_device_id := _get_tydom_gateway_registry_device_id(
+                    self.hass, self._device
+                ):
+                    info["via_device_id"] = gateway_registry_device_id
         return info
 
     async def async_added_to_hass(self) -> None:
@@ -465,6 +475,51 @@ class HAEntity:
         return info
 
 
+def _get_tydom_gateway_registry_device_id(hass: Any, device: Any) -> str | None:
+    """Resolve the owning gateway's Home Assistant device-registry ID.
+
+    Device identifiers are scoped to a config entry in Home Assistant 2026.9.
+    Resolving the parent through the owning hub therefore avoids linking a child
+    from one TYDOM gateway to an identically identified gateway from another
+    config entry.
+    """
+    hub = _get_hub_for_tydom_device(hass, device)
+    entry = getattr(hub, "_entry", None)
+    if hub is None or entry is None:
+        return None
+
+    gateway_device_id = next(
+        (
+            gateway.device_id
+            for gateway in getattr(hub, "devices", {}).values()
+            if isinstance(gateway, Tydom)
+        ),
+        None,
+    )
+    if gateway_device_id is None:
+        gateway_device_id = next(
+            (
+                ha_device._device.device_id
+                for ha_device in getattr(hub, "ha_devices", {}).values()
+                if isinstance(ha_device, HATydom)
+            ),
+            None,
+        )
+    if gateway_device_id is None:
+        return None
+
+    try:
+        return dr.async_get_device_id_by_identifier(
+            hass,
+            (DOMAIN, gateway_device_id),
+            config_entry_id=entry.entry_id,
+        )
+    except ValueError:
+        # The gateway entity has not been registered yet. Omitting the optional
+        # parent link is safer than creating a link to another config entry.
+        return None
+
+
 class GenericSensor(SensorEntity):
     """Representation of a generic sensor."""
 
@@ -536,15 +591,8 @@ class GenericSensor(SensorEntity):
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def _get_hub(self):
-        """Get the hub instance from hass data."""
-        if not hasattr(self, "hass") or self.hass is None:
-            return None
-        if DOMAIN not in self.hass.data:
-            return None
-        hubs = self.hass.data[DOMAIN]
-        if not hubs:
-            return None
-        return next(iter(hubs.values()))
+        """Return the hub that owns this entity's TYDOM device."""
+        return _get_hub_for_tydom_device(self.hass, self._device)
 
     def _get_tydom_gateway_device_id(self) -> str | None:
         """Get the Tydom gateway device_id to use as via_device_id."""
@@ -701,10 +749,13 @@ class GenericSensor(SensorEntity):
         if "sw_version" in device_info_dict and not grouped_with_parent:
             info["sw_version"] = device_info_dict["sw_version"]
 
-        # Link device to Tydom gateway via via_device
+        # Link device to the owning Tydom gateway.
         gateway_device_id = self._get_tydom_gateway_device_id()
         if gateway_device_id is not None and gateway_device_id != registry_device_id:
-            info["via_device"] = (DOMAIN, gateway_device_id)
+            if gateway_registry_device_id := _get_tydom_gateway_registry_device_id(
+                self.hass, self._device
+            ):
+                info["via_device_id"] = gateway_registry_device_id
 
         return info
 
@@ -770,15 +821,8 @@ class BinarySensorBase(BinarySensorEntity):
         self._device = device
 
     def _get_hub(self):
-        """Get the hub instance from hass data."""
-        if not hasattr(self, "hass") or self.hass is None:
-            return None
-        if DOMAIN not in self.hass.data:
-            return None
-        hubs = self.hass.data[DOMAIN]
-        if not hubs:
-            return None
-        return next(iter(hubs.values()))
+        """Return the hub that owns this entity's TYDOM device."""
+        return _get_hub_for_tydom_device(self.hass, self._device)
 
     def _get_tydom_gateway_device_id(self) -> str | None:
         """Get the Tydom gateway device_id to use as via_device_id."""
@@ -846,7 +890,10 @@ class BinarySensorBase(BinarySensorEntity):
         # Link to gateway if available
         gateway_device_id = self._get_tydom_gateway_device_id()
         if gateway_device_id is not None and gateway_device_id != registry_device_id:
-            info["via_device"] = (DOMAIN, gateway_device_id)
+            if gateway_registry_device_id := _get_tydom_gateway_registry_device_id(
+                self.hass, self._device
+            ):
+                info["via_device_id"] = gateway_registry_device_id
         return info
 
     async def async_added_to_hass(self):
@@ -909,15 +956,8 @@ class GenericBinarySensor(BinarySensorBase):
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def _get_hub(self):
-        """Get the hub instance from hass data."""
-        if not hasattr(self, "hass") or self.hass is None:
-            return None
-        if DOMAIN not in self.hass.data:
-            return None
-        hubs = self.hass.data[DOMAIN]
-        if not hubs:
-            return None
-        return next(iter(hubs.values()))
+        """Return the hub that owns this entity's TYDOM device."""
+        return _get_hub_for_tydom_device(self.hass, self._device)
 
     def _get_tydom_gateway_device_id(self) -> str | None:
         """Get the Tydom gateway device_id to use as via_device_id."""
@@ -1093,15 +1133,8 @@ class ClockSensor(SensorEntity):
         return attrs
 
     def _get_hub(self):
-        """Get the hub instance from hass data."""
-        if not hasattr(self, "hass") or self.hass is None:
-            return None
-        if DOMAIN not in self.hass.data:
-            return None
-        hubs = self.hass.data[DOMAIN]
-        if not hubs:
-            return None
-        return next(iter(hubs.values()))
+        """Return the hub that owns this entity's TYDOM device."""
+        return _get_hub_for_tydom_device(self.hass, self._device)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1214,15 +1247,8 @@ class GeolocationSensor(SensorEntity):
         return attrs
 
     def _get_hub(self):
-        """Get the hub instance from hass data."""
-        if not hasattr(self, "hass") or self.hass is None:
-            return None
-        if DOMAIN not in self.hass.data:
-            return None
-        hubs = self.hass.data[DOMAIN]
-        if not hubs:
-            return None
-        return next(iter(hubs.values()))
+        """Return the hub that owns this entity's TYDOM device."""
+        return _get_hub_for_tydom_device(self.hass, self._device)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -5042,8 +5068,11 @@ class HAScene(Scene, HAEntity):
         - Otherwise TWC scenes use virtual zone (Day/Night) devices
         - Other scenes are grouped into a virtual "Scènes Tydom" device
         """
-        # Get gateway device ID for via_device fallback
+        # Get gateway identifiers for the parent device link.
         gateway_device_id = self._get_tydom_gateway_device_id()
+        gateway_registry_device_id = _get_tydom_gateway_registry_device_id(
+            self.hass, self._device
+        )
 
         # Ensure gateway_device_id is available - if not, we can't create proper device_info
         if not gateway_device_id:
@@ -5096,8 +5125,9 @@ class HAScene(Scene, HAEntity):
                             "identifiers": {(DOMAIN, registry_device_id)},
                             "name": str(tywell_device.device_name),
                             "manufacturer": "Delta Dore",
-                            "via_device": (DOMAIN, str(gateway_device_id)),
                         }
+                        if gateway_registry_device_id:
+                            device_info["via_device_id"] = gateway_registry_device_id
                         product_name = getattr(tywell_device, "productName", None)
                         if product_name:
                             device_info["model"] = str(product_name)
@@ -5117,7 +5147,8 @@ class HAScene(Scene, HAEntity):
                 "model": "Tywell Control",
             }
 
-            device_info["via_device"] = (DOMAIN, gateway_device_id)
+            if gateway_registry_device_id:
+                device_info["via_device_id"] = gateway_registry_device_id
 
             LOGGER.debug(
                 "TWC scene device_info: scene=%s, is_twc=%s, zone=%s, device_identifier=%s",
@@ -5137,8 +5168,8 @@ class HAScene(Scene, HAEntity):
                 "manufacturer": "Delta Dore",
                 "model": "Tydom Scenes",
             }
-            if gateway_device_id:
-                info["via_device"] = (DOMAIN, gateway_device_id)
+            if gateway_registry_device_id:
+                info["via_device_id"] = gateway_registry_device_id
             return info
 
     async def async_added_to_hass(self) -> None:
@@ -5271,11 +5302,19 @@ class HAScene(Scene, HAEntity):
             # Find entities for each affected device
             related_entities = []
             found_devices = []
+            hub = self._get_hub()
+            entry = getattr(hub, "_entry", None)
+            if entry is None:
+                LOGGER.debug(
+                    "Cannot resolve scene-device relations for %s without its config entry",
+                    self._device.device_id,
+                )
+                return
 
             for affected_device_id in affected_device_ids:
-                # Find the device in the registry
-                device_entry = device_registry.async_get_device(
-                    identifiers={(DOMAIN, affected_device_id)}
+                # Device identifiers are scoped to one TYDOM config entry.
+                device_entry = device_registry.async_get_device_by_identifier(
+                    (DOMAIN, affected_device_id), entry.entry_id
                 )
 
                 if not device_entry:
@@ -5674,13 +5713,17 @@ class HAMoment(SwitchEntity, HAEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Return information to link this entity with the gateway device."""
-        return {
+        info: DeviceInfo = {
             "identifiers": {(DOMAIN, self._device.device_id)},
             "name": self._device.device_name,
             "manufacturer": "Delta Dore",
             "model": "Tydom Moment",
-            "via_device": (DOMAIN, self._get_tydom_gateway_device_id() or ""),
         }
+        if gateway_registry_device_id := _get_tydom_gateway_registry_device_id(
+            self.hass, self._device
+        ):
+            info["via_device_id"] = gateway_registry_device_id
+        return info
 
     @property
     def is_on(self) -> bool:
@@ -5920,9 +5963,10 @@ class HAGroupEntity(HAEntity):
             "manufacturer": "Delta Dore",
             "model": f"Tydom {self._device.group_usage.title()} Group",
         }
-        gateway_device_id = self._get_tydom_gateway_device_id()
-        if gateway_device_id is not None:
-            info["via_device"] = (DOMAIN, gateway_device_id)
+        if gateway_registry_device_id := _get_tydom_gateway_registry_device_id(
+            self.hass, self._device
+        ):
+            info["via_device_id"] = gateway_registry_device_id
         return info
 
     @property

--- a/custom_components/deltadore_tydom/remote_registry_migration.py
+++ b/custom_components/deltadore_tydom/remote_registry_migration.py
@@ -14,13 +14,10 @@ def remove_legacy_remote_endpoint(
     endpoint_unique_id: str,
 ) -> list[str]:
     """Remove one obsolete generic endpoint when it is safe to do so."""
-    legacy_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, endpoint_unique_id)}
+    legacy_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, endpoint_unique_id), config_entry_id
     )
     if legacy_device is None:
-        return []
-
-    if config_entry_id not in getattr(legacy_device, "config_entries", set()):
         return []
 
     allowed_unique_ids = {

--- a/tests/test_entity_sensor_registration.py
+++ b/tests/test_entity_sensor_registration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import MagicMock
 
@@ -63,6 +64,92 @@ def _load_ha_entity_class():
 
 
 HAEntity = _load_ha_entity_class()
+
+
+def _load_gateway_registry_helper(registry):
+    """Load the registry-link helper without Home Assistant dependencies."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    selected_nodes = [
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name
+        in {"_get_hub_for_tydom_device", "_get_tydom_gateway_registry_device_id"}
+    ]
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            *selected_nodes,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class Tydom:
+        pass
+
+    namespace = {
+        "Any": object,
+        "DOMAIN": "deltadore_tydom",
+        "Tydom": Tydom,
+        "dr": registry,
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["_get_tydom_gateway_registry_device_id"], Tydom
+
+
+class TestGatewayRegistryLink(TestCase):
+    """Verify registry parent links are scoped to the owning config entry."""
+
+    def test_resolves_gateway_device_id_in_owning_config_entry(self) -> None:
+        """A child device never looks up a same-named gateway in another entry."""
+        registry = MagicMock()
+        registry.async_get_device_id_by_identifier.return_value = "registry-gateway"
+        helper, Tydom = _load_gateway_registry_helper(registry)
+        client = object()
+        gateway = Tydom()
+        gateway.device_id = "gateway-id"
+        hub = SimpleNamespace(
+            _entry=SimpleNamespace(entry_id="entry-a"),
+            _tydom_client=client,
+            devices={"gateway-id": gateway},
+        )
+        hass = SimpleNamespace(data={"deltadore_tydom": {"entry-a": hub}})
+        child = SimpleNamespace(_tydom_client=client)
+
+        self.assertEqual(helper(hass, child), "registry-gateway")
+        registry.async_get_device_id_by_identifier.assert_called_once_with(
+            hass,
+            ("deltadore_tydom", "gateway-id"),
+            config_entry_id="entry-a",
+        )
+
+    def test_returns_none_until_gateway_is_registered(self) -> None:
+        """A startup ordering race leaves the optional parent link unset."""
+        registry = MagicMock()
+        registry.async_get_device_id_by_identifier.side_effect = ValueError
+        helper, Tydom = _load_gateway_registry_helper(registry)
+        client = object()
+        gateway = Tydom()
+        gateway.device_id = "gateway-id"
+        hub = SimpleNamespace(
+            _entry=SimpleNamespace(entry_id="entry-a"),
+            _tydom_client=client,
+            devices={"gateway-id": gateway},
+        )
+        hass = SimpleNamespace(data={"deltadore_tydom": {"entry-a": hub}})
+
+        self.assertIsNone(helper(hass, SimpleNamespace(_tydom_client=client)))
 
 
 def _load_opening_consumed_attrs():

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -317,13 +317,14 @@ class _Registry:
         self.devices = values
         self.removed: list[str] = []
 
-    def async_get_device(self, *, identifiers):
-        """Return the device whose identifiers match."""
+    def async_get_device_by_identifier(self, identifier, config_entry_id):
+        """Return the device matching one identifier in one config entry."""
         return next(
             (
                 device
                 for device in self.devices.values()
-                if device.identifiers & identifiers
+                if identifier in device.identifiers
+                and device.config_entry_id == config_entry_id
             ),
             None,
         )
@@ -348,7 +349,7 @@ class TestRemoteRegistryMigration(TestCase):
         device = types.SimpleNamespace(
             id="legacy-device",
             identifiers={("deltadore_tydom", self.endpoint_unique_id)},
-            config_entries={"entry"},
+            config_entry_id="entry",
         )
         for name, value in overrides.items():
             setattr(device, name, value)
@@ -419,7 +420,7 @@ class TestRemoteRegistryMigration(TestCase):
         device_registry = _Registry(
             {
                 "legacy-device": self._device(
-                    config_entries={"another-entry"}
+                    config_entry_id="another-entry"
                 )
             }
         )


### PR DESCRIPTION
## Summary

- replace deprecated DeviceInfo via_device tuples with config-entry-scoped via_device_id parent links
- replace unscoped device-registry lookups used by scene relations and the remote-control migration
- preserve safe startup behaviour when the gateway device has not yet been registered

## Tests

- python -m unittest discover -s tests -p test_*.py (193 tests)
- ruff check custom_components
- ruff format custom_components --check

Fixes #444