### PR TITLE
Add TRV Boost cancellation button

### DIFF
--- a/custom_components/deltadore_tydom/ha_entities.py
+++ b/custom_components/deltadore_tydom/ha_entities.py
@@ -6692,6 +6692,53 @@ class HAAlarmAcknowledgeButton(ButtonEntity, HAEntity):
         await self._device.acknowledge_events()
 
 
+class HACancelBoostButton(ButtonEntity, HAEntity):
+    """Button which cancels an active Boost on an area-backed TRV."""
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_translation_key = "cancel_boost"
+    _attr_icon = "mdi:timer-off-outline"
+
+    def __init__(self, device: TydomBoiler, hass) -> None:
+        """Initialise the TRV Boost cancellation button."""
+        self.hass = hass
+        self._device = device
+        self._attr_unique_id = f"{device.device_id}_cancel_boost"
+
+    @property
+    def available(self) -> bool:
+        """Expose the control only while the TRV reports an active Boost."""
+        return super().available and self._device.boost_active
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link the button to the physical radiator thermostat."""
+        device_info = self._get_device_info()
+        info: DeviceInfo = {
+            "identifiers": {(DOMAIN, self._device.device_id)},
+            "name": self._device.device_name,
+            "manufacturer": device_info["manufacturer"],
+        }
+        if "model" in device_info:
+            info["model"] = device_info["model"]
+        return self._enrich_device_info(info)
+
+    async def async_added_to_hass(self) -> None:
+        """Refresh availability whenever TYDOM publishes area state."""
+        await super().async_added_to_hass()
+        self._device.register_callback(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the update callback when Home Assistant removes the button."""
+        self._device.remove_callback(self.async_write_ha_state)
+        await super().async_will_remove_from_hass()
+
+    async def async_press(self) -> None:
+        """Cancel the active Boost without changing the normal setpoint."""
+        await self._device.cancel_boost()
+
+
 class HAAlarmPendingEventsSensor(SensorEntity, HAEntity):
     """Dashboard-friendly view of unacknowledged TYXAL alarm events."""
 

--- a/custom_components/deltadore_tydom/hub.py
+++ b/custom_components/deltadore_tydom/hub.py
@@ -63,6 +63,7 @@ from .ha_entities import (
     HASwitch,
     HAButton,
     HAAlarmAcknowledgeButton,
+    HACancelBoostButton,
     HAAlarmPendingEventsSensor,
     HAReloadButton,
     HARefreshEnergyButton,
@@ -480,6 +481,8 @@ class Hub:
         self.ha_devices[device.device_id] = ha_device
         if self.add_climate_callback is not None:
             self.add_climate_callback([ha_device])
+        if device.is_area_trv and self.add_button_callback is not None:
+            self.add_button_callback([HACancelBoostButton(device, self._hass)])
         self._add_discovered_entities(ha_device.get_sensors())
 
     async def _create_window_device(self, device: TydomWindow) -> None:

--- a/custom_components/deltadore_tydom/translations/en.json
+++ b/custom_components/deltadore_tydom/translations/en.json
@@ -270,6 +270,9 @@
             "acknowledge_events": {
                 "name": "Acknowledge events"
             },
+            "cancel_boost": {
+                "name": "Cancel Boost"
+            },
             "group_light": {
                 "name": "Light Group"
             },

--- a/custom_components/deltadore_tydom/translations/fr.json
+++ b/custom_components/deltadore_tydom/translations/fr.json
@@ -271,6 +271,9 @@
             "acknowledge_events": {
                 "name": "Acquitter les évènements"
             },
+            "cancel_boost": {
+                "name": "Annuler le Boost"
+            },
             "group_light": {
                 "name": "Groupe Lumières"
             },

--- a/custom_components/deltadore_tydom/tydom/tydom_devices.py
+++ b/custom_components/deltadore_tydom/tydom/tydom_devices.py
@@ -608,6 +608,11 @@ class TydomBoiler(TydomDevice):
         return self._type == "sh_hvac" and hasattr(self, "area_id")
 
     @property
+    def boost_active(self) -> bool:
+        """Return whether the area-backed TRV currently has Boost enabled."""
+        return str(getattr(self, "boost", "OFF")).upper() == "ON"
+
+    @property
     def is_derived_area_climate(self) -> bool:
         """Return whether this climate proxies a passive controller's area."""
         return self.device_id.endswith("_area_climate")
@@ -977,6 +982,17 @@ class TydomBoiler(TydomDevice):
             await self._tydom_client.put_devices_data(
                 self._id, self._endpoint, setpoint_attribute, temperature
             )
+
+    async def cancel_boost(self) -> None:
+        """Cancel the active Boost on an area-backed radiator thermostat."""
+        if not self.is_area_trv:
+            LOGGER.warning("Boost cancellation is not supported for %s", self.device_id)
+            return
+
+        await self._tydom_client.put_area_data_attributes(
+            self.area_id,
+            {"boost": "OFF"},
+        )
 
     async def set_thermic_level(self, level):
         """Set the pilot-wire order directly (fil-pilote zones)."""

--- a/tests/test_area_thermostats.py
+++ b/tests/test_area_thermostats.py
@@ -799,7 +799,12 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
                             "name": "currentSetpoint",
                             "value": 20.5,
                             "validity": "upToDate",
-                        }
+                        },
+                        {
+                            "name": "boost",
+                            "value": "ON",
+                            "validity": "upToDate",
+                        },
                     ],
                 }
             ],
@@ -814,6 +819,7 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
         self.assertEqual(devices[0].device_id, trv.device_id)
         self.assertEqual(devices[0].area_setpoint_attribute(), "currentSetpoint")
         self.assertEqual(devices[0].currentSetpoint, 20.5)
+        self.assertTrue(devices[0].boost_active)
 
     async def test_trv_override_does_not_require_local_setpoint_metadata(self) -> None:
         """Issue #259 TRVs can set a target without device-level area metadata."""
@@ -830,6 +836,29 @@ class AreaThermostatTests(IsolatedAsyncioTestCase):
                 "localMode": "LOCAL_SETPOINT",
             },
         )
+
+    async def test_trv_cancel_boost_uses_the_area_boost_register(self) -> None:
+        """Cancelling Boost leaves the user's normal setpoint and mode intact."""
+        trv = await self._discover_trv()
+        self.client.put_area_data_attributes = AsyncMock()
+        trv.boost = "ON"
+
+        self.assertTrue(trv.boost_active)
+        await trv.cancel_boost()
+
+        self.client.put_area_data_attributes.assert_awaited_once_with(
+            "7", {"boost": "OFF"}
+        )
+
+    async def test_trv_boost_state_is_normalised(self) -> None:
+        """The action is exposed only for an explicitly active Boost."""
+        trv = await self._discover_trv()
+
+        self.assertFalse(trv.boost_active)
+        trv.boost = "on"
+        self.assertTrue(trv.boost_active)
+        trv.boost = "OFF"
+        self.assertFalse(trv.boost_active)
 
     async def test_trv_uses_local_setpoint_limits_when_advertised(self) -> None:
         """Optional TRV metadata controls the Home Assistant range and step."""

--- a/tests/test_trv_boost_cancel_button.py
+++ b/tests/test_trv_boost_cancel_button.py
@@ -1,0 +1,97 @@
+"""Tests for the area-backed TRV Boost cancellation button."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+
+
+def _load_cancel_boost_button():
+    """Load the button class without importing Home Assistant."""
+    source_path = (
+        Path(__file__).parents[1]
+        / "custom_components"
+        / "deltadore_tydom"
+        / "ha_entities.py"
+    )
+    module = ast.parse(source_path.read_text(encoding="utf-8"))
+    class_node = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "HACancelBoostButton"
+    )
+    isolated_module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__",
+                names=[ast.alias(name="annotations")],
+                level=0,
+            ),
+            class_node,
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(isolated_module)
+
+    class ButtonEntity:
+        @property
+        def available(self) -> bool:
+            return True
+
+        async def async_added_to_hass(self) -> None:
+            pass
+
+        async def async_will_remove_from_hass(self) -> None:
+            pass
+
+    class HAEntity:
+        def _get_device_info(self) -> dict[str, str]:
+            return {"manufacturer": "Delta Dore", "model": "TRV 1.0"}
+
+        def _enrich_device_info(self, info):
+            return info
+
+    namespace = {
+        "ButtonEntity": ButtonEntity,
+        "DeviceInfo": dict,
+        "DOMAIN": "deltadore_tydom",
+        "HAEntity": HAEntity,
+        "TydomBoiler": object,
+    }
+    exec(compile(isolated_module, source_path, "exec"), namespace)
+    return namespace["HACancelBoostButton"]
+
+
+HACancelBoostButton = _load_cancel_boost_button()
+
+
+class CancelBoostButtonTests(IsolatedAsyncioTestCase):
+    """Exercise the native area TRV Boost cancellation button."""
+
+    async def test_button_tracks_boost_state_and_cancels_it(self) -> None:
+        """The button is actionable only during Boost and calls no other action."""
+        device = SimpleNamespace(
+            device_id="trv_device",
+            device_name="Radiator head",
+            boost_active=True,
+            cancel_boost=AsyncMock(),
+            register_callback=lambda callback: None,
+            remove_callback=lambda callback: None,
+        )
+        button = HACancelBoostButton(device, SimpleNamespace())
+
+        self.assertTrue(button.available)
+        await button.async_press()
+        device.cancel_boost.assert_awaited_once_with()
+
+        device.boost_active = False
+        self.assertFalse(button.available)
+        self.assertEqual(button._attr_unique_id, "trv_device_cancel_boost")
+        self.assertEqual(button._attr_translation_key, "cancel_boost")
+        self.assertEqual(
+            button.device_info["identifiers"],
+            {("deltadore_tydom", "trv_device")},
+        )


### PR DESCRIPTION
## Summary

Follow-up to the merged TRV 1.0 support in #359.

- Adds a per-TRV **Cancel Boost** button, available only while TYDOM reports `boost: ON`.
- Cancels the active Boost with the native area update `{ boost: OFF }` without changing the normal setpoint or schedule.
- Adds French and English translations and keeps the button linked to the physical radiator thermostat.

## Validation

- Manual validation on real hardware: start Boost in the TYDOM app, press **Annuler le Boost** in Home Assistant, and confirm the Boost stops in TYDOM while the normal setpoint and schedule remain unchanged.
- `pytest tests/test_area_thermostats.py tests/test_trv_boost_cancel_button.py -q` → 27 passed.
- Ruff format and lint pass.

The original issue #259 is already closed by #359; this PR deliberately contains only the remaining Boost-cancellation functionality.